### PR TITLE
Create k8s Events when CM changes can't be processed

### DIFF
--- a/topic-controller/resources/openshift-template.yaml
+++ b/topic-controller/resources/openshift-template.yaml
@@ -16,7 +16,7 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - ["configmaps", "events"]
+  - configmaps
   verbs:
   - get
   - list
@@ -25,6 +25,12 @@ rules:
   - patch
   - update
   - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - get
 ---
 apiVersion: v1
 kind: RoleBinding

--- a/topic-controller/resources/openshift-template.yaml
+++ b/topic-controller/resources/openshift-template.yaml
@@ -30,7 +30,7 @@ rules:
   resources:
   - events
   verbs:
-  - get
+  - create
 ---
 apiVersion: v1
 kind: RoleBinding

--- a/topic-controller/resources/openshift-template.yaml
+++ b/topic-controller/resources/openshift-template.yaml
@@ -16,7 +16,7 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - configmaps
+  - ["configmaps", "events"]
   verbs:
   - get
   - list
@@ -24,6 +24,7 @@ rules:
   - create
   - patch
   - update
+  - delete
 ---
 apiVersion: v1
 kind: RoleBinding

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/ConfigMapWatcher.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/ConfigMapWatcher.java
@@ -50,11 +50,16 @@ class ConfigMapWatcher implements Watcher<ConfigMap> {
                 if (ar.succeeded()) {
                     logger.info("Success processing ConfigMap watch event {} on map {} with labels {}", action, name, labels);
                 } else {
+                    String message;
                     if (ar.cause() instanceof InvalidConfigMapException) {
-                        logger.error("ConfigMap {} has an invalid 'data' section: {}", name, ar.cause().getMessage());
+                        message = "ConfigMap "+name+" has an invalid 'data' section: " + ar.cause().getMessage();
+                        logger.error("{}", message);
+
                     } else {
-                        logger.error("Failure processing ConfigMap watch event {} on map {} with labels {}", action, name, labels, ar.cause());
+                        message = "Failure processing ConfigMap watch event " + action + " on map " + name + " with labels " + labels +": " + ar.cause().getMessage();
+                        logger.error("{}", message, ar.cause());
                     }
+                    controller.enqueue(controller.new ErrorEvent(configMap, message, Controller.ErrorType.WARNING, errorResult -> {}));
                 }
             };
             switch (action) {

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/ConfigMapWatcher.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/ConfigMapWatcher.java
@@ -59,7 +59,7 @@ class ConfigMapWatcher implements Watcher<ConfigMap> {
                         message = "Failure processing ConfigMap watch event " + action + " on map " + name + " with labels " + labels +": " + ar.cause().getMessage();
                         logger.error("{}", message, ar.cause());
                     }
-                    controller.enqueue(controller.new ErrorEvent(configMap, message, Controller.ErrorType.WARNING, errorResult -> {}));
+                    controller.enqueue(controller.new Event(configMap, message, Controller.EventType.WARNING, errorResult -> {}));
                 }
             };
             switch (action) {

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/Controller.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/Controller.java
@@ -47,8 +47,17 @@ public class Controller {
     private TopicStore topicStore;
     private final InFlight inFlight;
 
-    class ErrorEvent implements Handler<Void> {
+    enum ErrorType {
+        INFO("Info"),
+        WARNING("Warning");
+        final String name;
+        ErrorType(String name) {
+            this.name = name;
+        }
+    }
 
+    class ErrorEvent implements Handler<Void> {
+        private final ErrorType errorType;
         private final String message;
         private final HasMetadata involvedObject;
         private final Handler<AsyncResult<Void>> handler;
@@ -57,37 +66,44 @@ public class Controller {
             this.involvedObject = exception.getInvolvedObject();
             this.message = exception.getMessage();
             this.handler = handler;
+            this.errorType = ErrorType.WARNING;
         }
 
-        public ErrorEvent(HasMetadata involvedObject, String message, Handler<AsyncResult<Void>> handler) {
+        public ErrorEvent(HasMetadata involvedObject, String message, ErrorType errorType, Handler<AsyncResult<Void>> handler) {
             this.involvedObject = involvedObject;
             this.message = message;
             this.handler = handler;
+            this.errorType = errorType;
         }
 
         @Override
         public void handle(Void v) {
-            String myHost = "";
             EventBuilder evtb = new EventBuilder().withApiVersion("v1");
             if (involvedObject != null) {
                 evtb.withNewInvolvedObject()
-                        .withKind(involvedObject.getKind())
+                        .withKind("ConfigMap")
                         .withName(involvedObject.getMetadata().getName())
                         .withApiVersion(involvedObject.getApiVersion())
                         .withNamespace(involvedObject.getMetadata().getNamespace())
                         .withUid(involvedObject.getMetadata().getUid())
                         .endInvolvedObject();
             }
-            evtb.withType("Warning")
-                    .withMessage(this.getClass().getSimpleName() + " failed: " + message)
-                    //.withReason("")
+            evtb.withType(errorType.name)
+                    .withMessage(message)
+                    .withNewMetadata().withLabels(cmPredicate.labels()).withGenerateName("topic-controller").endMetadata()
                     .withNewSource()
-                    .withHost(myHost)
                     .withComponent(Controller.class.getName())
                     .endSource();
             Event event = evtb.build();
+            switch (errorType) {
+                case INFO:
+                    logger.info("{}", message);
+                    break;
+                case WARNING:
+                    logger.warn("{}", message);
+                    break;
+            }
             k8s.createEvent(event, handler);
-            eventLogger.warn(event.toString());
         }
 
         public String toString() {
@@ -219,7 +235,7 @@ public class Controller {
         public void handle(Void v) throws ControllerException {
             kafka.updateTopicConfig(topic, ar-> {
                 if (ar.failed()) {
-                    enqueue(new ErrorEvent(involvedObject, ar.cause().toString(), eventResult -> {}));
+                    enqueue(new ErrorEvent(involvedObject, ar.cause().toString(), ErrorType.WARNING, eventResult -> {}));
                 }
                 handler.handle(ar);
             });
@@ -250,7 +266,7 @@ public class Controller {
         public void handle(Void v) throws ControllerException {
             kafka.increasePartitions(topic, ar-> {
                 if (ar.failed()) {
-                    enqueue(new ErrorEvent(involvedObject, ar.cause().toString(), eventResult -> {}));
+                    enqueue(new ErrorEvent(involvedObject, ar.cause().toString(), ErrorType.WARNING, eventResult -> {}));
                 }
                 handler.handle(ar);
             });
@@ -281,7 +297,7 @@ public class Controller {
         public void handle(Void v) throws ControllerException {
             kafka.changeReplicationFactor(topic, ar-> {
                 if (ar.failed()) {
-                    enqueue(new ErrorEvent(involvedObject, ar.cause().toString(), eventResult -> {}));
+                    enqueue(new ErrorEvent(involvedObject, ar.cause().toString(), ErrorType.WARNING, eventResult -> {}));
                 }
                 handler.handle(ar);
             });
@@ -484,7 +500,7 @@ public class Controller {
             // Just use kafka version, but also create a warning event
             logger.debug("cm created in k8s and topic created in kafka, and they are irreconcilably different => kafka version wins");
             enqueue(new ErrorEvent(involvedObject, "ConfigMap is incompatible with the topic metadata. " +
-                    "The topic metadata will be treated as canonical.", ar -> {
+                    "The topic metadata will be treated as canonical.", ErrorType.INFO, ar -> {
                 if (ar.succeeded()) {
                     enqueue(new UpdateConfigMap(kafkaTopic, involvedObject, ar2 -> {
                         if (ar2.succeeded()) {
@@ -510,7 +526,7 @@ public class Controller {
         if (conflict != null) {
             final String message = "ConfigMap and Topic both changed in a conflicting way: " + conflict;
             logger.error(message);
-            enqueue(new ErrorEvent(involvedObject, message, eventResult -> {}));
+            enqueue(new ErrorEvent(involvedObject, message, ErrorType.INFO, eventResult -> {}));
             reconciliationResultHandler.handle(Future.failedFuture(new Exception(message)));
         } else {
             TopicDiff merged = oursKafka.merge(oursK8s);
@@ -524,7 +540,7 @@ public class Controller {
                 if (partitionsDelta < 0) {
                     final String message = "Number of partitions cannot be decreased";
                     logger.error(message);
-                    enqueue(new ErrorEvent(involvedObject, message, eventResult -> {
+                    enqueue(new ErrorEvent(involvedObject, message, ErrorType.INFO, eventResult -> {
                     }));
                     reconciliationResultHandler.handle(Future.failedFuture(new Exception(message)));
                 } else {
@@ -708,7 +724,7 @@ public class Controller {
             Handler<Future<Void>> action = new Reconciliation("onConfigMapAdded") {
                 @Override
                 public void handle(Future<Void> fut) {
-                    Controller.this.reconcileOnCmChange(configMap, k8sTopic, fut);
+                    Controller.this.reconcileOnCmChange(configMap, k8sTopic, false, fut);
                 }
             };
             inFlight.enqueue(new TopicName(configMap), resultHandler, action);
@@ -743,7 +759,7 @@ public class Controller {
             Reconciliation action = new Reconciliation("onConfigMapModified") {
                 @Override
                 public void handle(Future<Void> fut) {
-                    Controller.this.reconcileOnCmChange(configMap, k8sTopic, fut);
+                    Controller.this.reconcileOnCmChange(configMap, k8sTopic, true, fut);
                 }
             };
             inFlight.enqueue(new TopicName(configMap),
@@ -755,7 +771,7 @@ public class Controller {
         }
     }
 
-    private void reconcileOnCmChange(ConfigMap configMap, Topic k8sTopic, Handler<AsyncResult<Void>> handler) {
+    private void reconcileOnCmChange(ConfigMap configMap, Topic k8sTopic, boolean isModify, Handler<AsyncResult<Void>> handler) {
         TopicName topicName = new TopicName(configMap);
         Future f1 = Future.future();
         Future f2 = Future.future();
@@ -766,7 +782,11 @@ public class Controller {
                 TopicMetadata topicMetadata = ar.result().resultAt(0);
                 Topic kafkaTopic = TopicSerialization.fromTopicMetadata(topicMetadata);
                 Topic privateTopic = ar.result().resultAt(1);
-                reconcile(configMap, k8sTopic, kafkaTopic, privateTopic, handler);
+                if (privateTopic == null && isModify) {
+                    enqueue(new ErrorEvent(configMap, "Kafka topics cannot be renamed, but ConfigMap's data." + TopicSerialization.CM_KEY_NAME + " has changed.", ErrorType.WARNING, handler));
+                } else {
+                    reconcile(configMap, k8sTopic, kafkaTopic, privateTopic, handler);
+                }
             } else {
                 handler.handle(Future.failedFuture(ar.cause()));
             }
@@ -779,7 +799,7 @@ public class Controller {
             Reconciliation handlerHandler = new Reconciliation("onConfigMapDeleted") {
                 @Override
                 public void handle(Future<Void> fut) {
-                    Controller.this.reconcileOnCmChange(configMap, null, fut);
+                    Controller.this.reconcileOnCmChange(configMap, null, false, fut);
                 }
             };
             inFlight.enqueue(new TopicName(configMap), handler,
@@ -804,7 +824,7 @@ public class Controller {
         public void handle(Void v) throws ControllerException {
             topicStore.update(topic, ar-> {
                 if (ar.failed()) {
-                    enqueue(new ErrorEvent(involvedObject, ar.cause().toString(), eventResult -> {}));
+                    enqueue(new ErrorEvent(involvedObject, ar.cause().toString(), ErrorType.WARNING, eventResult -> {}));
                 }
                 handler.handle(ar);
             });
@@ -835,7 +855,7 @@ public class Controller {
                 logger.debug("Completing {}", this);
                 if (ar.failed()) {
                     logger.debug("{} failed", this);
-                    enqueue(new ErrorEvent(involvedObject, ar.cause().toString(), eventResult -> {}));
+                    enqueue(new ErrorEvent(involvedObject, ar.cause().toString(), ErrorType.WARNING, eventResult -> {}));
                 } else {
                     logger.debug("{} succeeded", this);
                 }
@@ -865,7 +885,7 @@ public class Controller {
         public void handle(Void v) throws ControllerException {
             topicStore.delete(topicName, ar-> {
                 if (ar.failed()) {
-                    enqueue(new ErrorEvent(involvedObject, ar.cause().toString(), eventResult -> {}));
+                    enqueue(new ErrorEvent(involvedObject, ar.cause().toString(), ErrorType.WARNING, eventResult -> {}));
                 }
                 handler.handle(ar);
             });

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/Controller.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/Controller.java
@@ -18,7 +18,6 @@
 package io.strimzi.controller.topic;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
-import io.fabric8.kubernetes.api.model.Event;
 import io.fabric8.kubernetes.api.model.EventBuilder;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.vertx.core.AsyncResult;
@@ -47,33 +46,33 @@ public class Controller {
     private TopicStore topicStore;
     private final InFlight inFlight;
 
-    enum ErrorType {
+    enum EventType {
         INFO("Info"),
         WARNING("Warning");
         final String name;
-        ErrorType(String name) {
+        EventType(String name) {
             this.name = name;
         }
     }
 
-    class ErrorEvent implements Handler<Void> {
-        private final ErrorType errorType;
+    class Event implements Handler<Void> {
+        private final EventType eventType;
         private final String message;
         private final HasMetadata involvedObject;
         private final Handler<AsyncResult<Void>> handler;
 
-        public ErrorEvent(ControllerException exception, Handler<AsyncResult<Void>> handler) {
+        public Event(ControllerException exception, Handler<AsyncResult<Void>> handler) {
             this.involvedObject = exception.getInvolvedObject();
             this.message = exception.getMessage();
             this.handler = handler;
-            this.errorType = ErrorType.WARNING;
+            this.eventType = EventType.WARNING;
         }
 
-        public ErrorEvent(HasMetadata involvedObject, String message, ErrorType errorType, Handler<AsyncResult<Void>> handler) {
+        public Event(HasMetadata involvedObject, String message, EventType eventType, Handler<AsyncResult<Void>> handler) {
             this.involvedObject = involvedObject;
             this.message = message;
             this.handler = handler;
-            this.errorType = errorType;
+            this.eventType = eventType;
         }
 
         @Override
@@ -88,14 +87,14 @@ public class Controller {
                         .withUid(involvedObject.getMetadata().getUid())
                         .endInvolvedObject();
             }
-            evtb.withType(errorType.name)
+            evtb.withType(eventType.name)
                     .withMessage(message)
                     .withNewMetadata().withLabels(cmPredicate.labels()).withGenerateName("topic-controller").endMetadata()
                     .withNewSource()
                     .withComponent(Controller.class.getName())
                     .endSource();
-            Event event = evtb.build();
-            switch (errorType) {
+            io.fabric8.kubernetes.api.model.Event event = evtb.build();
+            switch (eventType) {
                 case INFO:
                     logger.info("{}", message);
                     break;
@@ -235,7 +234,7 @@ public class Controller {
         public void handle(Void v) throws ControllerException {
             kafka.updateTopicConfig(topic, ar-> {
                 if (ar.failed()) {
-                    enqueue(new ErrorEvent(involvedObject, ar.cause().toString(), ErrorType.WARNING, eventResult -> {}));
+                    enqueue(new Event(involvedObject, ar.cause().toString(), EventType.WARNING, eventResult -> {}));
                 }
                 handler.handle(ar);
             });
@@ -266,7 +265,7 @@ public class Controller {
         public void handle(Void v) throws ControllerException {
             kafka.increasePartitions(topic, ar-> {
                 if (ar.failed()) {
-                    enqueue(new ErrorEvent(involvedObject, ar.cause().toString(), ErrorType.WARNING, eventResult -> {}));
+                    enqueue(new Event(involvedObject, ar.cause().toString(), EventType.WARNING, eventResult -> {}));
                 }
                 handler.handle(ar);
             });
@@ -297,7 +296,7 @@ public class Controller {
         public void handle(Void v) throws ControllerException {
             kafka.changeReplicationFactor(topic, ar-> {
                 if (ar.failed()) {
-                    enqueue(new ErrorEvent(involvedObject, ar.cause().toString(), ErrorType.WARNING, eventResult -> {}));
+                    enqueue(new Event(involvedObject, ar.cause().toString(), EventType.WARNING, eventResult -> {}));
                 }
                 handler.handle(ar);
             });
@@ -499,8 +498,8 @@ public class Controller {
         } else {
             // Just use kafka version, but also create a warning event
             logger.debug("cm created in k8s and topic created in kafka, and they are irreconcilably different => kafka version wins");
-            enqueue(new ErrorEvent(involvedObject, "ConfigMap is incompatible with the topic metadata. " +
-                    "The topic metadata will be treated as canonical.", ErrorType.INFO, ar -> {
+            enqueue(new Event(involvedObject, "ConfigMap is incompatible with the topic metadata. " +
+                    "The topic metadata will be treated as canonical.", EventType.INFO, ar -> {
                 if (ar.succeeded()) {
                     enqueue(new UpdateConfigMap(kafkaTopic, involvedObject, ar2 -> {
                         if (ar2.succeeded()) {
@@ -526,7 +525,7 @@ public class Controller {
         if (conflict != null) {
             final String message = "ConfigMap and Topic both changed in a conflicting way: " + conflict;
             logger.error(message);
-            enqueue(new ErrorEvent(involvedObject, message, ErrorType.INFO, eventResult -> {}));
+            enqueue(new Event(involvedObject, message, EventType.INFO, eventResult -> {}));
             reconciliationResultHandler.handle(Future.failedFuture(new Exception(message)));
         } else {
             TopicDiff merged = oursKafka.merge(oursK8s);
@@ -540,7 +539,7 @@ public class Controller {
                 if (partitionsDelta < 0) {
                     final String message = "Number of partitions cannot be decreased";
                     logger.error(message);
-                    enqueue(new ErrorEvent(involvedObject, message, ErrorType.INFO, eventResult -> {
+                    enqueue(new Event(involvedObject, message, EventType.INFO, eventResult -> {
                     }));
                     reconciliationResultHandler.handle(Future.failedFuture(new Exception(message)));
                 } else {
@@ -783,7 +782,7 @@ public class Controller {
                 Topic kafkaTopic = TopicSerialization.fromTopicMetadata(topicMetadata);
                 Topic privateTopic = ar.result().resultAt(1);
                 if (privateTopic == null && isModify) {
-                    enqueue(new ErrorEvent(configMap, "Kafka topics cannot be renamed, but ConfigMap's data." + TopicSerialization.CM_KEY_NAME + " has changed.", ErrorType.WARNING, handler));
+                    enqueue(new Event(configMap, "Kafka topics cannot be renamed, but ConfigMap's data." + TopicSerialization.CM_KEY_NAME + " has changed.", EventType.WARNING, handler));
                 } else {
                     reconcile(configMap, k8sTopic, kafkaTopic, privateTopic, handler);
                 }
@@ -824,7 +823,7 @@ public class Controller {
         public void handle(Void v) throws ControllerException {
             topicStore.update(topic, ar-> {
                 if (ar.failed()) {
-                    enqueue(new ErrorEvent(involvedObject, ar.cause().toString(), ErrorType.WARNING, eventResult -> {}));
+                    enqueue(new Event(involvedObject, ar.cause().toString(), EventType.WARNING, eventResult -> {}));
                 }
                 handler.handle(ar);
             });
@@ -855,7 +854,7 @@ public class Controller {
                 logger.debug("Completing {}", this);
                 if (ar.failed()) {
                     logger.debug("{} failed", this);
-                    enqueue(new ErrorEvent(involvedObject, ar.cause().toString(), ErrorType.WARNING, eventResult -> {}));
+                    enqueue(new Event(involvedObject, ar.cause().toString(), EventType.WARNING, eventResult -> {}));
                 } else {
                     logger.debug("{} succeeded", this);
                 }
@@ -885,7 +884,7 @@ public class Controller {
         public void handle(Void v) throws ControllerException {
             topicStore.delete(topicName, ar-> {
                 if (ar.failed()) {
-                    enqueue(new ErrorEvent(involvedObject, ar.cause().toString(), ErrorType.WARNING, eventResult -> {}));
+                    enqueue(new Event(involvedObject, ar.cause().toString(), EventType.WARNING, eventResult -> {}));
                 }
                 handler.handle(ar);
             });

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/K8sImpl.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/K8sImpl.java
@@ -114,7 +114,7 @@ public class K8sImpl implements K8s {
             try {
                 try {
                     logger.debug("Creating event {}", event);
-                    //client.events().create(event);
+                    client.events().create(event);
                 } catch (KubernetesClientException e) {
                     logger.error("Error creating event {}", event, e);
                 }

--- a/topic-controller/src/test/java/io/strimzi/controller/topic/MockController.java
+++ b/topic-controller/src/test/java/io/strimzi/controller/topic/MockController.java
@@ -21,7 +21,6 @@ import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
-import io.vertx.core.Vertx;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,8 +31,8 @@ class MockController extends Controller {
         super(null, null, null, null, null);
     }
 
-    static class Event {
-        private final Event.Type type;
+    static class MockControllerEvent {
+        private final MockControllerEvent.Type type;
 
         static enum Type {
             CREATE,
@@ -44,13 +43,13 @@ class MockController extends Controller {
         private final TopicName topicName;
         private final ConfigMap configMap;
 
-        public Event(Event.Type type, TopicName topicName) {
+        public MockControllerEvent(MockControllerEvent.Type type, TopicName topicName) {
             this.type = type;
             this.topicName = topicName;
             this.configMap = null;
         }
 
-        public Event(Event.Type type, ConfigMap configMap) {
+        public MockControllerEvent(MockControllerEvent.Type type, ConfigMap configMap) {
             this.type = type;
             this.topicName = null;
             this.configMap = configMap;
@@ -61,12 +60,12 @@ class MockController extends Controller {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
 
-            Event event = (Event) o;
+            MockControllerEvent mockControllerEvent = (MockControllerEvent) o;
 
-            if (type != event.type) return false;
-            if (topicName != null ? !topicName.equals(event.topicName) : event.topicName != null)
+            if (type != mockControllerEvent.type) return false;
+            if (topicName != null ? !topicName.equals(mockControllerEvent.topicName) : mockControllerEvent.topicName != null)
                 return false;
-            return configMap != null ? configMap.equals(event.configMap) : event.configMap == null;
+            return configMap != null ? configMap.equals(mockControllerEvent.configMap) : mockControllerEvent.configMap == null;
         }
 
         @Override
@@ -93,49 +92,49 @@ class MockController extends Controller {
     public AsyncResult<Void> cmAddedResult = Future.failedFuture("Unexpected mock interaction. Configure " + getClass().getSimpleName()+".cmAddedResult");
     public AsyncResult<Void> cmDeletedResult = Future.failedFuture("Unexpected mock interaction. Configure " + getClass().getSimpleName()+".cmDeletedResult");
     public AsyncResult<Void> cmModifiedResult = Future.failedFuture("Unexpected mock interaction. Configure " + getClass().getSimpleName()+".cmModifiedResult");
-    private List<Event> events = new ArrayList<>();
+    private List<MockControllerEvent> mockControllerEvents = new ArrayList<>();
 
-    public List<Event> getEvents() {
-        return events;
+    public List<MockControllerEvent> getMockControllerEvents() {
+        return mockControllerEvents;
     }
 
     public void clearEvents() {
-        events.clear();
+        mockControllerEvents.clear();
     }
 
     @Override
     public void onTopicCreated(TopicName topicName, Handler<AsyncResult<Void>> handler) {
-        events.add(new Event(Event.Type.CREATE, topicName));
+        mockControllerEvents.add(new MockControllerEvent(MockControllerEvent.Type.CREATE, topicName));
         handler.handle(topicCreatedResult);
     }
 
     @Override
     public void onTopicDeleted(TopicName topicName, Handler<AsyncResult<Void>> handler) {
-        events.add(new Event(Event.Type.DELETE, topicName));
+        mockControllerEvents.add(new MockControllerEvent(MockControllerEvent.Type.DELETE, topicName));
         handler.handle(topicDeletedResult);
     }
 
     @Override
     public void onTopicConfigChanged(TopicName topicName, Handler<AsyncResult<Void>> handler) {
-        events.add(new Event(Event.Type.MODIFY_CONFIG, topicName));
+        mockControllerEvents.add(new MockControllerEvent(MockControllerEvent.Type.MODIFY_CONFIG, topicName));
         handler.handle(topicModifiedResult);
     }
 
     @Override
     public void onConfigMapAdded(ConfigMap cm, Handler<AsyncResult<Void>> handler) {
-        events.add(new Event(Event.Type.CREATE, cm));
+        mockControllerEvents.add(new MockControllerEvent(MockControllerEvent.Type.CREATE, cm));
         handler.handle(cmAddedResult);
     }
 
     @Override
     public void onConfigMapModified(ConfigMap cm, Handler<AsyncResult<Void>> handler) {
-        events.add(new Event(Event.Type.MODIFY, cm));
+        mockControllerEvents.add(new MockControllerEvent(MockControllerEvent.Type.MODIFY, cm));
         handler.handle(cmModifiedResult);
     }
 
     @Override
     public void onConfigMapDeleted(ConfigMap cm, Handler<AsyncResult<Void>> handler) {
-        events.add(new Event(Event.Type.DELETE, cm));
+        mockControllerEvents.add(new MockControllerEvent(MockControllerEvent.Type.DELETE, cm));
         handler.handle(cmDeletedResult);
     }
 }

--- a/topic-controller/src/test/java/io/strimzi/controller/topic/TopicsWatcherTest.java
+++ b/topic-controller/src/test/java/io/strimzi/controller/topic/TopicsWatcherTest.java
@@ -54,8 +54,8 @@ public class TopicsWatcherTest {
         TopicsWatcher tw = new TopicsWatcher(controller, tcw);
         tw.start(mockZk);
         mockZk.triggerChildren(Future.succeededFuture(asList("foo", "bar", "baz")));
-        assertEquals(asList(new MockController.Event(
-                MockController.Event.Type.CREATE, new TopicName("baz"))), controller.getEvents());
+        assertEquals(asList(new MockController.MockControllerEvent(
+                MockController.MockControllerEvent.Type.CREATE, new TopicName("baz"))), controller.getMockControllerEvents());
         assertTrue(tcw.watching("baz"));
     }
 
@@ -66,8 +66,8 @@ public class TopicsWatcherTest {
         // Now change the config
         controller.clearEvents();
         mockZk.triggerData(Future.succeededFuture(new byte[0]));
-        assertEquals(asList(new MockController.Event(
-                MockController.Event.Type.MODIFY_CONFIG, new TopicName("baz"))), controller.getEvents());
+        assertEquals(asList(new MockController.MockControllerEvent(
+                MockController.MockControllerEvent.Type.MODIFY_CONFIG, new TopicName("baz"))), controller.getMockControllerEvents());
     }
 
     @Test
@@ -80,8 +80,8 @@ public class TopicsWatcherTest {
         TopicsWatcher tw = new TopicsWatcher(controller, tcw);
         tw.start(mockZk);
         mockZk.triggerChildren(Future.succeededFuture(asList("foo")));
-        assertEquals(asList(new MockController.Event(
-                MockController.Event.Type.DELETE, new TopicName("bar"))), controller.getEvents());
+        assertEquals(asList(new MockController.MockControllerEvent(
+                MockController.MockControllerEvent.Type.DELETE, new TopicName("bar"))), controller.getMockControllerEvents());
         assertFalse(tcw.watching("baz"));
     }
 }


### PR DESCRIPTION
This is really about enabling some code which was already present, so it's mostly a job of tidying up that existing code. Annoyingly although k8s has info and warning events it doesn't (officially) have error events, otherwise the warnings would be errors.

This will be tested in a future PR.