### PR TITLE
Various fixes and improvemens to do with ConfigMap names

### DIFF
--- a/topic-controller/src/main/java/io/strimzi/controller/topic/K8s.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/K8s.java
@@ -26,14 +26,11 @@ import java.util.List;
 
 public interface K8s {
 
-    // TODO define what happens if cm already exists
     void createConfigMap(ConfigMap cm, Handler<AsyncResult<Void>> handler);
 
-    // TODO define what happens if cm doesn't exist
     void updateConfigMap(ConfigMap cm, Handler<AsyncResult<Void>> handler);
 
-    // TODO define what happens if cm doesn't exists
-    void deleteConfigMap(TopicName topicName, Handler<AsyncResult<Void>> handler);
+    void deleteConfigMap(MapName mapName, Handler<AsyncResult<Void>> handler);
 
     void listMaps(Handler<AsyncResult<List<ConfigMap>>> handler);
 

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/K8sImpl.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/K8sImpl.java
@@ -70,11 +70,11 @@ public class K8sImpl implements K8s {
     }
 
     @Override
-    public void deleteConfigMap(TopicName topicName, Handler<AsyncResult<Void>> handler) {
+    public void deleteConfigMap(MapName mapName, Handler<AsyncResult<Void>> handler) {
         vertx.executeBlocking(future -> {
             try {
                 // Delete the CM by the topic name, because neither ZK nor Kafka know the CM name
-                client.configMaps().withName(topicName.toString()).delete();
+                client.configMaps().withName(mapName.toString()).delete();
                 future.complete();
             } catch (Exception e) {
                 future.fail(e);

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/MapName.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/MapName.java
@@ -19,13 +19,26 @@ package io.strimzi.controller.topic;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
 
+import java.util.regex.Pattern;
+
 /**
  * Typesafe representation of the name of a ConfigMap.
  */
 class MapName {
     private final String name;
 
+    private static final Pattern RESOURCE_PATTERN = Pattern.compile("[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*");
+    public static final int MAX_RESOURCE_NAME_LENGTH = 253;
+
+    public static boolean isValidResourceName(String resourceName) {
+        return resourceName.length() <= MAX_RESOURCE_NAME_LENGTH
+                && RESOURCE_PATTERN.matcher(resourceName).matches();
+    }
+
     public MapName(String name) {
+        if (!isValidResourceName(name)) {
+            throw new IllegalArgumentException("'" + name + "' is not a valid Kubernetes resource name");
+        }
         this.name = name;
     }
 

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/Topic.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/Topic.java
@@ -139,6 +139,14 @@ public class Topic {
         return mapName;
     }
 
+    public MapName getOrAsMapName() {
+        if (mapName != null) {
+            return mapName;
+        } else {
+            return topicName.asMapName();
+        }
+    }
+
     public int getNumPartitions() {
         return numPartitions;
     }

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/TopicName.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/TopicName.java
@@ -20,6 +20,11 @@ package io.strimzi.controller.topic;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import org.apache.kafka.common.internals.Topic;
 
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
 /**
  * Typesafe representation of the name of a topic.
  */
@@ -56,8 +61,82 @@ class TopicName {
         return name.hashCode();
     }
 
+    // This is the same regex used by kubernetes (or at least oc create)
+    public static final String SEP = "---";
+
+    /**
+     * Return a valid map name for the given topic name. If the topic name is already valid as a resource name
+     * then it is used as the returned resource name, otherwise a "best effort" prefix is
+     * constructed (with invalid characters removed or changed) and a disambiguating hash is appended to that
+     * prefix and the concatenation of the prefix and hash is returned.
+     */
     public MapName asMapName() {
-        // TODO sanitize name
-        return new MapName(this.name);
+        MapName mname;
+        if (MapName.isValidResourceName(this.name)) {
+            mname = new MapName(this.name);
+        } else {
+            StringBuilder n = new StringBuilder();
+            for (int i = 0; i < this.name.length(); i++) {
+                char next = i < this.name.length() - 1 ? this.name.charAt(i+1) : '\0';
+                char ch = this.name.charAt(i);
+                if (isInRange('a', ch,'z')
+                        || isInRange('0', ch, '9')) {
+                    n.append(ch);
+                } else if (isInRange('A', ch, 'Z')) {
+                    n.append(Character.toLowerCase(ch));
+                } else if (ch == '-' || ch == '.' || ch == '_') {
+                    // avoid hyphen next to dot in the output
+                    for (int j = n.length()-1; j >= 0; j--) {
+                        if (isInRange('a', n.charAt(j), 'z')
+                                || isInRange('0', n.charAt(j), '9')) {
+                            n.append(ch == '_' ? '-' : ch);
+                            break;
+                        } else {
+                            break;
+                        }
+                    }
+                }
+                // only other possibiilty for ch is underscore, which is always invalid
+            }
+
+            // it's still possible that n ends with a sequence of hyphens or dots
+            int cut = 0;
+            for (int j = n.length()-1; j >= 0; j--) {
+                char ch = n.charAt(j);
+                if (ch == '.' || ch == '-') {
+                    cut++;
+                } else {
+                    break;
+                }
+            }
+            n.setLength(n.length()-cut);
+
+            final MessageDigest md;
+            try {
+                md = MessageDigest.getInstance("SHA-1");
+            } catch (NoSuchAlgorithmException e) {
+                throw new RuntimeException("Couldn't get SHA1 MessageDigest", e);
+            }
+            final int sha1HexLength = 40;
+            byte[] sha1sum = md.digest(this.name.getBytes(StandardCharsets.UTF_8));
+            int truncate = n.length() + sha1HexLength + SEP.length() - MapName.MAX_RESOURCE_NAME_LENGTH;
+            if (truncate > 0) {
+                n.setLength(MapName.MAX_RESOURCE_NAME_LENGTH - (sha1HexLength + SEP.length()));
+            }
+            // It's still possible that n is empty by this point
+            // (if tname consisted entirely of chars at invalid positions)
+            // and starting the name with "---" would make it invalid, so
+            // only add the SEP if there's something to separate.
+            if (n.length() > 0) {
+                n.append(SEP);
+            }
+            n.append(new BigInteger(1, sha1sum).toString(16));
+            mname = new MapName(n.toString());
+        }
+        return mname;
+    }
+
+    private boolean isInRange(char a, char ch, char z) {
+        return a <= ch && ch <= z;
     }
 }

--- a/topic-controller/src/test/java/io/strimzi/controller/topic/ControllerTest.java
+++ b/topic-controller/src/test/java/io/strimzi/controller/topic/ControllerTest.java
@@ -437,7 +437,7 @@ public class ControllerTest {
         Async async0 = context.async(2);
         mockK8s.setCreateResponse(mapName, null)
                 .createConfigMap(TopicSerialization.toConfigMap(kubeTopic, cmPredicate), ar -> async0.countDown());
-        mockK8s.setDeleteResponse(topicName, null);
+        mockK8s.setDeleteResponse(mapName, null);
         mockTopicStore.setCreateTopicResponse(topicName, null)
                 .create(privateTopic, ar-> async0.countDown());
         mockTopicStore.setDeleteTopicResponse(topicName, null);
@@ -790,13 +790,13 @@ public class ControllerTest {
     }
 
     private void topicDeleted(TestContext context, Exception storeException, Exception k8sException) {
-        Topic kubeTopic = new Topic.Builder(topicName.toString(), 10, (short)2, map("cleanup.policy", "bar")).build();
+        Topic kubeTopic = new Topic.Builder(topicName.toString(), 10, (short)2, map("cleanup.policy", "bar")).withMapName(mapName).build();
         Topic kafkaTopic = kubeTopic;
         Topic privateTopic = kubeTopic;
 
         mockK8s.setCreateResponse(mapName, null)
                 .createConfigMap(TopicSerialization.toConfigMap(kubeTopic, cmPredicate), ar -> {});
-        mockK8s.setDeleteResponse(topicName, k8sException);
+        mockK8s.setDeleteResponse(mapName, k8sException);
 
         mockTopicStore.setCreateTopicResponse(topicName, null)
                 .create(privateTopic, ar -> {});

--- a/topic-controller/src/test/java/io/strimzi/controller/topic/MockK8s.java
+++ b/topic-controller/src/test/java/io/strimzi/controller/topic/MockK8s.java
@@ -34,11 +34,10 @@ import java.util.function.Predicate;
 public class MockK8s implements K8s {
 
     private Map<MapName, ConfigMap> byName = new HashMap<>();
-    private Map<TopicName, ConfigMap> byTopicName = new HashMap<>();
     private List<Event> events = new ArrayList<>();
     private Function<MapName, AsyncResult<Void>> createResponse = n -> Future.failedFuture("Unexpected. ");
     private Function<MapName, AsyncResult<Void>> modifyResponse = n -> Future.failedFuture("Unexpected. ");
-    private Function<TopicName, AsyncResult<Void>> deleteResponse = n -> Future.failedFuture("Unexpected. ");
+    private Function<MapName, AsyncResult<Void>> deleteResponse = n -> Future.failedFuture("Unexpected. ");
 
     public MockK8s setCreateResponse(MapName mapName, Exception exception) {
         Function<MapName, AsyncResult<Void>> old = createResponse;
@@ -70,8 +69,8 @@ public class MockK8s implements K8s {
         return this;
     }
 
-    public MockK8s setDeleteResponse(TopicName mapName, Exception exception) {
-        Function<TopicName, AsyncResult<Void>> old = deleteResponse;
+    public MockK8s setDeleteResponse(MapName mapName, Exception exception) {
+        Function<MapName, AsyncResult<Void>> old = deleteResponse;
         deleteResponse = n -> {
             if (mapName.equals(n)) {
                 if (exception == null) {
@@ -90,9 +89,7 @@ public class MockK8s implements K8s {
         AsyncResult<Void> response = createResponse.apply(new MapName(cm));
         if (response.succeeded()) {
             ConfigMap old = byName.put(new MapName(cm), cm);
-            if (old == null) {
-                byTopicName.put(new TopicName(cm.getData().getOrDefault(TopicSerialization.CM_KEY_NAME, cm.getMetadata().getName())), cm);
-            } else {
+            if (old != null) {
                 handler.handle(Future.failedFuture("configmap already existed: " + cm.getMetadata().getName()));
                 return;
             }
@@ -108,23 +105,18 @@ public class MockK8s implements K8s {
             if (old == null) {
                 handler.handle(Future.failedFuture("configmap does not exist, cannot be updated: " + cm.getMetadata().getName()));
                 return;
-            } else {
-                byTopicName.put(new TopicName(cm.getData().getOrDefault(TopicSerialization.CM_KEY_NAME, cm.getMetadata().getName())), cm);
             }
         }
         handler.handle(response);
     }
 
     @Override
-    public void deleteConfigMap(TopicName topicName, Handler<AsyncResult<Void>> handler) {
-        AsyncResult<Void> response = deleteResponse.apply(topicName);
+    public void deleteConfigMap(MapName mapName, Handler<AsyncResult<Void>> handler) {
+        AsyncResult<Void> response = deleteResponse.apply(mapName);
         if (response.succeeded()) {
-            ConfigMap cm = byTopicName.remove(topicName);
-            if (cm == null) {
-                handler.handle(Future.failedFuture("No such configmap, with topic name " + topicName));
+            if (byName.remove(mapName) == null) {
+                handler.handle(Future.failedFuture("configmap does not exist, cannot be deleted: " + mapName));
                 return;
-            } else {
-                byName.remove(new MapName(cm.getMetadata().getName()));
             }
         }
         handler.handle(response);

--- a/topic-controller/src/test/java/io/strimzi/controller/topic/TopicNameTest.java
+++ b/topic-controller/src/test/java/io/strimzi/controller/topic/TopicNameTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.strimzi.controller.topic;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class TopicNameTest {
+
+    private void checkMappedName(String name, String expect) {
+        assertEquals(expect, new TopicName(name).asMapName().toString());
+    }
+
+    @Test
+    public void testAsMapName() {
+        checkMappedName("foo", "foo");
+        checkMappedName("Foo", "foo---201a6b3053cc1422d2c3670b62616221d2290929");
+        checkMappedName("FOO", "foo---feab40e1fca77c7360ccca1481bb8ba5f919ce3a");
+        checkMappedName("foo.bar", "foo.bar");
+        checkMappedName("foo.BAR", "foo.bar---2b539a9cb49ce7280d7ebfb93b08540a6535ba35");
+        checkMappedName("foo-bar.baz", "foo-bar.baz");
+        checkMappedName("__foo", "foo---117282ae03235561f215ee101800b2d5b3609f7");
+        checkMappedName("foo__", "foo---47318fcc6fa7f277565de829dbd878e03530e078");
+        checkMappedName("foo__bar", "foo-bar---423126006221ca9092992ce14121ee0a3eaed346");
+        checkMappedName("foo_bar", "foo-bar---5d5f20e74771b852025c3edb66c9462eeb913d03");
+        checkMappedName("--foo", "foo---5a5af07607cb6064c0183648a704188a457b1eb6");
+        checkMappedName("foo--", "foo---b16c222dbf36b52253b205d0132eab9d7d879907");
+        checkMappedName("foo--bar", "foo--bar");
+        checkMappedName("..foo", "foo---cab6ff58f3d59a9f69aaa8c19603f7ce9bb34056");
+        checkMappedName("foo..bar", "foo.bar---4683128189ed6ca9d78cb034fa97f327e46d7465");
+        checkMappedName("foo..", "foo---ab2e4e62f3b8c288495eb2616ee2cd678f83a63f");
+        checkMappedName("foo.-bar", "foo.bar---4f4325245861ad879d835e7fca95145c2f8c5eb8");
+        checkMappedName("foo-.bar", "foo-bar---6ba1b74e7c34254171fabf7cdfbba9936356e940");
+        checkMappedName("-", "3bc15c8aae3e4124dd409035f32ea2fd6835efc9");
+        checkMappedName("--", "e6a9fc04320a924f46c7c737432bb0389d9dd095");
+        checkMappedName("...", "6eae3a5b062c6d0d79f070c26e6d62486b40cb46");
+        checkMappedName("-.", "d6aee8987a388b8b4c590e42011c8a18286f7ca8");
+        checkMappedName(".-", "5166aaeb81d80edb1b34f9550e3c5cdf4edfe8a7");
+        checkMappedName("012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678", "012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678");
+        checkMappedName("01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567-", "012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789---5d35cf300f0748c74f224496d9973d9657c36b57");
+    }
+}


### PR DESCRIPTION
* Validate configmap names
* Implement CM name generation (using, approximately the algo discussed in #139)
* Use the MapName to identify what to delete in K8s.delete()
* The Private topic info needs to include the map name,
* Reorder the lookup of k8s+topicstore lookups when deleting a topics, so we
  know which ConfigMap we need to delete
