### PR TITLE
Add system tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 # IntelliJ IDEA specific
 .idea/
 *.iml
+**/*.pyc
+**/.cache

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # IntelliJ IDEA specific
 .idea/
 *.iml
+
+# Python-related
 **/*.pyc
 **/.cache

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,48 @@
+
+# System integration tests
+
+These tests require a `python` and `pytest` installation. 
+`python` is usually installed on linux by default.
+You can install `pytest` via `pip` like this:
+
+    # install pip, if you need to
+    sudo dnf install python2-pip
+    # use pip to install pytest
+    sudo pip install pytest
+    
+You can then run these tests, either from python directly, like this: 
+
+    python test_deployments.py
+    
+or more conveniently using `pytest`, like this:
+
+    # run all the test_* functions and Test* classes in found test_*.py files
+    pytest
+    
+## Bootstrapping a cluster
+    
+These assume you have a cluster (`oc`, `minikube`, `minishift`) running. If not, the test
+can bootstrap a cluster for you:
+
+    pytest --bootstrap=minikube
+    
+If it bootstraps a cluster then the cluster will be stopped at the end of the tests. 
+Otherwise, if the tests uses a running cluster, the cluster will be left up.
+    
+## Standard output
+    
+By default `pytest` will capture the standard output and error streams from your test and display them if the test fails. 
+When working interactively, this can make it harder to understand what a test is doing. 
+Use `pytest -s` to print the standard streams in real time:
+
+    # as above, but don't capture standard error and output for display after failed tests
+    pytest -s
+
+## Exiting immediately
+
+If a test is failing it can be useful to 1) exit immediately and 2) leave the cluster in the 
+failing state, rather than cleaning up after the test.
+
+    pytest -x --no-clean
+
+The tests themselves require a local installation of the `oc` tools, `minikube` and `kubectl`.

--- a/test/cluster.py
+++ b/test/cluster.py
@@ -1,0 +1,112 @@
+
+import pytest
+from exec_ import *
+from session import *
+
+class OpenShiftCluster(object):
+    """
+    Manages a local OpenShift cloud using `oc cluster up` etc.
+    """
+
+    name = "openshift"
+
+    @staticmethod
+    def start():
+        exec_status(["oc", "cluster", "up"])
+
+    @staticmethod
+    def stop():
+        exec_status(["oc", "cluster", "down"])
+
+    @staticmethod
+    def is_running():
+        try:
+            return exec_status(["oc", "cluster", "status"]) == 0
+        except OSError:
+            return False
+
+    @staticmethod
+    def session():
+        return OpenShiftSession()
+
+class MinikubeCluster(object):
+    """
+    Manages a local kubernetes cluster using `minikube start`, etc.
+    """
+
+    name = "minikube"
+
+    @staticmethod
+    def start():
+        exec_status([MinikubeCluster.name, "start"])
+
+    @staticmethod
+    def stop():
+        exec_status([MinikubeCluster.name, "stop"])
+
+    @staticmethod
+    def is_running():
+        try:
+            output = exec_output([MinikubeCluster.name, "status"], raise_on_error=False)
+            return "cluster: Running" in output.splitlines()
+        except OSError:
+            return False
+
+    @staticmethod
+    def session():
+        return K8SSession()
+
+class MinishiftCluster(object):
+    """
+    Manages a local OpenShift cluster using `minishift start`, etc.
+    """
+
+    name = "minishift"
+
+    @staticmethod
+    def start():
+        exec_status([MinishiftCluster.name, "start"])
+
+    @staticmethod
+    def stop():
+        exec_status([MinishiftCluster.name, "stop"])
+
+    @staticmethod
+    def is_running():
+        try:
+            output = exec_output([MinishiftCluster.name, "status"], raise_on_error=False)
+            return "cluster: Running" in output.splitlines()
+        except OSError:
+            return False
+
+    @staticmethod
+    def session():
+        return OpenShiftSession()
+
+CLUSTER_TYPES = {c.name: c for c in [OpenShiftCluster, MinikubeCluster, MinishiftCluster]}
+
+@pytest.fixture(scope="session")
+def cluster(request):
+    """
+    Fixture to use the already running cluster, or start a local cluster, according to the given
+    ``--bootstrap-cluster`` command line option.
+    :param request:
+    :return: The cluster
+    """
+    cluster_type = request.config.getoption("--bootstrap-cluster")
+    if cluster_type:
+        cluster = CLUSTER_TYPES[cluster_type]
+        if not cluster:
+            raise Exception(cluster_type + " is not supported")
+        if cluster.is_running():
+            raise Exception(cluster.name + " is already running")
+        cluster.start()
+        if request.config.getoption("--leave-cluster-up"):
+            # TODO oc delete --all statefulsets,svc,po
+            request.addfinalizer(cluster.stop)
+        return cluster
+    else:
+        for cluster in CLUSTER_TYPES.itervalues():
+            if cluster.is_running():
+                return cluster
+        raise Exception("no running cluster detected")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,16 @@
+import pytest
+
+def pytest_addoption(parser):
+    parser.addoption("--bootstrap-cluster",
+                     action="store",
+                     #choices=["oc", "minikube"],
+                     #metavar="type",
+                     help="Start a cluster of the given type, fail if a cluster is already running.")
+    parser.addoption("--leave-cluster-up",
+                     action="store_true",
+                     default=False,
+                     help="With --bootstrap-cluster: don't stop the cluster at the end of the tests. Without --bootstrap-cluster: noop.")
+    parser.addoption("--no-clean",
+                     action="store_true",
+                     default=False,
+                     help="Don't clean up between each test. Only really useful when running a single (failing) test.")

--- a/test/exec_.py
+++ b/test/exec_.py
@@ -1,0 +1,94 @@
+
+import subprocess
+import threading
+import logging
+
+#logging.basicConfig(level=logging.DEBUG)
+
+LOGGER = logging.getLogger("exec")
+
+class ExecTimeoutException(Exception):
+    """
+    Exception thrown to indicate a subprocess took too long to complete.
+    """
+    def __init__(self, exit_code, cmd, output, timeout_secs):
+        self.exit_code = exit_code
+        self.cmd = cmd
+        self.output = output
+        self.timeout_secs = timeout_secs
+
+    def __str__(self):
+        return "%s timed-out after %s seconds with output %s" % (" ".join(self.cmd), self.timeout_secs, self.output)
+
+def exec_status(cmd, timeout_secs=None):
+    """
+    Execute cmd in a subprocess, wait for it to complete, and return the exit code.
+
+    :param cmd: The command to execute.
+    :param timeout_secs: raise a :py:class:`ExecTimeoutException` if the subprocess doesn't finish within that timeout.
+    :return: The status code of the process.
+    """
+    timer = None
+    timedout = threading.Event()
+    process = subprocess.Popen(cmd)
+    LOGGER.info("exec pid=%s timeout=%s cmd=%s", process.pid, timeout_secs, " ".join(cmd))
+    if timeout_secs:
+        def on_timeout():
+            if not process.poll():
+                LOGGER.info("timeout pid=%s", process.pid)
+                timedout.set()
+                process.terminate()
+        timer = threading.Timer(float(timeout_secs), on_timeout)
+        timer.start()
+    exit_code = process.wait()
+    LOGGER.info("exit pid=%s code=%s", process.pid, exit_code)
+    if timer:
+        timer.cancel()
+    if timedout.is_set():
+        raise ExecTimeoutException(exit_code, cmd, None, timeout_secs)
+    return exit_code
+
+def exec_ok(cmd, timeout_secs=None):
+    """
+    Execute cmd in a subprocess, wait for it to complete, and raise Exception if the exit status was non-zero.
+
+    :param cmd: The command to execute.
+    :param timeout_secs: raise a :py:class:`ExecTimeoutException` if the subprocess doesn't finish within that timeout.
+    """
+    sc = exec_status(cmd, timeout_secs)
+    if sc != 0:
+        raise Exception("Expected zero status code from %s, but got %s" %(" ".join(cmd), sc))
+
+def exec_output(cmd, raise_on_error=True, timeout_secs=None):
+    """
+    Execute cmd in a subprocess, wait for it to complete and return its output.
+
+    :param cmd: The command to execute.
+    :param raise_on_error: If true and the process exits with non-zero status, raise subprocess.CalledProcessError.
+    :param timeout_secs: raise a :py:class:`ExecTimeoutException` if the subprocess doesn't finish within that timeout.
+    :return: The output of the command (what it wrote to standard output).
+    """
+    timer = None
+    timedout = threading.Event()
+    process = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+    LOGGER.info("exec pid=%s timeout=%s cmd=%s", process.pid, timeout_secs, " ".join(cmd))
+    if timeout_secs:
+        def on_timeout():
+            if not process.poll():
+                LOGGER.info("timeout pid=%s", process.pid)
+                process.terminate()
+                timedout.set()
+        timer = threading.Timer(float(timeout_secs), on_timeout)
+        timer.start()
+    output, unused_err = process.communicate()
+    exit_code = process.poll()
+    LOGGER.info("exit pid=%s code=%s", process.pid, exit_code)
+    if timer:
+        timer.cancel()
+    if timedout.is_set():
+        raise ExecTimeoutException(exit_code, cmd, output, timeout_secs)
+    if exit_code and raise_on_error:
+        LOGGER.info("pid=%s output=%s", process.pid, output)
+        raise subprocess.CalledProcessError(exit_code, cmd, output=output)
+    return output
+

--- a/test/kafka.py
+++ b/test/kafka.py
@@ -1,0 +1,242 @@
+
+import json
+import logging
+from exec_ import *
+
+LOGGER = logging.getLogger("kafka")
+
+class Kafka:
+    """
+    Run Kafka commands on a container within a pod
+    """
+    def __init__(self, session, pod, container=None):
+        """The given container in the given pod, or the first container in the given pod if no container given."""
+        self.session = session
+        self.pod = pod
+        self.container = container
+
+    def _copy_configs(self, configs):
+        """
+        Dump the given configs to a local file, copy them to a temporary file on the container,
+        return the remote temporary file name.
+        :param configs: The configs, can be string, dict or (local) file descriptor
+        :return: The remote temporary file name
+        """
+        raise Exception("Not implemented yet")
+        ## TODO copy the string to a local file
+        ## then copy that file to the pod
+        #session.cp(src, pod, container, dest)
+
+    def verifiable_producer(self, topic, broker_list,
+                            max_messages=-1, throughput=-1, acks=-1, producer_config_string=None,
+                            value_prefix=None,
+                            cmd_timeout_secs=30.0):
+        """
+        Execute ``kafka-verifiable-producer.sh`` via `oc/kubectl exec` in the given container of the given pod,
+        returning the JSON it emits, or throwing an Exception
+
+        :param topic: The topic to produce records in
+        :param broker_list: The bootstrap brokers
+        :param max_messages: See ``--max-messages``
+        :param throughput: See ``--throughput``
+        :param acks: See ``--acks``
+        :param producer_config_string: The producer config as a string. This will be copied into the pod and passed to ``kafka-verifiable-producer.sh``
+        :param value_prefix: See ``--value-prefix``
+        :param cmd_timeout_secs:  A timeout, in seconds. An :py:class:`ExecTimeoutException` will be raised if ``oc/kubectl exec`` takes longer.
+        :return: A :ref:`ToolData` representing the tool_data event in the JSON emitted by ``kafka-verifiable-producer.sh``.
+        """
+        LOGGER.info("Producing %s messages to topic %s", max_messages, topic)
+        cmd = ["/opt/kafka/bin/kafka-verifiable-producer.sh",
+               "--topic", topic,
+               "--broker-list", broker_list]
+        if max_messages > 0:
+            cmd += ["--max-messages", str(max_messages)]
+        if throughput > 0:
+            cmd += ["--thoughput", str(throughput)]
+        if acks > 0:
+            cmd += ["--acks", str(acks)]
+        if producer_config_string:
+            raise Exception("Not implemented yet")
+            ## TODO copy the string to a local file
+            ## then copy that file to the pod
+            #session.cp(src, pod, container, dest)
+            remote_configs = self._copy_configs(producer_config_string)
+            cmd  += ["--producer-condfig", remote_configs]
+        if value_prefix:
+            cmd  += ["--value-prefix", value_prefix]
+        LOGGER.debug("pod: %s, container: %s, cmd %s", self.pod, self.container, " ".join(cmd))
+        lines_of_json = self.session.exec_(self.pod, cmd, self.container, cmd_timeout_secs=cmd_timeout_secs)
+        events = [json.loads(json_string) for json_string in lines_of_json.splitlines()]
+        if events[-1]['name'] == 'tool_data':
+            return Kafka.ToolData(events[-1])
+        else:
+            raise Exception("Couldn't find tool_data event in JSON output of kafka-verifiable-producer.sh")
+
+    class ToolData(object):
+        """
+        Representation of the "tool_data" event in the JSON output of kafka-verifiable-producer.sh, e.g.
+
+            {"avg_throughput":39.0625,"target_throughput":-1,"name":"tool_data","sent":10,"acked":10}
+        """
+        def __init__(self, dict):
+            for key,item in dict.iteritems():
+                setattr(self, key, item)
+
+        def __str__(self):
+            return "sent %s, acked %s" % (self.sent, self.acked)
+
+    def verifiable_consumer(self, topic, group_id, broker_list, max_messages=None, session_timeout=None, verbose=None, enable_auto_commit=None,
+                            reset_policy=None, assignment_strategy=None, consumer_config=None, cmd_timeout_secs=30):
+        """
+        Execute ``kafka-verifiable-consumer.sh`` via `oc/kubectl exec` in the given container of the given pod,
+        returning the JSON it emits, or throwing an Exception
+
+        :param topic: The topic to produce records in.
+        :param group_id: The consumer group id.
+        :param broker_list: The bootstrap brokers.
+        :param max_messages: See ``--max-messages``.
+        :param session_timeout: A timeout for the consumer session.
+        :param verbose: See ``--verbose``
+        :param enable_auto_commit: See ``--enable-autocommit``
+        :param reset_policy: See ``--reset-policy``
+        :param assignment_strategy: See ``--assignment-strategy``
+        :param consumer_config: See ``--consumer.config``
+        :param cmd_timeout_secs:  A timeout, in seconds. An :py:class:`ExecTimeoutException` will be raised if ``oc/kubectl exec`` takes longer.
+        :return:
+        """
+        LOGGER.info("Consuming %s messages from topic %s", max_messages, topic)
+        cmd = ["/opt/kafka/bin/kafka-verifiable-consumer.sh",
+               "--topic", topic,
+               "--group-id", group_id,
+               "--broker-list", broker_list]
+        if max_messages:
+            cmd += ["--max-messages", str(max_messages)]
+        if session_timeout:
+            cmd += ["--session-timeout", str(session_timeout)]
+        if verbose:
+            cmd += ["--verbose"]
+        if enable_auto_commit:
+            cmd += ["--enable-autocommit"]
+        if reset_policy:
+            cmd += ["--reset-policy", reset_policy]
+        if assignment_strategy:
+            cmd += ["--assignment-strategy", assignment_strategy]
+        if consumer_config:
+            # TODO like the producer config
+            cmd += ["--consumer.config", consumer_config]
+        # KAFKA-6130 means we have to timeout the command because it doesn't exit
+        LOGGER.debug("pod: %s, container: %s, cmd %s", self.pod, self.container, " ".join(cmd))
+        try:
+            lines_of_json = self.session.exec_(self.pod, cmd, self.container, cmd_timeout_secs=cmd_timeout_secs)
+        except ExecTimeoutException as e:
+            logging.info("%s timed-out" % (cmd))
+            logging.info("KAFKA-6130 means we have to timeout the command because it doesn't exit")
+            lines_of_json = e.output
+        logging.debug(lines_of_json)
+        events = [json.loads(json_string) for json_string in lines_of_json.splitlines()]
+        try:
+            records_consumed_event = next(event for event in events if event['name'] == 'records_consumed')
+            return Kafka.RecordsConsumed(records_consumed_event)
+        except StopIteration:
+            raise Exception("Couldn't find records_consoc umed event in JSON output of kafka-verifiable-producer.sh: %s" % (events))
+
+    class RecordsConsumed(object):
+        """
+        Representation of the "records_consumer" event in the JSON output of kafka-verifiable-consumer.sh, e.g.
+
+        {"timestamp":1509019939248,"count":278,"name":"records_consumed","partitions":[{"topic":"my_topic","partition":0,"count":10,"minOffset":82,"maxOffset":91}]}
+        """
+        def __init__(self, dict):
+            for key,item in dict.iteritems():
+                setattr(self, key, item)
+
+        def __str__(self):
+            return "topic %s, partition %s, count %s" % (self.topic, self.partition, self.count)
+
+    def create_topic(self, zookeeper, topic, partitions=1, replicas=1, disable_rack_aware=False, if_not_exists=False,
+                     cmd_timeout_secs=30, **configs):
+        LOGGER.info("Creating topics %s", str(topic))
+        cmd = ["/opt/kafka/bin/kafka-topics.sh", "--zookeeper", zookeeper, "--create", "--topic", topic, "--partitions", str(partitions)]
+
+        if isinstance(replicas, int):
+            cmd += ["--replication-factor", str(replicas)]
+        elif isinstance(replicas, list):
+            cmd += ["--replica-assignment", replicas]#TODO
+        else:
+            raise
+
+        if disable_rack_aware:
+            cmd += ["--disable-rack-aware", disable_rack_aware]
+
+        if if_not_exists:
+            cmd.append("--if-not-exists")
+
+        if configs:
+            for key, item in configs.iteritems():
+                cmd += ["--config", "%s=%s" % (key, item)]
+
+        LOGGER.debug("pod: %s, container: %s, cmd %s", self.pod, self.container, " ".join(cmd))
+        self.session.exec_(self.pod, cmd, self.container, cmd_timeout_secs=cmd_timeout_secs)
+
+    def list_topics(self, zookeeper, cmd_timeout_secs=30):
+        """
+        Execute ``kafka-topics.sh --list`` via `oc/kubectl exec` in the given container of the given pod.
+
+        :param zookeeper: Zookeeper host:port.
+        :param cmd_timeout_secs:  A timeout, in seconds. An :py:class:`ExecTimeoutException` will be raised if ``oc/kubectl exec`` takes longer.
+        """
+        LOGGER.info("listing topics")
+        cmd = ["/opt/kafka/bin/kafka-topics.sh", "--zookeeper", zookeeper, "--list"]
+        LOGGER.debug("pod: %s, container: %s, cmd %s", self.pod, self.container, " ".join(cmd))
+        return self.session.exec_(self.pod, cmd, self.container, cmd_timeout_secs=cmd_timeout_secs).splitlines()
+
+    def describe_topics(self, zookeeper, topic, cmd_timeout_secs=30):
+        """
+        Execute ``kafka-topics.sh --describe`` via `oc/kubectl exec` in the given container of the given pod.
+
+        :param zookeeper: Zookeeper host:port.
+        :param topic: A topic, or topics or None (to describe all the topics)
+        :param cmd_timeout_secs:  A timeout, in seconds. An :py:class:`ExecTimeoutException` will be raised if ``oc/kubectl exec`` takes longer.
+        :return:
+        """
+        LOGGER.info("describing topics %s", str(topic))
+        cmd = ["/opt/kafka/bin/kafka-topics.sh", "--zookeeper", zookeeper, "--describe"]
+        if isinstance(topic, str):
+            cmd += ["--topic", topic]
+        elif isinstance(topic, list):
+            for t in topic:
+                cmd += ["--topic", t]
+        LOGGER.debug("pod: %s, container: %s, cmd %s", self.pod, self.container, " ".join(cmd))
+        self.session.exec_(self.pod, cmd, self.container, cmd_timeout_secs=cmd_timeout_secs)
+        # TODO parse output
+
+    def delete_topic(self, zookeeper, topic, if_exists=False,
+                     cmd_timeout_secs=30):
+        """
+        Execute ``kafka-topics.sh --delete`` via `oc/kubectl exec` in the given container of the given pod
+
+        :param zookeeper: Zookeeper ``host:port``.
+        :param topic: A topic or topics
+        :param if_exists: See ``--if-exists``.
+        :param cmd_timeout_secs:  A timeout, in seconds. An :py:class:`ExecTimeoutException` will be raised if ``oc/kubectl exec`` takes longer.
+        :return:
+        """
+        LOGGER.info("deleting topics %s", str(topic))
+        cmd = ["/opt/kafka/bin/kafka-topics.sh", "--zookeeper", zookeeper, "--delete"]
+
+        if if_exists:
+            cmd.append("--if-exists")
+
+        if isinstance(topic, str) or isinstance(topic, unicode):
+            cmd += ["--topic", topic]
+        elif isinstance(topic, list):
+            for t in topic:
+                cmd += ["--topic", t]
+        else:
+            raise Exception("topics parameter can't be a " + str(type(topic)))
+        LOGGER.debug("pod: %s, container: %s, cmd %s", self.pod, self.container, " ".join(cmd))
+        self.session.exec_(self.pod, cmd, self.container, cmd_timeout_secs=cmd_timeout_secs)
+
+    # TODO wrappers for kafka-reassign-partitions.sh etc
+    # TODO kill broker, bounce broker
+    # TODO also provide a Zookeeper abstraction like this one.

--- a/test/session.py
+++ b/test/session.py
@@ -1,0 +1,130 @@
+
+import pytest
+import os.path
+import time
+import logging
+from exec_ import *
+
+LOGGER = logging.getLogger("session")
+
+class SessionTimeoutException(Exception):
+    pass
+
+class BaseSession(object):
+    """Baseclass for managing a cluster"""
+
+    def __init__(self, cmd):
+        self.cmd = cmd
+        self.finalizers = []
+
+    def _exec(self, cmd_args):
+        try:
+            exec_output(cmd_args)
+            return 0
+        except subprocess.CalledProcessError as e:
+            LOGGER.warn("output: %s" % (e.output))
+            return e.returncode
+
+    def apply(self, *files):
+        "oc/kubectl apply -f files"
+        for f in files:
+            if not os.path.exists(f):
+                raise Exception("%s does not exist" % f)
+        exec_ok([self.cmd, "apply"] + [item for sublist in (["-f", f] for f in files) for item in sublist])
+
+    def create(self, *files):
+        "oc/kubectl create -f files"
+        for f in files:
+            if not os.path.exists(f):
+                raise Exception("%s does not exist" % (f))
+        exec_ok([self.cmd, "create"] + [item for sublist in (["-f", f] for f in files) for item in sublist])
+
+    def delete(self, *options):
+        exec_ok([self.cmd, "delete"] + list(options))
+
+    def get(self, *what):
+        "oc/kubectl get what"
+        return exec_output([self.cmd, "get"] + list(what)).splitlines()[1:]
+
+    def await_endpoint(self, endpoint_name, required_number, timeout=300):
+        """
+        Wait for the number of endpoints with the given name to reach the given number,
+        throwing a :py:class:`SessionTimeoutException` if it takes more than the given timeout.
+        """
+        wait = True
+        start = time.time()
+        LOGGER.info("Waiting for up to %ss for %s endpoints called %s", timeout, required_number, endpoint_name)
+        while wait:
+            if (time.time() - start > timeout):
+                raise SessionTimeoutException("timeout after %ss waiting for %s endpoints with name %s" %
+                                       (timeout, required_number, endpoint_name))
+            time.sleep(5)
+            output = self.get("endpoints", endpoint_name)
+            d = dict([y.split()[:2] for y in output])
+            num_endpoints = len(d[endpoint_name].split(","))
+            LOGGER.debug("%s of %s endpoints, remaining timeout=%s", num_endpoints, required_number, start + timeout - time.time())
+            wait = num_endpoints != required_number
+
+    def exec_(self, pod, cmd, container=None, cmd_timeout_secs=30.0):
+        """
+        oc/kubectl exec pod -c container -i -t -- CMD
+        """
+        c = [self.cmd, "exec", pod, "-i", "-t"]
+        if container:
+            c += ["-c", container]
+        c += ["--"]
+        return exec_output(c + [str(a) for a in cmd], timeout_secs=cmd_timeout_secs)
+
+    def addfinalizer(self, finalizer):
+        """
+        Add a nullary function to clean-up state when the session closes.
+        :param finalizer: The finalizer function. This function should take no arguments.
+        """
+        self.finalizers.append(finalizer)
+
+    def close(self):
+        LOGGER.info("Closing session")
+        for finalizer in self.finalizers:
+            finalizer()
+        self.delete("statefulset", "--all")
+        self.delete("svc", "--all")
+
+
+class OpenShiftSession(BaseSession):
+    """A running openshift session, with deployments managed using the `oc` tool."""
+
+    def __init__(self):
+        super(OpenShiftSession, self).__init__("oc")
+
+    def new_app(self, name):
+        self._exec([self.cmd, "new-app", name])
+
+    @property
+    def is_openshift(self):
+        return True
+
+    def __str__(self):
+        return "oc session"
+
+
+class K8SSession(BaseSession):
+    """A running kubernetes session, with deployments managed using the ``kubectl`` tool."""
+
+    def __init__(self):
+        super(K8SSession, self).__init__("kubectl")
+
+    @property
+    def is_openshift(self):
+        return False
+
+    def __str__(self):
+        return "kubectl session"
+
+
+@pytest.fixture
+def session(request, cluster):
+    sess = cluster.session()
+    if not request.config.getoption("--no-clean"):
+        request.addfinalizer(sess.close)
+    return sess
+

--- a/test/test_deployments.py
+++ b/test/test_deployments.py
@@ -1,0 +1,122 @@
+import pytest
+import logging
+import re
+import uuid
+import sys
+import random
+import string
+from cluster import *
+from kafka import Kafka
+
+logging.basicConfig(level=logging.DEBUG)
+
+def random_topic_name():
+    return "topic"+''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(8))
+
+def random_group_name(prefix=""):
+    return "group"+''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(8))
+
+def openshift_template_inmemory_deployment(session):
+    if not session.is_openshift:
+        pytest.skip("only supported on openshift, because k8s doesn't have templates")
+    session.create("../kafka-inmemory/resources/openshift-template.yaml")
+    session.new_app("barnabas")
+    ## TODO: don't hardcode the expected number of endpoints
+    session.await_endpoint("kafka", 3)
+    def cleanup():
+        session.delete("-f", "../kafka-inmemory/resources/openshift-template.yaml")
+    session.addfinalizer(cleanup)
+    return session
+
+def openshift_template_statefulsets_deployment(session):
+    if not session.is_openshift:
+        pytest.skip("only supported on openshift, because k8s doesn't have templates")
+    session.create("../kafka-statefulsets/resources/openshift-template.yaml")
+    session.new_app("barnabas")
+    # TODO: don't hardcode the expected number of endpoints
+    session.await_endpoint("kafka", 3)
+    def cleanup():
+        session.delete("-f", "../kafka-statefulsets/resources/openshift-template.yaml")
+    session.addfinalizer(cleanup)
+    return session
+
+def inmemory_deployment(session):
+    if session.is_openshift:
+        pytest.skip("not supported on openshift, due to needing root user")
+    session.apply("../kafka-inmemory/resources/zookeeper.yaml",
+                  "../kafka-inmemory/resources/zookeeper-headless-service.yaml",
+                  "../kafka-inmemory/resources/zookeeper-service.yaml",
+                  "../kafka-inmemory/resources/kafka.yaml",
+                  "../kafka-inmemory/resources/kafka-headless-service.yaml",
+                  "../kafka-inmemory/resources/kafka-service.yaml")
+    # TODO: don't hardcode the expected number of endpoints
+    session.await_endpoint("kafka", 3)
+    return session
+
+def statefulsets_deployment(session):
+    if session.is_openshift:
+        pytest.skip("not supported on openshift, due to needing root user")
+    session.apply("../kafka-statefulsets/resources/cluster-volumes.yaml",
+        "../kafka-statefulsets/resources/zookeeper.yaml",
+        "../kafka-statefulsets/resources/zookeeper-headless-service.yaml",
+        "../kafka-statefulsets/resources/zookeeper-service.yaml",
+        "../kafka-statefulsets/resources/kafka.yaml",
+        "../kafka-statefulsets/resources/kafka-headless-service.yaml",
+        "../kafka-statefulsets/resources/kafka-service.yaml")
+    # TODO: don't hardcode the expected number of endpoints
+    session.await_endpoint("kafka", 3)
+    return session
+
+deployments = ["openshift_template_inmemory_deployment", "openshift_template_statefulsets_deployment", "inmemory_deployment", "statefulsets_deployment"]
+
+def pytest_generate_tests(metafunc):
+     if 'deployment' in metafunc.fixturenames:
+         metafunc.parametrize("deployment", deployments, indirect=True)
+
+@pytest.fixture
+def deployment(request, session):
+    sess = session
+    LOGGER.info("Deploying %s on %s", request.param, session)
+    if request.param == 'openshift_template_inmemory_deployment':
+        return openshift_template_inmemory_deployment(sess)
+    elif request.param == 'openshift_template_statefulsets_deployment':
+        return openshift_template_statefulsets_deployment(sess)
+    elif request.param == 'inmemory_deployment':
+        return inmemory_deployment(sess)
+    elif request.param == 'statefulsets_deployment':
+        return statefulsets_deployment(sess)
+    else:
+        raise ValueError("invalid config")
+
+#@pytest.mark.parametrize("deployment", deployments)
+def test_produce_consume(request, deployment):
+    logging.info("test_produce_consume with %s" % (deployment))
+    sess = deployment
+    ## Find zk host:port
+    regex = re.compile("(?P<name>\S+)\s+(?P<cluster_ip>\S+)\s+(?P<external_ip>\S+)\s+(?P<port>\S+)/(?P<proto>\S+)\s+(?P<age>\S+)")
+    match = regex.match(sess.get("svc", "zookeeper")[0])
+    zookeeper_ip = match.group("cluster_ip")
+    zookeeper_port = match.group("port")
+    zookeeper = zookeeper_ip+":"+zookeeper_port
+    # TODO find all kafka pods
+    # TODO test from a non-broker pod
+    # TODO test from outside the cluster if there's an external IP
+    kafka = Kafka(sess, "kafka-0")
+    # Create a topic for the test
+    topic = random_topic_name()
+    group = random_group_name()
+    num_messages=10
+    kafka.create_topic(zookeeper, topic)
+    # Produce to this topic
+    send_results = kafka.verifiable_producer(topic, "localhost:9092", max_messages=num_messages)
+    assert(send_results.sent == send_results.acked)
+    # Consume from this topic
+    receive_results = kafka.verifiable_consumer(topic, group, "localhost:9092", max_messages=num_messages,
+                                          cmd_timeout_secs=10, verbose=True)
+    assert(send_results.sent == receive_results.count)
+    # clean up
+    kafka.delete_topic(zookeeper, topic, if_exists=True)
+
+
+if __name__ == '__main__':
+    pytest.main(args=sys.argv)


### PR DESCRIPTION
This isn't ready for merging yet, but definitely ready for sharing.

This basically allows to run system tests against various deployments. Currently there's only a single test, which just tests:

1. Creating a topic
2. Producing to it
3. Consuming from it
4. Deleting the topic

See the `README.md` for some basic instructions on running the tests. The tests are pretty slow, because the the deployments take a while. The actual tests run quite quickly.