### PR TITLE
Refactoring labels on all cluster resources

### DIFF
--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterController.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterController.java
@@ -36,6 +36,8 @@ public class ClusterController extends AbstractVerticle {
     public static final String STRIMZI_DOMAIN = "strimzi.io";
     public static final String STRIMZI_CLUSTER_CONTROLLER_DOMAIN = "cluster.controller.strimzi.io";
     public static final String STRIMZI_TYPE_LABEL = STRIMZI_DOMAIN + "/type";
+    public static final String STRIMZI_CLUSTER_LABEL = STRIMZI_DOMAIN + "/cluster";
+    public static final String STRIMZI_NAME_LABEL = STRIMZI_DOMAIN + "/name";
 
     private final K8SUtils k8s;
     private final Map<String, String> labels;

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterController.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterController.java
@@ -213,7 +213,7 @@ public class ClusterController extends AbstractVerticle {
         List<StatefulSet> sss = k8s.getStatefulSets(namespace, kafkaLabels);
 
         List<String> cmsNames = cms.stream().map(cm -> cm.getMetadata().getName()).collect(Collectors.toList());
-        List<String> sssNames = sss.stream().map(cm -> cm.getMetadata().getName()).collect(Collectors.toList());
+        List<String> sssNames = sss.stream().map(cm -> cm.getMetadata().getLabels().get(ClusterController.STRIMZI_CLUSTER_LABEL)).collect(Collectors.toList());
 
         List<ConfigMap> addList = cms.stream().filter(cm -> !sssNames.contains(cm.getMetadata().getName())).collect(Collectors.toList());
         List<ConfigMap> updateList = cms.stream().filter(cm -> sssNames.contains(cm.getMetadata().getName())).collect(Collectors.toList());
@@ -255,7 +255,7 @@ public class ClusterController extends AbstractVerticle {
         List<Deployment> deps = k8s.getDeployments(namespace, kafkaLabels);
 
         List<String> cmsNames = cms.stream().map(cm -> cm.getMetadata().getName()).collect(Collectors.toList());
-        List<String> sssNames = deps.stream().map(cm -> cm.getMetadata().getName()).collect(Collectors.toList());
+        List<String> sssNames = deps.stream().map(cm -> cm.getMetadata().getLabels().get(ClusterController.STRIMZI_CLUSTER_LABEL)).collect(Collectors.toList());
 
         List<ConfigMap> addList = cms.stream().filter(cm -> !sssNames.contains(cm.getMetadata().getName())).collect(Collectors.toList());
         List<ConfigMap> updateList = cms.stream().filter(cm -> sssNames.contains(cm.getMetadata().getName())).collect(Collectors.toList());
@@ -269,7 +269,7 @@ public class ClusterController extends AbstractVerticle {
     private void addKafkaConnectClusters(List<ConfigMap> add)   {
         for (ConfigMap cm : add) {
             log.info("Reconciliation: Kafka Connect cluster {} should be added", cm.getMetadata().getName());
-            addKafkaCluster(cm);
+            addKafkaConnectCluster(cm);
         }
     }
 

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterController.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterController.java
@@ -361,7 +361,7 @@ public class ClusterController extends AbstractVerticle {
                 });
             }
             else {
-                log.error("Failed to delete Kafka cluster {}. SKipping Zookeeper cluster deletion.", name);
+                log.error("Failed to delete Kafka cluster {}. Skipping Zookeeper cluster deletion.", name);
             }
         });
     }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterController.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterController.java
@@ -217,7 +217,7 @@ public class ClusterController extends AbstractVerticle {
 
         List<ConfigMap> addList = cms.stream().filter(cm -> !sssNames.contains(cm.getMetadata().getName())).collect(Collectors.toList());
         List<ConfigMap> updateList = cms.stream().filter(cm -> sssNames.contains(cm.getMetadata().getName())).collect(Collectors.toList());
-        List<StatefulSet> deletionList = sss.stream().filter(ss -> !cmsNames.contains(ss.getMetadata().getName())).collect(Collectors.toList());
+        List<StatefulSet> deletionList = sss.stream().filter(ss -> !cmsNames.contains(ss.getMetadata().getLabels().get(ClusterController.STRIMZI_CLUSTER_LABEL))).collect(Collectors.toList());
 
         addKafkaClusters(addList);
         deleteKafkaClusters(deletionList);
@@ -255,11 +255,11 @@ public class ClusterController extends AbstractVerticle {
         List<Deployment> deps = k8s.getDeployments(namespace, kafkaLabels);
 
         List<String> cmsNames = cms.stream().map(cm -> cm.getMetadata().getName()).collect(Collectors.toList());
-        List<String> sssNames = deps.stream().map(cm -> cm.getMetadata().getLabels().get(ClusterController.STRIMZI_CLUSTER_LABEL)).collect(Collectors.toList());
+        List<String> depsNames = deps.stream().map(cm -> cm.getMetadata().getLabels().get(ClusterController.STRIMZI_CLUSTER_LABEL)).collect(Collectors.toList());
 
-        List<ConfigMap> addList = cms.stream().filter(cm -> !sssNames.contains(cm.getMetadata().getName())).collect(Collectors.toList());
-        List<ConfigMap> updateList = cms.stream().filter(cm -> sssNames.contains(cm.getMetadata().getName())).collect(Collectors.toList());
-        List<Deployment> deletionList = deps.stream().filter(dep -> !cmsNames.contains(dep.getMetadata().getName())).collect(Collectors.toList());
+        List<ConfigMap> addList = cms.stream().filter(cm -> !depsNames.contains(cm.getMetadata().getName())).collect(Collectors.toList());
+        List<ConfigMap> updateList = cms.stream().filter(cm -> depsNames.contains(cm.getMetadata().getName())).collect(Collectors.toList());
+        List<Deployment> deletionList = deps.stream().filter(dep -> !cmsNames.contains(dep.getMetadata().getLabels().get(ClusterController.STRIMZI_CLUSTER_LABEL))).collect(Collectors.toList());
 
         addKafkaConnectClusters(addList);
         deleteConnectConnectClusters(deletionList);

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/CreateKafkaClusterOperation.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/CreateKafkaClusterOperation.java
@@ -23,11 +23,12 @@ public class CreateKafkaClusterOperation extends KafkaClusterOperation {
             if (res.succeeded()) {
                 Lock lock = res.result();
 
-                log.info("Creating Kafka cluster {} in namespace {}", name, namespace);
-
                 KafkaCluster kafka;
                 try {
+
                     kafka = KafkaCluster.fromConfigMap(k8s.getConfigmap(namespace, name));
+                    log.info("Creating Kafka cluster {} in namespace {}", kafka.getName(), namespace);
+
                 } catch (Exception ex) {
                     log.error("Error while parsing cluster ConfigMap", ex);
                     handler.handle(Future.failedFuture("ConfigMap parsing error"));
@@ -55,11 +56,11 @@ public class CreateKafkaClusterOperation extends KafkaClusterOperation {
 
                 CompositeFuture.join(futureConfigMap, futureService, futureHeadlessService, futureStatefulSet).setHandler(ar -> {
                     if (ar.succeeded()) {
-                        log.info("Kafka cluster {} successfully created in namespace {}", name, namespace);
+                        log.info("Kafka cluster {} successfully created in namespace {}", kafka.getName(), namespace);
                         handler.handle(Future.succeededFuture());
                         lock.release();
                     } else {
-                        log.error("Kafka cluster {} failed to create in namespace {}", name, namespace);
+                        log.error("Kafka cluster {} failed to create in namespace {}", kafka.getName(), namespace);
                         handler.handle(Future.failedFuture("Failed to create Kafka cluster"));
                         lock.release();
                     }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/CreateKafkaConnectClusterOperation.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/CreateKafkaConnectClusterOperation.java
@@ -22,9 +22,8 @@ public class CreateKafkaConnectClusterOperation extends KafkaConnectClusterOpera
             if (res.succeeded()) {
                 Lock lock = res.result();
 
-                log.info("Creating Kafka Connect cluster {} in namespace {}", name, namespace);
-
                 KafkaConnectCluster connect = KafkaConnectCluster.fromConfigMap(k8s.getConfigmap(namespace, name));
+                log.info("Creating Kafka Connect cluster {} in namespace {}", connect.getName(), namespace);
 
                 Future<Void> futureService = Future.future();
                 OperationExecutor.getInstance().execute(new CreateServiceOperation(connect.generateService()), futureService.completer());
@@ -34,11 +33,11 @@ public class CreateKafkaConnectClusterOperation extends KafkaConnectClusterOpera
 
                 CompositeFuture.join(futureService, futureDeployment).setHandler(ar -> {
                     if (ar.succeeded()) {
-                        log.info("Kafka Connect cluster {} successfully created in namespace {}", name, namespace);
+                        log.info("Kafka Connect cluster {} successfully created in namespace {}", connect.getName(), namespace);
                         handler.handle(Future.succeededFuture());
                         lock.release();
                     } else {
-                        log.error("Kafka Connect cluster {} failed to create in namespace {}", name, namespace);
+                        log.error("Kafka Connect cluster {} failed to create in namespace {}", connect.getName(), namespace);
                         handler.handle(Future.failedFuture("Failed to create Kafka Connect cluster"));
                         lock.release();
                     }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/CreateZookeeperClusterOperation.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/CreateZookeeperClusterOperation.java
@@ -23,11 +23,12 @@ public class CreateZookeeperClusterOperation extends ZookeeperClusterOperation {
             if (res.succeeded()) {
                 Lock lock = res.result();
 
-                log.info("Creating Zookeeper cluster {} in namespace {}", name + "-zookeeper", namespace);
-
                 ZookeeperCluster zk;
                 try {
+
                     zk = ZookeeperCluster.fromConfigMap(k8s.getConfigmap(namespace, name));
+                    log.info("Creating Zookeeper cluster {} in namespace {}", zk.getName(), namespace);
+
                 } catch (Exception ex) {
                     log.error("Error while parsing cluster ConfigMap", ex);
                     handler.handle(Future.failedFuture("ConfigMap parsing error"));
@@ -55,11 +56,11 @@ public class CreateZookeeperClusterOperation extends ZookeeperClusterOperation {
 
                 CompositeFuture.join(futureConfigMap, futureService, futureHeadlessService, futureStatefulSet).setHandler(ar -> {
                     if (ar.succeeded()) {
-                        log.info("Zookeeper cluster {} successfully created in namespace {}", name + "-zookeeper", namespace);
+                        log.info("Zookeeper cluster {} successfully created in namespace {}", zk.getName(), namespace);
                         handler.handle(Future.succeededFuture());
                         lock.release();
                     } else {
-                        log.error("Zookeeper cluster {} failed to create in namespace {}", name + "-zookeeper", namespace);
+                        log.error("Zookeeper cluster {} failed to create in namespace {}", zk.getName(), namespace);
                         handler.handle(Future.failedFuture("Failed to create Zookeeper cluster"));
                         lock.release();
                     }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/DeleteKafkaConnectClusterOperation.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/DeleteKafkaConnectClusterOperation.java
@@ -3,6 +3,7 @@ package io.strimzi.controller.cluster.operations;
 import io.strimzi.controller.cluster.K8SUtils;
 import io.strimzi.controller.cluster.operations.kubernetes.DeleteDeploymentOperation;
 import io.strimzi.controller.cluster.operations.kubernetes.DeleteServiceOperation;
+import io.strimzi.controller.cluster.resources.KafkaConnectCluster;
 import io.vertx.core.*;
 import io.vertx.core.shareddata.Lock;
 import org.slf4j.Logger;
@@ -21,21 +22,23 @@ public class DeleteKafkaConnectClusterOperation extends KafkaConnectClusterOpera
             if (res.succeeded()) {
                 Lock lock = res.result();
 
-                log.info("Deleting Kafka Connect cluster {} from namespace {}", name, namespace);
+                KafkaConnectCluster connect = KafkaConnectCluster.fromDeployment(k8s, namespace, name);
+
+                log.info("Deleting Kafka Connect cluster {} from namespace {}", connect.getName(), namespace);
 
                 Future<Void> futureService = Future.future();
-                OperationExecutor.getInstance().execute(new DeleteServiceOperation(namespace, name), futureService.completer());
+                OperationExecutor.getInstance().execute(new DeleteServiceOperation(namespace, connect.getName()), futureService.completer());
 
                 Future<Void> futureDeployment = Future.future();
-                OperationExecutor.getInstance().execute(new DeleteDeploymentOperation(namespace, name), futureDeployment.completer());
+                OperationExecutor.getInstance().execute(new DeleteDeploymentOperation(namespace, connect.getName()), futureDeployment.completer());
 
                 CompositeFuture.join(futureService, futureDeployment).setHandler(ar -> {
                     if (ar.succeeded()) {
-                        log.info("Kafka Connect cluster {} successfully deleted from namespace {}", name, namespace);
+                        log.info("Kafka Connect cluster {} successfully deleted from namespace {}", connect.getName(), namespace);
                         handler.handle(Future.succeededFuture());
                         lock.release();
                     } else {
-                        log.error("Kafka Connect cluster {} failed to delete from namespace {}", name, namespace);
+                        log.error("Kafka Connect cluster {} failed to delete from namespace {}", connect.getName(), namespace);
                         handler.handle(Future.failedFuture("Failed to delete Kafka Connect cluster"));
                         lock.release();
                     }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/UpdateKafkaClusterOperation.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/UpdateKafkaClusterOperation.java
@@ -43,7 +43,7 @@ public class UpdateKafkaClusterOperation extends KafkaClusterOperation {
 
                         kafka = KafkaCluster.fromConfigMap(kafkaConfigMap);
                         log.info("Updating Kafka cluster {} in namespace {}", kafka.getName(), namespace);
-                        diff = kafka.diff(k8s, namespace, name);
+                        diff = kafka.diff(k8s, namespace);
 
                     } catch (Exception ex) {
 

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/UpdateKafkaConnectClusterOperation.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/UpdateKafkaConnectClusterOperation.java
@@ -40,7 +40,7 @@ public class UpdateKafkaConnectClusterOperation extends KafkaConnectClusterOpera
 
                     connect = KafkaConnectCluster.fromConfigMap(connectConfigMap);
                     log.info("Updating Kafka Connect cluster {} in namespace {}", connect.getName(), namespace);
-                    diff = connect.diff(k8s, namespace, name);
+                    diff = connect.diff(k8s, namespace);
 
                 } else  {
                     log.error("ConfigMap {} doesn't exist anymore in namespace {}", name, namespace);

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/UpdateZookeeperClusterOperation.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/UpdateZookeeperClusterOperation.java
@@ -40,7 +40,7 @@ public class UpdateZookeeperClusterOperation extends ZookeeperClusterOperation {
 
                         zk = ZookeeperCluster.fromConfigMap(zkConfigMap);
                         log.info("Updating Zookeeper cluster {} in namespace {}", zk.getName(), namespace);
-                        diff = zk.diff(k8s, namespace, name);
+                        diff = zk.diff(k8s, namespace);
 
                     } catch (Exception ex) {
 

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/AbstractCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/AbstractCluster.java
@@ -28,7 +28,7 @@ public abstract class AbstractCluster {
 
     protected static final String METRICS_CONFIG_FILE = "config.yml";
 
-    protected final String name;
+    protected final String cluster;
     protected final String namespace;
     protected Map<String, String> labels = new HashMap<>();
 
@@ -42,6 +42,7 @@ public abstract class AbstractCluster {
     protected int healthCheckInitialDelay;
 
     protected String headlessName;
+    protected String name;
 
     protected final int metricsPort = 9404;
     protected final String metricsPortName = "kafkametrics";
@@ -52,8 +53,19 @@ public abstract class AbstractCluster {
 
     protected Storage storage;
 
-    protected AbstractCluster(String namespace, String name) {
-        this.name = name;
+    protected String mounthPath;
+    protected String volumeName;
+    protected String metricsConfigVolumeName;
+    protected String metricsConfigMountPath;
+
+    /**
+     * Constructor
+     *
+     * @param namespace Kubernetes/OpenShift namespace where cluster resources are going to be created
+     * @param cluster   overall cluster name
+     */
+    protected AbstractCluster(String namespace, String cluster) {
+        this.cluster = cluster;
         this.namespace = namespace;
     }
 
@@ -62,7 +74,7 @@ public abstract class AbstractCluster {
     }
 
     protected void setLabels(Map<String, String> newLabels) {
-        newLabels.put("cluster-name", name);
+        newLabels.put(ClusterController.STRIMZI_CLUSTER_LABEL, cluster);
         this.labels = new HashMap<>(newLabels);
     }
 
@@ -86,6 +98,10 @@ public abstract class AbstractCluster {
         this.healthCheckInitialDelay = healthCheckInitialDelay;
     }
 
+    public String getName() {
+        return name;
+    }
+
     public String getHeadlessName() {
         return headlessName;
     }
@@ -96,7 +112,7 @@ public abstract class AbstractCluster {
 
     protected Map<String, String> getLabelsWithName(String name) {
         Map<String, String> labelsWithName = new HashMap<>(labels);
-        labelsWithName.put("name", name);
+        labelsWithName.put(ClusterController.STRIMZI_NAME_LABEL, name);
         return labelsWithName;
     }
 
@@ -134,6 +150,10 @@ public abstract class AbstractCluster {
 
     protected void setStorage(Storage storage) {
         this.storage = storage;
+    }
+
+    public String getVolumeName() {
+        return this.volumeName;
     }
 
     protected VolumeMount createVolumeMount(String name, String path) {

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/KafkaCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/KafkaCluster.java
@@ -19,7 +19,7 @@ public class KafkaCluster extends AbstractCluster {
     private final int clientPort = 9092;
     private final String clientPortName = "clients";
 
-    private static String NAME_SUFFIX = ""; // TODO : add new suffix ?
+    private static String NAME_SUFFIX = "-kafka";
     private static String HEADLESS_NAME_SUFFIX = NAME_SUFFIX + "-headless";
     private static String METRICS_CONFIG_SUFFIX = NAME_SUFFIX + "-metrics-config";
 
@@ -164,13 +164,12 @@ public class KafkaCluster extends AbstractCluster {
      *
      * @param k8s   K8SUtils client instance for accessing Kubernetes/OpenShift cluster
      * @param namespace Kubernetes/OpenShift namespace where cluster resources belong to
-     * @param cluster   overall cluster name
      * @return  ClusterDiffResult instance with differences
      */
-    public ClusterDiffResult diff(K8SUtils k8s, String namespace, String cluster)  {
+    public ClusterDiffResult diff(K8SUtils k8s, String namespace)  {
 
-        StatefulSet ss = k8s.getStatefulSet(namespace, cluster + KafkaCluster.NAME_SUFFIX);
-        ConfigMap metricsConfigMap = k8s.getConfigmap(namespace, cluster + KafkaCluster.METRICS_CONFIG_SUFFIX);
+        StatefulSet ss = k8s.getStatefulSet(namespace, getName());
+        ConfigMap metricsConfigMap = k8s.getConfigmap(namespace, getMetricsConfigName());
 
         ClusterDiffResult diff = new ClusterDiffResult();
 

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/KafkaConnectCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/KafkaConnectCluster.java
@@ -153,12 +153,11 @@ public class KafkaConnectCluster extends AbstractCluster {
      *
      * @param k8s   K8SUtils client instance for accessing Kubernetes/OpenShift cluster
      * @param namespace Kubernetes/OpenShift namespace where cluster resources belong to
-     * @param cluster   overall cluster name
      * @return  ClusterDiffResult instance with differences
      */
-    public ClusterDiffResult diff(K8SUtils k8s, String namespace, String cluster) {
+    public ClusterDiffResult diff(K8SUtils k8s, String namespace) {
 
-        Deployment dep = k8s.getDeployment(namespace, cluster + KafkaConnectCluster.NAME_SUFFIX);
+        Deployment dep = k8s.getDeployment(namespace, getName());
 
         ClusterDiffResult diff = new ClusterDiffResult();
 

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/ZookeeperCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/ZookeeperCluster.java
@@ -151,13 +151,12 @@ public class ZookeeperCluster extends AbstractCluster {
      *
      * @param k8s   K8SUtils client instance for accessing Kubernetes/OpenShift cluster
      * @param namespace Kubernetes/OpenShift namespace where cluster resources belong to
-     * @param cluster   overall cluster name
      * @return  ClusterDiffResult instance with differences
      */
-    public ClusterDiffResult diff(K8SUtils k8s, String namespace, String cluster)  {
+    public ClusterDiffResult diff(K8SUtils k8s, String namespace)  {
 
-        StatefulSet ss = k8s.getStatefulSet(namespace, cluster + ZookeeperCluster.NAME_SUFFIX);
-        ConfigMap metricsConfigMap = k8s.getConfigmap(namespace, cluster + ZookeeperCluster.METRICS_CONFIG_SUFFIX);
+        StatefulSet ss = k8s.getStatefulSet(namespace, getName());
+        ConfigMap metricsConfigMap = k8s.getConfigmap(namespace, getMetricsConfigName());
 
         ClusterDiffResult diff = new ClusterDiffResult();
 

--- a/resources/kubernetes/kafka-connect.yaml
+++ b/resources/kubernetes/kafka-connect.yaml
@@ -10,7 +10,7 @@ data:
   image: "strimzi/kafka-connect:latest"
   healthcheck-delay: "60"
   healthcheck-timeout: "5"
-  KAFKA_CONNECT_BOOTSTRAP_SERVERS: "kafka-kafka:9092"
+  KAFKA_CONNECT_BOOTSTRAP_SERVERS: "mycluster-kafka:9092"
   KAFKA_CONNECT_GROUP_ID: "my-connect-cluster"
   KAFKA_CONNECT_KEY_CONVERTER: "org.apache.kafka.connect.json.JsonConverter"
   KAFKA_CONNECT_KEY_CONVERTER_SCHEMAS_ENABLE: "true"

--- a/resources/kubernetes/kafka-connect.yaml
+++ b/resources/kubernetes/kafka-connect.yaml
@@ -10,7 +10,7 @@ data:
   image: "strimzi/kafka-connect:latest"
   healthcheck-delay: "60"
   healthcheck-timeout: "5"
-  KAFKA_CONNECT_BOOTSTRAP_SERVERS: "kafka:9092"
+  KAFKA_CONNECT_BOOTSTRAP_SERVERS: "kafka-kafka:9092"
   KAFKA_CONNECT_GROUP_ID: "my-connect-cluster"
   KAFKA_CONNECT_KEY_CONVERTER: "org.apache.kafka.connect.json.JsonConverter"
   KAFKA_CONNECT_KEY_CONVERTER_SCHEMAS_ENABLE: "true"

--- a/resources/kubernetes/kafka-ephemeral.yaml
+++ b/resources/kubernetes/kafka-ephemeral.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: kafka-ephemeral
+  name: mycluster-ephemeral
   labels:
     strimzi.io/kind: cluster
     strimzi.io/type: kafka

--- a/resources/kubernetes/kafka-persistent.yaml
+++ b/resources/kubernetes/kafka-persistent.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: kafka
+  name: mycluster
   labels:
     strimzi.io/kind: cluster
     strimzi.io/type: kafka

--- a/resources/openshift/controller-with-template.yaml
+++ b/resources/openshift/controller-with-template.yaml
@@ -400,7 +400,7 @@ parameters:
   displayName: Kafka bootstrap servers
   name: KAFKA_CONNECT_BOOTSTRAP_SERVERS
   required: true
-  value: kafka:9092
+  value: kafka-kafka:9092
 - description: A unique string that identifies the Connect cluster group this worker belongs to. Note this must not conflict with any consumer group IDs.
   displayName: Group ID
   name: KAFKA_CONNECT_GROUP_ID

--- a/resources/openshift/controller-with-template.yaml
+++ b/resources/openshift/controller-with-template.yaml
@@ -129,12 +129,12 @@ metadata:
     tags: "messaging,datastore"
     iconClass: "fa fa-share-alt fa-flip-horizontal"
     template.openshift.io/documentation-url: "http://strimzi.io"
-message: "Use 'kafka:9092' as bootstrap server in your application"
+message: "Use 'mycluster-kafka:9092' as bootstrap server in your application"
 parameters:
 - description: All Kubernetes resources will be named after the cluster name
   displayName: Name of the cluster
   name: CLUSTER_NAME
-  value: kafka
+  value: mycluster
 - description: Number of Zookeper cluster nodes which will be deployed (odd number of nodes is recomended)
   displayName: Number of Zookeper cluster nodes (odd number of nodes is recomended)
   name: ZOOKEEPER_NODE_COUNT
@@ -252,12 +252,12 @@ metadata:
     tags: "messaging,datastore"
     iconClass: "fa fa-share-alt fa-flip-horizontal"
     template.openshift.io/documentation-url: "http://strimzi.io"
-message: "Use 'kafka:9092' as bootstrap server in your application"
+message: "Use 'mycluster-kafka:9092' as bootstrap server in your application"
 parameters:
 - description: All Kubernetes resources will be named after the cluster name
   displayName: Name of the cluster
   name: CLUSTER_NAME
-  value: kafka
+  value: mycluster
 - description: Number of Zookeper cluster nodes which will be deployed (odd number of nodes is recomended)
   displayName: Number of Zookeper cluster nodes (odd number of nodes is recomended)
   name: ZOOKEEPER_NODE_COUNT
@@ -385,12 +385,12 @@ metadata:
     tags: "messaging"
     iconClass: "fa fa-exchange"
     template.openshift.io/documentation-url: "http://strimzi.io"
-message: "Use 'kafka-connect:8083' to access Kafka Connect REST API."
+message: "Use 'my-connect-cluster-connect:8083' to access Kafka Connect REST API."
 parameters:
 - description: All Kubernetes resources will be named after the cluster name
   displayName: Name of the cluster
   name: CLUSTER_NAME
-  value: kafka-connect
+  value: my-connect-cluster
 - description: Specifies the number of Kafka Connect instances to be started by default.
   displayName: Number of Kafka Connect instances
   name: INSTANCES
@@ -400,7 +400,7 @@ parameters:
   displayName: Kafka bootstrap servers
   name: KAFKA_CONNECT_BOOTSTRAP_SERVERS
   required: true
-  value: kafka-kafka:9092
+  value: mycluster-kafka:9092
 - description: A unique string that identifies the Connect cluster group this worker belongs to. Note this must not conflict with any consumer group IDs.
   displayName: Group ID
   name: KAFKA_CONNECT_GROUP_ID


### PR DESCRIPTION
Refactoring labels on all cluster resources
Avoiding to refer cluster related names from operation
Moved common volume fields to the AbstractCluster class
It fixes #158 