### PR TITLE
Add support for Persistent volumes updates

### DIFF
--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/KafkaCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/KafkaCluster.java
@@ -234,29 +234,31 @@ public class KafkaCluster extends AbstractCluster {
             }
         }
 
-        if (!ss.getSpec().getVolumeClaimTemplates().isEmpty()) {
-
-            if (storage.type() == Storage.StorageType.PERSISTENT_CLAIM) {
-
-                Storage ssStorage = Storage.fromPersistentVolumeClaim(ss.getSpec().getVolumeClaimTemplates().get(0));
-                if (ss.getMetadata().getAnnotations() != null) {
-                    String deleteClaimAnnotation = String.format("%s/%s", ClusterController.STRIMZI_CLUSTER_CONTROLLER_DOMAIN, Storage.DELETE_CLAIM_FIELD);
-                    ssStorage.withDeleteClaim(Boolean.valueOf(ss.getMetadata().getAnnotations().computeIfAbsent(deleteClaimAnnotation, s -> "false")));
-                }
-
-                if (storage.isDeleteClaim() != ssStorage.isDeleteClaim()) {
-                    diff.setDifferent(true);
-                }
-            // changing from "persistent-claim" to "ephemeral"
-            } else {
-                // TODO : warning ! the user is trying to change storage type which is not allowed !
-            }
+        // get the current (deployed) kind of storage
+        Storage ssStorage;
+        if (ss.getSpec().getVolumeClaimTemplates().isEmpty()) {
+            ssStorage = new Storage(Storage.StorageType.EPHEMERAL);
         } else {
-
-            // changing from current "ephemeral" to "persistent-claim"
-            if (storage.type() == Storage.StorageType.PERSISTENT_CLAIM) {
-                // TODO : warning ! the user is trying to change storage type which is not allowed !
+            ssStorage = Storage.fromPersistentVolumeClaim(ss.getSpec().getVolumeClaimTemplates().get(0));
+            // the delete-claim flack is backed by the StatefulSets
+            if (ss.getMetadata().getAnnotations() != null) {
+                String deleteClaimAnnotation = String.format("%s/%s", ClusterController.STRIMZI_CLUSTER_CONTROLLER_DOMAIN, Storage.DELETE_CLAIM_FIELD);
+                ssStorage.withDeleteClaim(Boolean.valueOf(ss.getMetadata().getAnnotations().computeIfAbsent(deleteClaimAnnotation, s -> "false")));
             }
+        }
+
+        // compute the differences with the requested storage (from the updated ConfigMap)
+        Storage.StorageDiffResult storageDiffResult = storage.diff(ssStorage);
+
+        // check for all the not allowed changes to the storage
+        boolean isStorageRejected = (storageDiffResult.isType() || storageDiffResult.isSize() ||
+                storageDiffResult.isStorageClass() || storageDiffResult.isSelector());
+
+        // only delete-claim flag can be changed
+        if (!isStorageRejected && (storage.type() == Storage.StorageType.PERSISTENT_CLAIM)) {
+            diff.setDifferent(storageDiffResult.isDeleteClaim());
+        } else {
+            log.warn("Changing storage configuration other than delete-claim is not supported !");
         }
 
         return diff;

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/Storage.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/Storage.java
@@ -4,7 +4,6 @@ import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LabelSelectorRequirement;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Quantity;
-import io.strimzi.controller.cluster.ClusterController;
 import io.vertx.core.json.JsonObject;
 
 import java.util.List;
@@ -143,11 +142,6 @@ public class Storage {
 
         if (pvc.getSpec().getSelector() != null) {
             storage.withSelector(pvc.getSpec().getSelector());
-        }
-
-        if (pvc.getMetadata().getAnnotations() != null) {
-            String deleteClaimAnnotation = String.format("%s/%s", ClusterController.STRIMZI_CLUSTER_CONTROLLER_DOMAIN, Storage.DELETE_CLAIM_FIELD);
-            storage.withDeleteClaim(Boolean.valueOf(pvc.getMetadata().getAnnotations().computeIfAbsent(deleteClaimAnnotation, s -> "false")));
         }
 
         return storage;

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/Storage.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/Storage.java
@@ -8,6 +8,7 @@ import io.vertx.core.json.JsonObject;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
@@ -145,6 +146,184 @@ public class Storage {
         }
 
         return storage;
+    }
+
+    /**
+     * Compute the difference between two Storage instances
+     *
+     * @param other the other instance to compare with
+     * @return  the result with all differences
+     */
+    public StorageDiffResult diff(Storage other) {
+
+        StorageDiffResult diffResult = new StorageDiffResult();
+
+        diffResult
+                .withDifferentType(this.type != other.type())
+                .withDifferentSize(!this.compareSize(other.size()))
+                .withDifferentDeleteClaim(this.isDeleteClaim != other.isDeleteClaim())
+                .withDifferentStorageClass(!this.compareStorageClass(other.storageClass()))
+                .withDifferentSelector(!this.compareSelector(other.selector()));
+
+
+        return diffResult;
+    }
+
+    /**
+     * Compare two Storage sizes
+     *
+     * @param other the other Storage size
+     * @return  if the compared Storage sizes are equals
+     */
+    private boolean compareSize(Quantity other) {
+
+        return Objects.isNull(this.size) ?
+                Objects.isNull(other) : this.size.getAmount().equals(other.getAmount());
+    }
+
+    /**
+     * Compare two Storage classes
+     *
+     * @param other the other Storage class
+     * @return  if the compared Storage classes are equals
+     */
+    private boolean compareStorageClass(String other) {
+
+        return Objects.isNull(this.storageClass) ?
+                Objects.isNull(other) : this.storageClass.equals(other);
+    }
+
+    /**
+     * Compare two selectors
+     *
+     * @param other the other selector
+     * @return  if the compared selectors are equals
+     */
+    private boolean compareSelector(LabelSelector other) {
+
+        if (!Objects.isNull(this.selector) && !Objects.isNull(other)) {
+
+            if (Objects.isNull(this.selector.getMatchLabels()) && !Objects.isNull(other.getMatchLabels())) {
+                return false;
+            }
+
+            if (!Objects.isNull(this.selector.getMatchLabels()) && Objects.isNull(other.getMatchLabels())) {
+                return false;
+            }
+
+            if (this.selector.getMatchLabels().size() != other.getMatchLabels().size()) {
+                return false;
+            }
+
+            return this.selector.getMatchLabels().entrySet().equals(other.getMatchLabels().entrySet());
+
+        } else if (Objects.isNull(this.selector) && Objects.isNull(other)) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Result after comparing two Storage instances
+     */
+    public class StorageDiffResult {
+
+        private boolean isType;
+        private boolean isSize;
+        private boolean isStorageClass;
+        private boolean isSelector;
+        private boolean isDeleteClaim;
+
+        /**
+         * @return  if the Storage type is different
+         */
+        public boolean isType() {
+            return this.isType;
+        }
+
+        /**
+         * @return  if the Storage size is different
+         */
+        public boolean isSize() {
+            return this.isSize;
+        }
+
+        /**
+         * @return  if the Storage class is different
+         */
+        public boolean isStorageClass() {
+            return this.isStorageClass;
+        }
+
+        /**
+         * @return  if the selector is different
+         */
+        public boolean isSelector() {
+            return this.isSelector;
+        }
+
+        /**
+         * @return  if the deleteClaim is different
+         */
+        public boolean isDeleteClaim() {
+            return this.isDeleteClaim;
+        }
+
+        /**
+         * Set if the Storage type is different
+         *
+         * @param isType    if type is different
+         * @return  current StorageDiffResult instance
+         */
+        public StorageDiffResult withDifferentType(boolean isType) {
+            this.isType = isType;
+            return this;
+        }
+
+        /**
+         * Set if the Storage size is different
+         *
+         * @param isSize    if size is different
+         * @return  current StorageDiffResult instance
+         */
+        public StorageDiffResult withDifferentSize(boolean isSize) {
+            this.isSize = isSize;
+            return this;
+        }
+
+        /**
+         * Set if the Storage class is different
+         *
+         * @param isStorageClass    if storage class is different
+         * @return  current StorageDiffResult instance
+         */
+        public StorageDiffResult withDifferentStorageClass(boolean isStorageClass) {
+            this.isStorageClass = isStorageClass;
+            return this;
+        }
+
+        /**
+         * Set if the selector is different
+         *
+         * @param isSelector    if the selector is different
+         * @return  current StorageDiffResult instance
+         */
+        public StorageDiffResult withDifferentSelector(boolean isSelector) {
+            this.isSelector = isSelector;
+            return this;
+        }
+
+        /**
+         * Set if the deleteClaim is different
+         *
+         * @param isDeleteClaim if the deleteClaim is different
+         * @return  current StorageDiffResult instance
+         */
+        public StorageDiffResult withDifferentDeleteClaim(boolean isDeleteClaim) {
+            this.isDeleteClaim = isDeleteClaim;
+            return this;
+        }
     }
 
 

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/ZookeeperCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/ZookeeperCluster.java
@@ -136,7 +136,12 @@ public class ZookeeperCluster extends AbstractCluster {
         }
 
         if (!ss.getSpec().getVolumeClaimTemplates().isEmpty()) {
+
             Storage storage = Storage.fromPersistentVolumeClaim(ss.getSpec().getVolumeClaimTemplates().get(0));
+            if (ss.getMetadata().getAnnotations() != null) {
+                String deleteClaimAnnotation = String.format("%s/%s", ClusterController.STRIMZI_CLUSTER_CONTROLLER_DOMAIN, Storage.DELETE_CLAIM_FIELD);
+                storage.withDeleteClaim(Boolean.valueOf(ss.getMetadata().getAnnotations().computeIfAbsent(deleteClaimAnnotation, s -> "false")));
+            }
             zk.setStorage(storage);
         } else {
             Storage storage = new Storage(Storage.StorageType.EPHEMERAL);
@@ -207,6 +212,31 @@ public class ZookeeperCluster extends AbstractCluster {
             }
         }
 
+        if (!ss.getSpec().getVolumeClaimTemplates().isEmpty()) {
+
+            if (storage.type() == Storage.StorageType.PERSISTENT_CLAIM) {
+
+                Storage ssStorage = Storage.fromPersistentVolumeClaim(ss.getSpec().getVolumeClaimTemplates().get(0));
+                if (ss.getMetadata().getAnnotations() != null) {
+                    String deleteClaimAnnotation = String.format("%s/%s", ClusterController.STRIMZI_CLUSTER_CONTROLLER_DOMAIN, Storage.DELETE_CLAIM_FIELD);
+                    ssStorage.withDeleteClaim(Boolean.valueOf(ss.getMetadata().getAnnotations().computeIfAbsent(deleteClaimAnnotation, s -> "false")));
+                }
+
+                if (storage.isDeleteClaim() != ssStorage.isDeleteClaim()) {
+                    diff.setDifferent(true);
+                }
+                // changing from "persistent-claim" to "ephemeral"
+            } else {
+                // TODO : warning ! the user is trying to change storage type which is not allowed !
+            }
+        } else {
+
+            // changing from current "ephemeral" to "persistent-claim"
+            if (storage.type() == Storage.StorageType.PERSISTENT_CLAIM) {
+                // TODO : warning ! the user is trying to change storage type which is not allowed !
+            }
+        }
+
         return diff;
     }
 
@@ -256,9 +286,14 @@ public class ZookeeperCluster extends AbstractCluster {
 
     public StatefulSet patchStatefulSet(StatefulSet statefulSet) {
 
+        Map<String, String> annotations = new HashMap<>();
+        annotations.put(String.format("%s/%s", ClusterController.STRIMZI_CLUSTER_CONTROLLER_DOMAIN, Storage.DELETE_CLAIM_FIELD),
+                String.valueOf(storage.isDeleteClaim()));
+
         return patchStatefulSet(statefulSet,
                 createExecProbe(healthCheckPath, healthCheckInitialDelay, healthCheckTimeout),
-                createExecProbe(healthCheckPath, healthCheckInitialDelay, healthCheckTimeout));
+                createExecProbe(healthCheckPath, healthCheckInitialDelay, healthCheckTimeout),
+                annotations);
     }
 
     protected List<EnvVar> getEnvVars() {


### PR DESCRIPTION
Only updating the `delete-claim` flag is allowed, any other operation is rejected.