### PR TITLE
Connect S2I template does not need normal image configuration

### DIFF
--- a/resources/openshift/cluster-controller-with-template.yaml
+++ b/resources/openshift/cluster-controller-with-template.yaml
@@ -621,18 +621,6 @@ parameters:
   displayName: Status replication factor
   name: KAFKA_CONNECT_STATUS_STORAGE_REPLICATION_FACTOR
   value: "3"
-- description: Image repository name
-  displayName: Repository Name
-  name: IMAGE_REPO_NAME
-  value: strimzi
-- description: Image name
-  displayName: Image Name
-  name: IMAGE_NAME
-  value: kafka-connect
-- description: Image tag
-  displayName: Image tag
-  name: IMAGE_TAG
-  value: latest
 - description: Image repository name of the S2I Docker image
   displayName: S2I image repository
   name: S2I_IMAGE_REPO_NAME
@@ -663,7 +651,6 @@ objects:
       strimzi.io/type: kafka-connect
   data:
     nodes: "${INSTANCES}"
-    image: "${IMAGE_REPO_NAME}/${IMAGE_NAME}:${IMAGE_TAG}"
     s2i: |-
       {
         "enabled": true,


### PR DESCRIPTION
Kafka Connect S2I deployment doesn't need the IMAGE specification, because it is anyway overwritten by the generated ImageStream created by the builds. This PR removes it from the OpenShift template.