### PR TITLE
Name cluster resources consistently

### DIFF
--- a/resources/kubernetes/kafka-connect.yaml
+++ b/resources/kubernetes/kafka-connect.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: kafka-connect
+  name: my-connect-cluster
   labels:
     strimzi.io/kind: cluster
     strimzi.io/type: kafka-connect
@@ -10,7 +10,7 @@ data:
   image: "strimzi/kafka-connect:latest"
   healthcheck-delay: "60"
   healthcheck-timeout: "5"
-  KAFKA_CONNECT_BOOTSTRAP_SERVERS: "mycluster-kafka:9092"
+  KAFKA_CONNECT_BOOTSTRAP_SERVERS: "my-cluster-kafka:9092"
   KAFKA_CONNECT_GROUP_ID: "my-connect-cluster"
   KAFKA_CONNECT_KEY_CONVERTER: "org.apache.kafka.connect.json.JsonConverter"
   KAFKA_CONNECT_KEY_CONVERTER_SCHEMAS_ENABLE: "true"

--- a/resources/kubernetes/kafka-ephemeral.yaml
+++ b/resources/kubernetes/kafka-ephemeral.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: mycluster-ephemeral
+  name: my-cluster
   labels:
     strimzi.io/kind: cluster
     strimzi.io/type: kafka

--- a/resources/kubernetes/kafka-persistent.yaml
+++ b/resources/kubernetes/kafka-persistent.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: mycluster
+  name: my-cluster
   labels:
     strimzi.io/kind: cluster
     strimzi.io/type: kafka

--- a/resources/openshift/controller-with-template.yaml
+++ b/resources/openshift/controller-with-template.yaml
@@ -129,12 +129,12 @@ metadata:
     tags: "messaging,datastore"
     iconClass: "fa fa-share-alt fa-flip-horizontal"
     template.openshift.io/documentation-url: "http://strimzi.io"
-message: "Use 'mycluster-kafka:9092' as bootstrap server in your application"
+message: "Use 'my-cluster-kafka:9092' as bootstrap server in your application"
 parameters:
 - description: All Kubernetes resources will be named after the cluster name
   displayName: Name of the cluster
   name: CLUSTER_NAME
-  value: mycluster
+  value: my-cluster
 - description: Number of Zookeper cluster nodes which will be deployed (odd number of nodes is recomended)
   displayName: Number of Zookeper cluster nodes (odd number of nodes is recomended)
   name: ZOOKEEPER_NODE_COUNT
@@ -252,12 +252,12 @@ metadata:
     tags: "messaging,datastore"
     iconClass: "fa fa-share-alt fa-flip-horizontal"
     template.openshift.io/documentation-url: "http://strimzi.io"
-message: "Use 'mycluster-kafka:9092' as bootstrap server in your application"
+message: "Use 'my-cluster-kafka:9092' as bootstrap server in your application"
 parameters:
 - description: All Kubernetes resources will be named after the cluster name
   displayName: Name of the cluster
   name: CLUSTER_NAME
-  value: mycluster
+  value: my-cluster
 - description: Number of Zookeper cluster nodes which will be deployed (odd number of nodes is recomended)
   displayName: Number of Zookeper cluster nodes (odd number of nodes is recomended)
   name: ZOOKEEPER_NODE_COUNT
@@ -400,7 +400,7 @@ parameters:
   displayName: Kafka bootstrap servers
   name: KAFKA_CONNECT_BOOTSTRAP_SERVERS
   required: true
-  value: mycluster-kafka:9092
+  value: my-cluster-kafka:9092
 - description: A unique string that identifies the Connect cluster group this worker belongs to. Note this must not conflict with any consumer group IDs.
   displayName: Group ID
   name: KAFKA_CONNECT_GROUP_ID


### PR DESCRIPTION
We should name cluster resources consistently. Not once `mycluster` and once °my-connect-cluster` (with dashes). This PR fixes all cluster names to use `-` ... `my-cluster` and `my-connect-cluster`. It also fixes some other left overs which were overlooked while changing the names last time.