### PR TITLE
Added catch on ConfigMap parsing error for releasing lock

### DIFF
--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/CreateKafkaClusterOperation.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/CreateKafkaClusterOperation.java
@@ -25,7 +25,15 @@ public class CreateKafkaClusterOperation extends KafkaClusterOperation {
 
                 log.info("Creating Kafka cluster {} in namespace {}", name, namespace);
 
-                KafkaCluster kafka = KafkaCluster.fromConfigMap(k8s.getConfigmap(namespace, name));
+                KafkaCluster kafka;
+                try {
+                    kafka = KafkaCluster.fromConfigMap(k8s.getConfigmap(namespace, name));
+                } catch (Exception ex) {
+                    log.error("Error while parsing cluster ConfigMap", ex);
+                    handler.handle(Future.failedFuture("ConfigMap parsing error"));
+                    lock.release();
+                    return;
+                }
 
                 // start creating configMap operation only if metrics are enabled,
                 // otherwise the future is already complete (for the "join")

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/CreateZookeeperClusterOperation.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/CreateZookeeperClusterOperation.java
@@ -25,7 +25,15 @@ public class CreateZookeeperClusterOperation extends ZookeeperClusterOperation {
 
                 log.info("Creating Zookeeper cluster {} in namespace {}", name + "-zookeeper", namespace);
 
-                ZookeeperCluster zk = ZookeeperCluster.fromConfigMap(k8s.getConfigmap(namespace, name));
+                ZookeeperCluster zk;
+                try {
+                    zk = ZookeeperCluster.fromConfigMap(k8s.getConfigmap(namespace, name));
+                } catch (Exception ex) {
+                    log.error("Error while parsing cluster ConfigMap", ex);
+                    handler.handle(Future.failedFuture("ConfigMap parsing error"));
+                    lock.release();
+                    return;
+                }
 
                 // start creating configMap operation only if metrics are enabled,
                 // otherwise the future is already complete (for the "join")


### PR DESCRIPTION
@scholzj most of the current configuration parameters in the cluster configmap have default value if the key is missing. It's not possible for the `kafka-storage` and `zookeeper-storage` which are mandatory (we don't want to push the user to a default storage type as agreed in the past). It means that user could miss the above keys in the configmap file (or more in general the configmap could have some malformed JSON values, see the metrics as well). In this case the `fromConfigMap` method throws an exception which, with this PR, is caught during create/update operation for releasing the lock and returning.
Another solution could be catching this kind of errors inside the `fromConfigMap` method itself returning a `null`; at the upper level this `null` could be handled as parsing error and doing the same. 
Wdyt ?