### PR TITLE
Fix mandatory env vars about Zookeeper and Kafka connections

### DIFF
--- a/topic-controller/src/main/java/io/strimzi/controller/topic/Config.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/Config.java
@@ -122,9 +122,9 @@ public class Config {
 
     public static final Value<LabelPredicate> LABELS = new Value(TC_CM_LABELS, LABEL_PREDICATE,"strimzi.io/kind=topic",
             "A comma-separated list of key=value pairs for selecting ConfigMaps that describe topics.");
-    public static final Value<String> KAFKA_BOOTSTRAP_SERVERS = new Value(TC_KAFKA_BOOTSTRAP_SERVERS, STRING,getenv("KAFKA_SERVICE_HOST") + ":" + getenv("KAFKA_SERVICE_PORT"),
+    public static final Value<String> KAFKA_BOOTSTRAP_SERVERS = new Value(TC_KAFKA_BOOTSTRAP_SERVERS, STRING,true,
             "A comma-separated list of kafka bootstrap servers.");
-    public static final Value<String> ZOOKEEPER_CONNECT = new Value(TC_ZK_CONNECT, STRING, getenv("KAFKA_ZOOKEEPER_SERVICE_HOST") + ":" + getenv("KAFKA_ZOOKEEPER_SERVICE_PORT"),
+    public static final Value<String> ZOOKEEPER_CONNECT = new Value(TC_ZK_CONNECT, STRING, true,
             "The zookeeper connection string.");
     public static final Value<Long> ZOOKEEPER_SESSION_TIMEOUT_MS = new Value(TC_ZK_SESSION_TIMEOUT, DURATION, "20 seconds",
             "The zookeeper session timeout.");
@@ -189,7 +189,7 @@ public class Config {
             return (T) value.type.parse(s);
         } else {
             if (value.required) {
-                throw new IllegalArgumentException();
+                throw new IllegalArgumentException("Config value: " + value.key + " is mandatory");
             }
             return null;
         }

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/Config.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/Config.java
@@ -122,7 +122,7 @@ public class Config {
 
     public static final Value<LabelPredicate> LABELS = new Value(TC_CM_LABELS, LABEL_PREDICATE,"strimzi.io/kind=topic",
             "A comma-separated list of key=value pairs for selecting ConfigMaps that describe topics.");
-    public static final Value<String> KAFKA_BOOTSTRAP_SERVERS = new Value(TC_KAFKA_BOOTSTRAP_SERVERS, STRING,true,
+    public static final Value<String> KAFKA_BOOTSTRAP_SERVERS = new Value(TC_KAFKA_BOOTSTRAP_SERVERS, STRING, true,
             "A comma-separated list of kafka bootstrap servers.");
     public static final Value<String> ZOOKEEPER_CONNECT = new Value(TC_ZK_CONNECT, STRING, true,
             "The zookeeper connection string.");

--- a/topic-controller/src/test/java/io/strimzi/controller/topic/ConfigTest.java
+++ b/topic-controller/src/test/java/io/strimzi/controller/topic/ConfigTest.java
@@ -20,39 +20,60 @@ package io.strimzi.controller.topic;
 import org.junit.Test;
 
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 public class ConfigTest {
 
+    private static final Map<String, String> mandatory = new HashMap<>();
+
+    static {
+        mandatory.put(Config.ZOOKEEPER_CONNECT.key, "localhost:2181");
+        mandatory.put(Config.KAFKA_BOOTSTRAP_SERVERS.key, "localhost:9092");
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void unknownKey() {
         new Config(Collections.singletonMap("foo", "bar"));
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void empty() {
         Config c = new Config(Collections.emptyMap());
-        assertEquals(Config.ZOOKEEPER_CONNECT.defaultValue, c.get(Config.ZOOKEEPER_CONNECT));
-        assertEquals(Config.KAFKA_BOOTSTRAP_SERVERS.defaultValue, c.get(Config.KAFKA_BOOTSTRAP_SERVERS));
+    }
+
+    @Test
+    public void defaults() {
+        Map<String, String> map = new HashMap<>(mandatory);
+        Config c = new Config(map);
         assertEquals(20_000, c.get(Config.ZOOKEEPER_SESSION_TIMEOUT_MS).intValue());
     }
 
     @Test
     public void override() {
-        Config c = new Config(Collections.singletonMap(Config.ZOOKEEPER_SESSION_TIMEOUT_MS.key, "13 seconds"));
-        assertEquals(Config.ZOOKEEPER_CONNECT.defaultValue, c.get(Config.ZOOKEEPER_CONNECT));
-        assertEquals(Config.KAFKA_BOOTSTRAP_SERVERS.defaultValue, c.get(Config.KAFKA_BOOTSTRAP_SERVERS));
+        Map<String, String> map = new HashMap<>(mandatory);
+        map.put(Config.ZOOKEEPER_SESSION_TIMEOUT_MS.key, "13 seconds");
+
+        Config c = new Config(map);
         assertEquals(13_000, c.get(Config.ZOOKEEPER_SESSION_TIMEOUT_MS).intValue());
     }
 
     @Test
     public void intervals() {
-        new Config(Collections.singletonMap(Config.ZOOKEEPER_SESSION_TIMEOUT_MS.key, "13 seconds"));
-        new Config(Collections.singletonMap(Config.ZOOKEEPER_SESSION_TIMEOUT_MS.key, "13seconds"));
+        Map<String, String> map = new HashMap<>(mandatory);
+
+        map.put(Config.ZOOKEEPER_SESSION_TIMEOUT_MS.key, "13 seconds");
+        new Config(map);
+
+        map.put(Config.ZOOKEEPER_SESSION_TIMEOUT_MS.key, "13seconds");
+        new Config(map);
+
         try {
-            new Config(Collections.singletonMap(Config.ZOOKEEPER_SESSION_TIMEOUT_MS.key, "13foos"));
+            map.put(Config.ZOOKEEPER_SESSION_TIMEOUT_MS.key, "13foos");
+            new Config(map);
             fail();
         } catch (IllegalArgumentException e) {
 

--- a/topic-controller/src/test/java/io/strimzi/controller/topic/ControllerAssignedKafkaImplTest.java
+++ b/topic-controller/src/test/java/io/strimzi/controller/topic/ControllerAssignedKafkaImplTest.java
@@ -37,11 +37,15 @@ import static java.util.Collections.singletonMap;
 @RunWith(VertxUnitRunner.class)
 public class ControllerAssignedKafkaImplTest {
 
-    private static final Map<String, String> mandatory = new HashMap<>();
+    private static Config config;
 
     static {
-        mandatory.put(Config.ZOOKEEPER_CONNECT.key, "localhost:2181");
-        mandatory.put(Config.KAFKA_BOOTSTRAP_SERVERS.key, "localhost:9092");
+
+        Map<String, String> map = new HashMap<>();
+        map.put(Config.ZOOKEEPER_CONNECT.key, "localhost:2181");
+        map.put(Config.KAFKA_BOOTSTRAP_SERVERS.key, "localhost:9092");
+        map.put(Config.REASSIGN_VERIFY_INTERVAL_MS.key, "1 seconds");
+        config = new Config(map);
     }
 
     /**
@@ -119,9 +123,6 @@ public class ControllerAssignedKafkaImplTest {
     public void changeReplicationFactor_missingExecutable(TestContext context) {
         MockAdminClient adminClient = new MockAdminClient();
         Vertx vertx = Vertx.vertx();
-        Map<String, String> map = new HashMap<>(mandatory);
-        mandatory.put(Config.REASSIGN_VERIFY_INTERVAL_MS.key, "1 seconds");
-        Config config = new Config(map);
         Topic topic = new Topic.Builder("changeReplicationFactor", 2, (short) 2, emptyMap()).build();
         String[] partitions = new String[]{"changeReplicationFactor-0", "changeReplicationFactor-1"};
         final String doesNotExist = "/some/executable/that/does/not/exist";
@@ -145,9 +146,6 @@ public class ControllerAssignedKafkaImplTest {
     public void changeReplicationFactor_notExecutable(TestContext context) {
         MockAdminClient adminClient = new MockAdminClient();
         Vertx vertx = Vertx.vertx();
-        Map<String, String> map = new HashMap<>(mandatory);
-        mandatory.put(Config.REASSIGN_VERIFY_INTERVAL_MS.key, "1 seconds");
-        Config config = new Config(map);
         Topic topic = new Topic.Builder("changeReplicationFactor", 2, (short) 2, emptyMap()).build();
         String[] partitions = new String[]{"changeReplicationFactor-0", "changeReplicationFactor-1"};
         Subclass sub = new Subclass(adminClient, vertx, config, "pom.xml", asList(
@@ -170,9 +168,6 @@ public class ControllerAssignedKafkaImplTest {
     public void changeReplicationFactor(TestContext context) {
         MockAdminClient adminClient = new MockAdminClient();
         Vertx vertx = Vertx.vertx();
-        Map<String, String> map = new HashMap<>(mandatory);
-        mandatory.put(Config.REASSIGN_VERIFY_INTERVAL_MS.key, "1 seconds");
-        Config config = new Config(map);
         Topic topic = new Topic.Builder("changeReplicationFactor", 2, (short) 2, emptyMap()).build();
         String[] partitions = new String[]{"changeReplicationFactor-0", "changeReplicationFactor-1"};
         Subclass sub = new Subclass(adminClient, vertx, config, asList(
@@ -197,9 +192,6 @@ public class ControllerAssignedKafkaImplTest {
     public void changeReplicationFactor_TransientErrorInVerify(TestContext context) {
         MockAdminClient adminClient = new MockAdminClient();
         Vertx vertx = Vertx.vertx();
-        Map<String, String> map = new HashMap<>(mandatory);
-        mandatory.put(Config.REASSIGN_VERIFY_INTERVAL_MS.key, "1 seconds");
-        Config config = new Config(map);
         Topic topic = new Topic.Builder("changeReplicationFactor", 2, (short) 2, emptyMap()).build();
         String[] partitions = new String[]{"changeReplicationFactor-0", "changeReplicationFactor-1"};
         Subclass sub = new Subclass(adminClient, vertx, config, asList(
@@ -221,9 +213,6 @@ public class ControllerAssignedKafkaImplTest {
     public void changeReplicationFactor_ErrorInVerify(TestContext context) {
         MockAdminClient adminClient = new MockAdminClient();
         Vertx vertx = Vertx.vertx();
-        Map<String, String> map = new HashMap<>(mandatory);
-        mandatory.put(Config.REASSIGN_VERIFY_INTERVAL_MS.key, "1 seconds");
-        Config config = new Config(map);
         Topic topic = new Topic.Builder("changeReplicationFactor", 2, (short) 2, emptyMap()).build();
         String[] partitions = new String[]{"changeReplicationFactor-0", "changeReplicationFactor-1"};
         Subclass sub = new Subclass(adminClient, vertx, config, asList(
@@ -250,9 +239,6 @@ public class ControllerAssignedKafkaImplTest {
     public void changeReplicationFactor_ExecuteInProgress(TestContext context) {
         MockAdminClient adminClient = new MockAdminClient();
         Vertx vertx = Vertx.vertx();
-        Map<String, String> map = new HashMap<>(mandatory);
-        mandatory.put(Config.REASSIGN_VERIFY_INTERVAL_MS.key, "1 seconds");
-        Config config = new Config(map);
         Topic topic = new Topic.Builder("changeReplicationFactor", 2, (short) 2, emptyMap()).build();
         String[] partitions = new String[]{"changeReplicationFactor-0", "changeReplicationFactor-1"};
         Subclass sub = new Subclass(adminClient, vertx, config, asList(
@@ -278,9 +264,6 @@ public class ControllerAssignedKafkaImplTest {
     public void changeReplicationFactor_ExecuteFail(TestContext context) {
         MockAdminClient adminClient = new MockAdminClient();
         Vertx vertx = Vertx.vertx();
-        Map<String, String> map = new HashMap<>(mandatory);
-        mandatory.put(Config.REASSIGN_VERIFY_INTERVAL_MS.key, "1 seconds");
-        Config config = new Config(map);
         Topic topic = new Topic.Builder("changeReplicationFactor", 2, (short) 2, emptyMap()).build();
         String[] partitions = new String[]{"changeReplicationFactor-0", "changeReplicationFactor-1"};
         Subclass sub = new Subclass(adminClient, vertx, config, asList(

--- a/topic-controller/src/test/java/io/strimzi/controller/topic/ControllerAssignedKafkaImplTest.java
+++ b/topic-controller/src/test/java/io/strimzi/controller/topic/ControllerAssignedKafkaImplTest.java
@@ -26,7 +26,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
@@ -34,6 +36,13 @@ import static java.util.Collections.singletonMap;
 
 @RunWith(VertxUnitRunner.class)
 public class ControllerAssignedKafkaImplTest {
+
+    private static final Map<String, String> mandatory = new HashMap<>();
+
+    static {
+        mandatory.put(Config.ZOOKEEPER_CONNECT.key, "localhost:2181");
+        mandatory.put(Config.KAFKA_BOOTSTRAP_SERVERS.key, "localhost:9092");
+    }
 
     /**
      * We subclass the class under test so that we can run our own executable
@@ -110,7 +119,9 @@ public class ControllerAssignedKafkaImplTest {
     public void changeReplicationFactor_missingExecutable(TestContext context) {
         MockAdminClient adminClient = new MockAdminClient();
         Vertx vertx = Vertx.vertx();
-        Config config = new Config(singletonMap(Config.REASSIGN_VERIFY_INTERVAL_MS.key, "1 seconds"));
+        Map<String, String> map = new HashMap<>(mandatory);
+        mandatory.put(Config.REASSIGN_VERIFY_INTERVAL_MS.key, "1 seconds");
+        Config config = new Config(map);
         Topic topic = new Topic.Builder("changeReplicationFactor", 2, (short) 2, emptyMap()).build();
         String[] partitions = new String[]{"changeReplicationFactor-0", "changeReplicationFactor-1"};
         final String doesNotExist = "/some/executable/that/does/not/exist";
@@ -134,7 +145,9 @@ public class ControllerAssignedKafkaImplTest {
     public void changeReplicationFactor_notExecutable(TestContext context) {
         MockAdminClient adminClient = new MockAdminClient();
         Vertx vertx = Vertx.vertx();
-        Config config = new Config(singletonMap(Config.REASSIGN_VERIFY_INTERVAL_MS.key, "1 seconds"));
+        Map<String, String> map = new HashMap<>(mandatory);
+        mandatory.put(Config.REASSIGN_VERIFY_INTERVAL_MS.key, "1 seconds");
+        Config config = new Config(map);
         Topic topic = new Topic.Builder("changeReplicationFactor", 2, (short) 2, emptyMap()).build();
         String[] partitions = new String[]{"changeReplicationFactor-0", "changeReplicationFactor-1"};
         Subclass sub = new Subclass(adminClient, vertx, config, "pom.xml", asList(
@@ -157,7 +170,9 @@ public class ControllerAssignedKafkaImplTest {
     public void changeReplicationFactor(TestContext context) {
         MockAdminClient adminClient = new MockAdminClient();
         Vertx vertx = Vertx.vertx();
-        Config config = new Config(singletonMap(Config.REASSIGN_VERIFY_INTERVAL_MS.key, "1 seconds"));
+        Map<String, String> map = new HashMap<>(mandatory);
+        mandatory.put(Config.REASSIGN_VERIFY_INTERVAL_MS.key, "1 seconds");
+        Config config = new Config(map);
         Topic topic = new Topic.Builder("changeReplicationFactor", 2, (short) 2, emptyMap()).build();
         String[] partitions = new String[]{"changeReplicationFactor-0", "changeReplicationFactor-1"};
         Subclass sub = new Subclass(adminClient, vertx, config, asList(
@@ -182,7 +197,9 @@ public class ControllerAssignedKafkaImplTest {
     public void changeReplicationFactor_TransientErrorInVerify(TestContext context) {
         MockAdminClient adminClient = new MockAdminClient();
         Vertx vertx = Vertx.vertx();
-        Config config = new Config(singletonMap(Config.REASSIGN_VERIFY_INTERVAL_MS.key, "1 seconds"));
+        Map<String, String> map = new HashMap<>(mandatory);
+        mandatory.put(Config.REASSIGN_VERIFY_INTERVAL_MS.key, "1 seconds");
+        Config config = new Config(map);
         Topic topic = new Topic.Builder("changeReplicationFactor", 2, (short) 2, emptyMap()).build();
         String[] partitions = new String[]{"changeReplicationFactor-0", "changeReplicationFactor-1"};
         Subclass sub = new Subclass(adminClient, vertx, config, asList(
@@ -204,7 +221,9 @@ public class ControllerAssignedKafkaImplTest {
     public void changeReplicationFactor_ErrorInVerify(TestContext context) {
         MockAdminClient adminClient = new MockAdminClient();
         Vertx vertx = Vertx.vertx();
-        Config config = new Config(singletonMap(Config.REASSIGN_VERIFY_INTERVAL_MS.key, "1 seconds"));
+        Map<String, String> map = new HashMap<>(mandatory);
+        mandatory.put(Config.REASSIGN_VERIFY_INTERVAL_MS.key, "1 seconds");
+        Config config = new Config(map);
         Topic topic = new Topic.Builder("changeReplicationFactor", 2, (short) 2, emptyMap()).build();
         String[] partitions = new String[]{"changeReplicationFactor-0", "changeReplicationFactor-1"};
         Subclass sub = new Subclass(adminClient, vertx, config, asList(
@@ -231,7 +250,9 @@ public class ControllerAssignedKafkaImplTest {
     public void changeReplicationFactor_ExecuteInProgress(TestContext context) {
         MockAdminClient adminClient = new MockAdminClient();
         Vertx vertx = Vertx.vertx();
-        Config config = new Config(singletonMap(Config.REASSIGN_VERIFY_INTERVAL_MS.key, "1 seconds"));
+        Map<String, String> map = new HashMap<>(mandatory);
+        mandatory.put(Config.REASSIGN_VERIFY_INTERVAL_MS.key, "1 seconds");
+        Config config = new Config(map);
         Topic topic = new Topic.Builder("changeReplicationFactor", 2, (short) 2, emptyMap()).build();
         String[] partitions = new String[]{"changeReplicationFactor-0", "changeReplicationFactor-1"};
         Subclass sub = new Subclass(adminClient, vertx, config, asList(
@@ -257,7 +278,9 @@ public class ControllerAssignedKafkaImplTest {
     public void changeReplicationFactor_ExecuteFail(TestContext context) {
         MockAdminClient adminClient = new MockAdminClient();
         Vertx vertx = Vertx.vertx();
-        Config config = new Config(singletonMap(Config.REASSIGN_VERIFY_INTERVAL_MS.key, "1 seconds"));
+        Map<String, String> map = new HashMap<>(mandatory);
+        mandatory.put(Config.REASSIGN_VERIFY_INTERVAL_MS.key, "1 seconds");
+        Config config = new Config(map);
         Topic topic = new Topic.Builder("changeReplicationFactor", 2, (short) 2, emptyMap()).build();
         String[] partitions = new String[]{"changeReplicationFactor-0", "changeReplicationFactor-1"};
         Subclass sub = new Subclass(adminClient, vertx, config, asList(


### PR DESCRIPTION
Made STRIMZI_ZOOKEEPER_CONNECT and STRIMZI_KAFKA_BOOTSTRAP_SERVERS mandatory
Updated unit tests accordingly