### PR TITLE
Change app labels in Cluster Controller from barnabas to strimzi

### DIFF
--- a/cluster-controller/src/main/java/io/enmasse/barnabas/controller/cluster/ClusterControllerConfig.java
+++ b/cluster-controller/src/main/java/io/enmasse/barnabas/controller/cluster/ClusterControllerConfig.java
@@ -13,8 +13,8 @@ public class ClusterControllerConfig {
     }
 
     public static ClusterControllerConfig fromEnv() {
-        String namespace = System.getenv("BARNABAS_CONTROLLER_NAMESPACE");
-        String stringLabels = System.getenv("BARNABAS_CONTROLLER_LABELS");
+        String namespace = System.getenv("STRIMZI_CONTROLLER_NAMESPACE");
+        String stringLabels = System.getenv("STRIMZI_CONTROLLER_LABELS");
 
         Map<String, String> labelsMap = new HashMap<>();
 

--- a/cluster-controller/src/main/java/io/enmasse/barnabas/controller/cluster/Main.java
+++ b/cluster-controller/src/main/java/io/enmasse/barnabas/controller/cluster/Main.java
@@ -11,14 +11,9 @@ public class Main {
     private static final Logger log = LoggerFactory.getLogger(Main.class.getName());
 
     public static void main(String args[]) {
-        String namespace = "myproject";
-        Map<String, String> labels = new HashMap<>();
-        labels.put("app", "barnabas");
-        labels.put("kind", "cluster");
-
         try {
             Vertx vertx = Vertx.vertx();
-            vertx.deployVerticle(new ClusterController(new ClusterControllerConfig(namespace, labels)), res -> {
+            vertx.deployVerticle(new ClusterController(ClusterControllerConfig.fromEnv()), res -> {
                 if (res.succeeded())    {
                     log.info("Cluster Controller verticle started");
                 }

--- a/kafka-connect/resources/kubernetes.yaml
+++ b/kafka-connect/resources/kubernetes.yaml
@@ -3,9 +3,9 @@ kind: ConfigMap
 metadata:
   name: kafka-connect
   labels:
-    app: barnabas
-    type: deployment
-    kind: kafka-connect
+    app: strimzi
+    kind: cluster
+    type: kafka-connect
 data:
   nodes: "1"
   image: "strimzi/kafka-connect:latest"

--- a/kafka-connect/resources/openshift-template.yaml
+++ b/kafka-connect/resources/openshift-template.yaml
@@ -83,9 +83,9 @@ objects:
   metadata:
     name: kafka-connect
     labels:
-      app: barnabas
-      type: deployment
-      kind: kafka-connect
+      app: strimzi
+      kind: cluster
+      type: kafka-connect
   data:
     nodes: "${INSTANCES}"
     image: "${IMAGE_REPO_NAME}/${IMAGE_NAME}:${IMAGE_TAG}"

--- a/kafka-inmemory/resources/kubernetes.yaml
+++ b/kafka-inmemory/resources/kubernetes.yaml
@@ -101,15 +101,22 @@ spec:
       containers:
         - name: strimzi-cluster-controller
           image: strimzi/cluster-controller:latest
+          env:
+            - name: STRIMZI_CONTROLLER_LABELS
+              value: "app=strimzi,kind=cluster"
+            - name: STRIMZI_CONTROLLER_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: kafka
   labels:
-    app: barnabas
-    type: deployment
-    kind: kafka
+    app: strimzi
+    kind: cluster
+    type: kafka
 data:
   kafka-nodes: "3"
   kafka-image: "strimzi/kafka-statefulsets:latest"

--- a/kafka-inmemory/resources/openshift-template.yaml
+++ b/kafka-inmemory/resources/openshift-template.yaml
@@ -2,16 +2,16 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: barnabas-cluster-controller
+  name: strimzi-cluster-controller
   labels:
-    app: barnabas
+    app: strimzi
 ---
 apiVersion: v1
 kind: ClusterRole
 metadata:
-  name: barnabas-cluster-controller-role
+  name: strimzi-cluster-controller-role
   labels:
-    app: barnabas
+    app: strimzi
 rules:
 - apiGroups:
   - ""
@@ -75,32 +75,39 @@ rules:
 apiVersion: v1
 kind: RoleBinding
 metadata:
-  name: barnabas-cluster-controller-binding
+  name: strimzi-cluster-controller-binding
   labels:
-    app: barnabas
+    app: strimzi
 subjects:
   - kind: ServiceAccount
-    name: barnabas-cluster-controller
+    name: strimzi-cluster-controller
 roleRef:
   kind: ClusterRole
-  name: barnabas-cluster-controller-role
+  name: strimzi-cluster-controller-role
   apiGroup: v1
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: barnabas-cluster-controller
+  name: strimzi-cluster-controller
 spec:
   replicas: 1
   template:
     metadata:
       labels:
-        name: barnabas-cluster-controller
+        name: strimzi-cluster-controller
     spec:
-      serviceAccountName: barnabas-cluster-controller
+      serviceAccountName: strimzi-cluster-controller
       containers:
-        - name: barnabas-cluster-controller
-          image: enmasseproject/barnabas-cluster-controller:latest
+        - name: strimzi-cluster-controller
+          image: strimzi/cluster-controller:latest
+          env:
+            - name: STRIMZI_CONTROLLER_LABELS
+              value: "app=strimzi,kind=cluster"
+            - name: STRIMZI_CONTROLLER_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
 ---
 apiVersion: v1
 kind: Template
@@ -192,9 +199,9 @@ objects:
   metadata:
     name: kafka
     labels:
-      app: barnabas
-      type: deployment
-      kind: kafka
+      app: strimzi
+      type: kafka
+      kind: cluster
   data:
     kafka-nodes: "${KAFKA_NODE_COUNT}"
     kafka-image: "${IMAGE_REPO_NAME}/${KAFKA_IMAGE_NAME}:${KAFKA_IMAGE_TAG}"


### PR DESCRIPTION
* Use env variables starting with `STRIMZI_` instead of `BARNABAS_`
* Changes the `app` label from `barnabas` to `strimzi`
* Fix the `kind` and `type` labels in templates