### PR TITLE
Various improvements around stopping the `Session`

### DIFF
--- a/topic-controller/src/main/java/io/strimzi/controller/topic/BaseKafkaImpl.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/BaseKafkaImpl.java
@@ -50,15 +50,21 @@ public abstract class BaseKafkaImpl implements Kafka {
 
     protected final Vertx vertx;
 
+    private volatile boolean stopped = false;
+
     public BaseKafkaImpl(AdminClient adminClient, Vertx vertx) {
         this.adminClient = adminClient;
         this.vertx = vertx;
     }
 
+    public void stop() {
+        this.stopped = true;
+    }
+
     abstract class Work implements Runnable, Handler<Void> {
         @Override
         public void run() {
-            if (!complete()) {
+            if (!stopped && !complete()) {
                 vertx.runOnContext(this);
             }
         }

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/Controller.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/Controller.java
@@ -895,5 +895,9 @@ public class Controller {
             return "DeleteFromTopicStore(topicName="+topicName+")";
         }
     }
+
+    public boolean isWorkInflight() {
+        return inFlight.size() > 0;
+    }
 }
 


### PR DESCRIPTION
* We need a way to stop the KafkaImpl,
  otherwise it can keep polling after the AdminClient has been closed.
* Session.stop() nows awaits completion of inflight,
* Previously Session.stop() it was blocking the vertx context thread
  (for too long, we got warnings), so switch to overriding the async
  version of AbstractVerticle.stop().
* Add an overall timeout for stopping the Session, since otherwise if
  something went wrong we could loop forever.