### PR TITLE
Fix minor issues when diffing storage

### DIFF
--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/KafkaCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/KafkaCluster.java
@@ -257,7 +257,7 @@ public class KafkaCluster extends AbstractCluster {
         // only delete-claim flag can be changed
         if (!isStorageRejected && (storage.type() == Storage.StorageType.PERSISTENT_CLAIM)) {
             if (storageDiffResult.isDeleteClaim()) {
-                diff.setDifferent(storageDiffResult.isDeleteClaim());
+                diff.setDifferent(true);
             }
         } else if (isStorageRejected) {
             log.warn("Changing storage configuration other than delete-claim is not supported !");

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/KafkaCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/KafkaCluster.java
@@ -256,8 +256,10 @@ public class KafkaCluster extends AbstractCluster {
 
         // only delete-claim flag can be changed
         if (!isStorageRejected && (storage.type() == Storage.StorageType.PERSISTENT_CLAIM)) {
-            diff.setDifferent(storageDiffResult.isDeleteClaim());
-        } else {
+            if (storageDiffResult.isDeleteClaim()) {
+                diff.setDifferent(storageDiffResult.isDeleteClaim());
+            }
+        } else if (isStorageRejected) {
             log.warn("Changing storage configuration other than delete-claim is not supported !");
         }
 

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/ZookeeperCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/ZookeeperCluster.java
@@ -234,8 +234,10 @@ public class ZookeeperCluster extends AbstractCluster {
 
         // only delete-claim flag can be changed
         if (!isStorageRejected && (storage.type() == Storage.StorageType.PERSISTENT_CLAIM)) {
-            diff.setDifferent(storageDiffResult.isDeleteClaim());
-        } else {
+            if (storageDiffResult.isDeleteClaim()) {
+                diff.setDifferent(true);
+            }
+        } else if (isStorageRejected) {
             log.warn("Changing storage configuration other than delete-claim is not supported !");
         }
 


### PR DESCRIPTION
There seem to be some minor issues when doing the Storage diff:
- The warning message is printed even when nothing was changed but the cluster is ephemeral
- When delete claim is not changed, it can potentially call `setDifferent(false)` and thus overwrite the differences set by other checks. The `setDifferent(...)` method should be always called only with `true`