### PR TITLE
Added an HTTP health checks server for readiness and liveness probes

### DIFF
--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterController.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterController.java
@@ -435,7 +435,7 @@ public class ClusterController extends AbstractVerticle {
         this.vertx.createHttpServer()
                 .requestHandler(request -> {
 
-                    if (request.path().equals("/health")) {
+                    if (request.path().equals("/healthy")) {
                         request.response().setStatusCode(HttpResponseStatus.OK.code()).end();
                     } else if (request.path().equals("/ready")) {
                         request.response().setStatusCode(HttpResponseStatus.OK.code()).end();


### PR DESCRIPTION
Added readiness and liveness probes on cluster-controller in the Deployment description

According the discussion on #143 it's just about starting an HTTP server replying OK on the `/health` and `/ready` paths for liveness and readiness probe when the watcher is created successfully.
I was taking a look to the Vert.x Health Checks but it doesn't seem to bring any great advantage for this use case. Anyway, I'll dig into it.