### PR TITLE
Add unit tests for Kafka Connect

### DIFF
--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectClusterOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectClusterOperations.java
@@ -123,8 +123,9 @@ public class KafkaConnectClusterOperations extends AbstractClusterOperations<Kaf
 
             if (connectConfigMap != null)    {
                 connect = KafkaConnectCluster.fromConfigMap(isOpenShift, connectConfigMap);
+                Deployment dep = deploymentOperations.get(namespace, connect.getName());
                 log.info("Updating Kafka Connect cluster {} in namespace {}", connect.getName(), namespace);
-                diff = connect.diff(namespace, deploymentOperations);
+                diff = connect.diff(dep);
             } else  {
                 throw new IllegalStateException("ConfigMap " + name + " doesn't exist anymore in namespace " + namespace);
             }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/KafkaConnectCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/KafkaConnectCluster.java
@@ -139,7 +139,7 @@ public class KafkaConnectCluster extends AbstractCluster {
         kafkaConnect.setReplicas(dep.getSpec().getReplicas());
         kafkaConnect.setImage(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getImage());
         kafkaConnect.setHealthCheckInitialDelay(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getReadinessProbe().getInitialDelaySeconds());
-        kafkaConnect.setHealthCheckInitialDelay(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getReadinessProbe().getTimeoutSeconds());
+        kafkaConnect.setHealthCheckTimeout(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getReadinessProbe().getTimeoutSeconds());
 
         Map<String, String> vars = dep.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv().stream().collect(
                 Collectors.toMap(EnvVar::getName, EnvVar::getValue));
@@ -160,14 +160,10 @@ public class KafkaConnectCluster extends AbstractCluster {
     /**
      * Return the differences between the current Kafka Connect cluster and the deployed one
      *
-     * @param namespace Kubernetes/OpenShift namespace where cluster resources belong to
+     * @param dep Deployment which should be diffed
      * @return  ClusterDiffResult instance with differences
      */
-    public ClusterDiffResult diff(
-            String namespace,
-            DeploymentOperations deploymentOperations) {
-
-        Deployment dep = deploymentOperations.get(namespace, getName());
+    public ClusterDiffResult diff(Deployment dep) {
 
         boolean scaleUp = false;
         boolean scaleDown = false;
@@ -235,8 +231,8 @@ public class KafkaConnectCluster extends AbstractCluster {
                 Collections.singletonList(createContainerPort(REST_API_PORT_NAME, REST_API_PORT, "TCP")),
                 createHttpProbe(healthCheckPath, REST_API_PORT_NAME, healthCheckInitialDelay, healthCheckTimeout),
                 createHttpProbe(healthCheckPath, REST_API_PORT_NAME, healthCheckInitialDelay, healthCheckTimeout),
-                null,
-                null
+                Collections.EMPTY_MAP,
+                Collections.EMPTY_MAP
                 );
     }
 
@@ -244,8 +240,8 @@ public class KafkaConnectCluster extends AbstractCluster {
         return patchDeployment(dep,
                 createHttpProbe(healthCheckPath, REST_API_PORT_NAME, healthCheckInitialDelay, healthCheckTimeout),
                 createHttpProbe(healthCheckPath, REST_API_PORT_NAME, healthCheckInitialDelay, healthCheckTimeout),
-                null,
-                null
+                Collections.EMPTY_MAP,
+                Collections.EMPTY_MAP
                 );
     }
 

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/ResourceUtils.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/ResourceUtils.java
@@ -20,6 +20,7 @@ package io.strimzi.controller.cluster;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.strimzi.controller.cluster.resources.KafkaCluster;
+import io.strimzi.controller.cluster.resources.KafkaConnectCluster;
 import io.strimzi.controller.cluster.resources.KafkaConnectS2ICluster;
 
 import java.util.HashMap;
@@ -120,6 +121,51 @@ public class ResourceUtils {
                 .withName(clusterCmName)
                 .withNamespace(clusterCmNamespace)
                 .withLabels(labels(ClusterController.STRIMZI_KIND_LABEL, "cluster", ClusterController.STRIMZI_TYPE_LABEL, "kafka-connect-s2i"))
+                .endMetadata()
+                .withData(cmData)
+                .build();
+    }
+
+    /**
+     * Generate ConfigMap for Kafka Conect cluster
+     */
+    public static ConfigMap createKafkaConnectClusterConfigMap(String clusterCmNamespace, String clusterCmName, int replicas,
+                                                                  String image, int healthDelay, int healthTimeout, String bootstrapServers,
+                                                                  String groupID, int configReplicationFactor, int offsetReplicationFactor,
+                                                                  int statusReplicationFactor, String keyConverter, String valueConverter,
+                                                                  boolean keyConverterSchemas, boolean valuesConverterSchema) {
+        Map<String, String> cmData = new HashMap<>();
+        cmData.put(KafkaConnectCluster.KEY_IMAGE, image);
+        cmData.put(KafkaConnectCluster.KEY_REPLICAS, Integer.toString(replicas));
+        cmData.put(KafkaConnectCluster.KEY_HEALTHCHECK_DELAY, Integer.toString(healthDelay));
+        cmData.put(KafkaConnectCluster.KEY_HEALTHCHECK_TIMEOUT, Integer.toString(healthTimeout));
+        cmData.put(KafkaConnectCluster.KEY_BOOTSTRAP_SERVERS, bootstrapServers);
+        cmData.put(KafkaConnectCluster.KEY_GROUP_ID, groupID);
+        cmData.put(KafkaConnectCluster.KEY_CONFIG_STORAGE_REPLICATION_FACTOR, Integer.toString(configReplicationFactor));
+        cmData.put(KafkaConnectCluster.KEY_OFFSET_STORAGE_REPLICATION_FACTOR, Integer.toString(offsetReplicationFactor));
+        cmData.put(KafkaConnectCluster.KEY_STATUS_STORAGE_REPLICATION_FACTOR, Integer.toString(statusReplicationFactor));
+        cmData.put(KafkaConnectCluster.KEY_KEY_CONVERTER, keyConverter);
+        cmData.put(KafkaConnectCluster.KEY_KEY_CONVERTER_SCHEMAS_EXAMPLE, Boolean.toString(keyConverterSchemas));
+        cmData.put(KafkaConnectCluster.KEY_VALUE_CONVERTER, valueConverter);
+        cmData.put(KafkaConnectCluster.KEY_VALUE_CONVERTER_SCHEMAS_EXAMPLE, Boolean.toString(valuesConverterSchema));
+
+        ConfigMap cm = createEmptyKafkaConnectClusterConfigMap(clusterCmNamespace, clusterCmName);
+        cm.setData(cmData);
+
+        return cm;
+    }
+
+    /**
+     * Generate empty KafkaConnect config map
+     */
+    public static ConfigMap createEmptyKafkaConnectClusterConfigMap(String clusterCmNamespace, String clusterCmName) {
+        Map<String, String> cmData = new HashMap<>();
+
+        return new ConfigMapBuilder()
+                .withNewMetadata()
+                .withName(clusterCmName)
+                .withNamespace(clusterCmNamespace)
+                .withLabels(labels(ClusterController.STRIMZI_KIND_LABEL, "cluster", ClusterController.STRIMZI_TYPE_LABEL, "kafka-connect"))
                 .endMetadata()
                 .withData(cmData)
                 .build();

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectClusterOperationsTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectClusterOperationsTest.java
@@ -1,0 +1,459 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.strimzi.controller.cluster.operations.cluster;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.extensions.Deployment;
+import io.fabric8.openshift.api.model.BuildConfig;
+import io.fabric8.openshift.api.model.ImageStream;
+import io.strimzi.controller.cluster.ResourceUtils;
+import io.strimzi.controller.cluster.operations.resource.BuildConfigOperations;
+import io.strimzi.controller.cluster.operations.resource.ConfigMapOperations;
+import io.strimzi.controller.cluster.operations.resource.DeploymentOperations;
+import io.strimzi.controller.cluster.operations.resource.ImageStreamOperations;
+import io.strimzi.controller.cluster.operations.resource.ServiceOperations;
+import io.strimzi.controller.cluster.resources.KafkaConnectCluster;
+import io.strimzi.controller.cluster.resources.KafkaConnectCluster;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(VertxUnitRunner.class)
+public class KafkaConnectClusterOperationsTest {
+
+    protected static Vertx vertx;
+
+    @BeforeClass
+    public static void before() {
+        vertx = Vertx.vertx();
+    }
+
+    @AfterClass
+    public static void after() {
+        vertx.close();
+    }
+
+    @Test
+    public void testCreateCluster(TestContext context) {
+        ConfigMapOperations mockCmOps = mock(ConfigMapOperations.class);
+        ServiceOperations mockServiceOps = mock(ServiceOperations.class);
+        DeploymentOperations mockDcOps = mock(DeploymentOperations.class);
+
+        String clusterCmName = "foo";
+        String clusterCmNamespace = "test";
+
+        ConfigMap clusterCm = ResourceUtils.createEmptyKafkaConnectClusterConfigMap(clusterCmNamespace, clusterCmName);
+        when(mockCmOps.get(clusterCmNamespace, clusterCmName)).thenReturn(clusterCm);
+
+        ArgumentCaptor<Service> serviceCaptor = ArgumentCaptor.forClass(Service.class);
+        when(mockServiceOps.create(serviceCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        ArgumentCaptor<Deployment> dcCaptor = ArgumentCaptor.forClass(Deployment.class);
+        when(mockDcOps.create(dcCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        KafkaConnectClusterOperations ops = new KafkaConnectClusterOperations(vertx, true,
+                mockCmOps, mockDcOps, mockServiceOps);
+
+        KafkaConnectCluster connect = KafkaConnectCluster.fromConfigMap(true, clusterCm);
+
+        Async async = context.async();
+        ops.create(clusterCmNamespace, clusterCmName, createResult -> {
+            context.assertTrue(createResult.succeeded());
+
+            // Vertify service
+            List<Service> capturedServices = serviceCaptor.getAllValues();
+            context.assertEquals(1, capturedServices.size());
+            Service service = capturedServices.get(0);
+            context.assertEquals(connect.getName(), service.getMetadata().getName());
+            context.assertEquals(connect.generateService(), service, "Services are not equal");
+
+            // Verify Deployment
+            List<Deployment> capturedDc = dcCaptor.getAllValues();
+            context.assertEquals(1, capturedDc.size());
+            Deployment dc = capturedDc.get(0);
+            context.assertEquals(connect.getName(), dc.getMetadata().getName());
+            context.assertEquals(connect.generateDeployment(), dc, "Deployments are not equal");
+
+            async.complete();
+        });
+    }
+
+    @Test
+    public void testUpdateClusterNoDiff(TestContext context) {
+        ConfigMapOperations mockCmOps = mock(ConfigMapOperations.class);
+        ServiceOperations mockServiceOps = mock(ServiceOperations.class);
+        DeploymentOperations mockDcOps = mock(DeploymentOperations.class);
+
+        String clusterCmName = "foo";
+        String clusterCmNamespace = "test";
+
+        ConfigMap clusterCm = ResourceUtils.createEmptyKafkaConnectClusterConfigMap(clusterCmNamespace, clusterCmName);
+        KafkaConnectCluster connect = KafkaConnectCluster.fromConfigMap(true, clusterCm);
+        when(mockCmOps.get(clusterCmNamespace, clusterCmName)).thenReturn(clusterCm);
+        when(mockServiceOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateService());
+        when(mockDcOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateDeployment());
+
+        ArgumentCaptor<String> serviceNamespaceCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> serviceNameCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Service> serviceCaptor = ArgumentCaptor.forClass(Service.class);
+        when(mockServiceOps.patch(serviceNamespaceCaptor.capture(), serviceNameCaptor.capture(), serviceCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        ArgumentCaptor<String> dcNamespaceCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> dcNameCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Deployment> dcCaptor = ArgumentCaptor.forClass(Deployment.class);
+        when(mockDcOps.patch(dcNamespaceCaptor.capture(), dcNameCaptor.capture(), dcCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        ArgumentCaptor<String> dcScaleUpNamespaceCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> dcScaleUpNameCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Integer> dcScaleUpReplicasCaptor = ArgumentCaptor.forClass(Integer.class);
+        when(mockDcOps.scaleUp(dcScaleUpNamespaceCaptor.capture(), dcScaleUpNameCaptor.capture(), dcScaleUpReplicasCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        ArgumentCaptor<String> dcScaleDownNamespaceCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> dcScaleDownNameCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Integer> dcScaleDownReplicasCaptor = ArgumentCaptor.forClass(Integer.class);
+        when(mockDcOps.scaleDown(dcScaleDownNamespaceCaptor.capture(), dcScaleDownNameCaptor.capture(), dcScaleDownReplicasCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        KafkaConnectClusterOperations ops = new KafkaConnectClusterOperations(vertx, true,
+                mockCmOps, mockDcOps, mockServiceOps);
+
+        Async async = context.async();
+        ops.update(clusterCmNamespace, clusterCmName, createResult -> {
+            context.assertTrue(createResult.succeeded());
+
+            // Vertify service
+            List<Service> capturedServices = serviceCaptor.getAllValues();
+            context.assertEquals(0, capturedServices.size());
+
+            // Verify Deployment Config
+            List<Deployment> capturedDc = dcCaptor.getAllValues();
+            context.assertEquals(0, capturedDc.size());
+
+            // Verify scaleDown / scaleUp were not called
+            context.assertEquals(0, dcScaleDownNameCaptor.getAllValues().size());
+            context.assertEquals(0, dcScaleUpNameCaptor.getAllValues().size());
+
+            async.complete();
+        });
+    }
+
+    @Test
+    public void testUpdateCluster(TestContext context) {
+        ConfigMapOperations mockCmOps = mock(ConfigMapOperations.class);
+        ServiceOperations mockServiceOps = mock(ServiceOperations.class);
+        DeploymentOperations mockDcOps = mock(DeploymentOperations.class);
+
+        String clusterCmName = "foo";
+        String clusterCmNamespace = "test";
+
+        ConfigMap clusterCm = ResourceUtils.createEmptyKafkaConnectClusterConfigMap(clusterCmNamespace, clusterCmName);
+        KafkaConnectCluster connect = KafkaConnectCluster.fromConfigMap(true, clusterCm);
+        clusterCm.getData().put("image", "some/different:image"); // Change the image to generate some diff
+
+        when(mockCmOps.get(clusterCmNamespace, clusterCmName)).thenReturn(clusterCm);
+        when(mockServiceOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateService());
+        when(mockDcOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateDeployment());
+
+        ArgumentCaptor<String> serviceNamespaceCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> serviceNameCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Service> serviceCaptor = ArgumentCaptor.forClass(Service.class);
+        when(mockServiceOps.patch(serviceNamespaceCaptor.capture(), serviceNameCaptor.capture(), serviceCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        ArgumentCaptor<String> dcNamespaceCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> dcNameCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Deployment> dcCaptor = ArgumentCaptor.forClass(Deployment.class);
+        when(mockDcOps.patch(dcNamespaceCaptor.capture(), dcNameCaptor.capture(), dcCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        ArgumentCaptor<String> dcScaleUpNamespaceCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> dcScaleUpNameCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Integer> dcScaleUpReplicasCaptor = ArgumentCaptor.forClass(Integer.class);
+        when(mockDcOps.scaleUp(dcScaleUpNamespaceCaptor.capture(), dcScaleUpNameCaptor.capture(), dcScaleUpReplicasCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        ArgumentCaptor<String> dcScaleDownNamespaceCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> dcScaleDownNameCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Integer> dcScaleDownReplicasCaptor = ArgumentCaptor.forClass(Integer.class);
+        when(mockDcOps.scaleDown(dcScaleDownNamespaceCaptor.capture(), dcScaleDownNameCaptor.capture(), dcScaleDownReplicasCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        KafkaConnectClusterOperations ops = new KafkaConnectClusterOperations(vertx, true,
+                mockCmOps, mockDcOps, mockServiceOps);
+
+        Async async = context.async();
+        ops.update(clusterCmNamespace, clusterCmName, createResult -> {
+            context.assertTrue(createResult.succeeded());
+
+            KafkaConnectCluster compareTo = KafkaConnectCluster.fromConfigMap(true, clusterCm);
+
+            // Vertify service
+            List<Service> capturedServices = serviceCaptor.getAllValues();
+            context.assertEquals(1, capturedServices.size());
+            Service service = capturedServices.get(0);
+            context.assertEquals(compareTo.getName(), service.getMetadata().getName());
+            context.assertEquals(compareTo.generateService(), service, "Services are not equal");
+
+            // Verify Deployment
+            List<Deployment> capturedDc = dcCaptor.getAllValues();
+            context.assertEquals(1, capturedDc.size());
+            Deployment dc = capturedDc.get(0);
+            context.assertEquals(compareTo.getName(), dc.getMetadata().getName());
+            context.assertEquals(compareTo.generateDeployment(), dc, "Deployments are not equal");
+
+            // Verify scaleDown / scaleUp were not called
+            context.assertEquals(0, dcScaleDownNameCaptor.getAllValues().size());
+            context.assertEquals(0, dcScaleUpNameCaptor.getAllValues().size());
+
+            async.complete();
+        });
+    }
+
+    @Test
+    public void testUpdateClusterFailure(TestContext context) {
+        ConfigMapOperations mockCmOps = mock(ConfigMapOperations.class);
+        ServiceOperations mockServiceOps = mock(ServiceOperations.class);
+        DeploymentOperations mockDcOps = mock(DeploymentOperations.class);
+
+        String clusterCmName = "foo";
+        String clusterCmNamespace = "test";
+
+        ConfigMap clusterCm = ResourceUtils.createEmptyKafkaConnectClusterConfigMap(clusterCmNamespace, clusterCmName);
+        KafkaConnectCluster connect = KafkaConnectCluster.fromConfigMap(true, clusterCm);
+        clusterCm.getData().put("image", "some/different:image"); // Change the image to generate some diff
+
+        when(mockCmOps.get(clusterCmNamespace, clusterCmName)).thenReturn(clusterCm);
+        when(mockServiceOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateService());
+        when(mockDcOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateDeployment());
+
+        ArgumentCaptor<String> serviceNamespaceCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> serviceNameCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Service> serviceCaptor = ArgumentCaptor.forClass(Service.class);
+        when(mockServiceOps.patch(serviceNamespaceCaptor.capture(), serviceNameCaptor.capture(), serviceCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        ArgumentCaptor<String> dcNamespaceCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> dcNameCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Deployment> dcCaptor = ArgumentCaptor.forClass(Deployment.class);
+        when(mockDcOps.patch(dcNamespaceCaptor.capture(), dcNameCaptor.capture(), dcCaptor.capture())).thenReturn(Future.failedFuture("Failed"));
+
+        ArgumentCaptor<String> dcScaleUpNamespaceCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> dcScaleUpNameCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Integer> dcScaleUpReplicasCaptor = ArgumentCaptor.forClass(Integer.class);
+        when(mockDcOps.scaleUp(dcScaleUpNamespaceCaptor.capture(), dcScaleUpNameCaptor.capture(), dcScaleUpReplicasCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        ArgumentCaptor<String> dcScaleDownNamespaceCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> dcScaleDownNameCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Integer> dcScaleDownReplicasCaptor = ArgumentCaptor.forClass(Integer.class);
+        when(mockDcOps.scaleDown(dcScaleDownNamespaceCaptor.capture(), dcScaleDownNameCaptor.capture(), dcScaleDownReplicasCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        KafkaConnectClusterOperations ops = new KafkaConnectClusterOperations(vertx, true,
+                mockCmOps, mockDcOps, mockServiceOps);
+
+        Async async = context.async();
+        ops.update(clusterCmNamespace, clusterCmName, createResult -> {
+            context.assertFalse(createResult.succeeded());
+
+            async.complete();
+        });
+    }
+
+    @Test
+    public void testUpdateClusterScaleUp(TestContext context) {
+        String newReplicas = "4";
+
+        ConfigMapOperations mockCmOps = mock(ConfigMapOperations.class);
+        ServiceOperations mockServiceOps = mock(ServiceOperations.class);
+        DeploymentOperations mockDcOps = mock(DeploymentOperations.class);
+
+        String clusterCmName = "foo";
+        String clusterCmNamespace = "test";
+
+        ConfigMap clusterCm = ResourceUtils.createEmptyKafkaConnectClusterConfigMap(clusterCmNamespace, clusterCmName);
+        KafkaConnectCluster connect = KafkaConnectCluster.fromConfigMap(true, clusterCm);
+        clusterCm.getData().put(KafkaConnectCluster.KEY_REPLICAS, newReplicas); // Change replicas to create ScaleUp
+
+        when(mockCmOps.get(clusterCmNamespace, clusterCmName)).thenReturn(clusterCm);
+        when(mockServiceOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateService());
+        when(mockDcOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateDeployment());
+
+        ArgumentCaptor<String> serviceNamespaceCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> serviceNameCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Service> serviceCaptor = ArgumentCaptor.forClass(Service.class);
+        when(mockServiceOps.patch(serviceNamespaceCaptor.capture(), serviceNameCaptor.capture(), serviceCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        ArgumentCaptor<String> dcNamespaceCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> dcNameCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Deployment> dcCaptor = ArgumentCaptor.forClass(Deployment.class);
+        when(mockDcOps.patch(dcNamespaceCaptor.capture(), dcNameCaptor.capture(), dcCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        ArgumentCaptor<String> dcScaleUpNamespaceCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> dcScaleUpNameCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Integer> dcScaleUpReplicasCaptor = ArgumentCaptor.forClass(Integer.class);
+        when(mockDcOps.scaleUp(dcScaleUpNamespaceCaptor.capture(), dcScaleUpNameCaptor.capture(), dcScaleUpReplicasCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        ArgumentCaptor<String> dcScaleDownNamespaceCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> dcScaleDownNameCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Integer> dcScaleDownReplicasCaptor = ArgumentCaptor.forClass(Integer.class);
+        when(mockDcOps.scaleDown(dcScaleDownNamespaceCaptor.capture(), dcScaleDownNameCaptor.capture(), dcScaleDownReplicasCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        KafkaConnectClusterOperations ops = new KafkaConnectClusterOperations(vertx, true,
+                mockCmOps, mockDcOps, mockServiceOps);
+
+        Async async = context.async();
+        ops.update(clusterCmNamespace, clusterCmName, createResult -> {
+            context.assertTrue(createResult.succeeded());
+
+            // Vertify service
+            List<Service> capturedServices = serviceCaptor.getAllValues();
+            context.assertEquals(0, capturedServices.size());
+
+            // Verify Deployment
+            List<Deployment> capturedDc = dcCaptor.getAllValues();
+            context.assertEquals(0, capturedDc.size());
+
+            // Verify ScaleUp
+            context.assertEquals(1, dcScaleUpNameCaptor.getAllValues().size());
+            context.assertEquals(clusterCmNamespace, dcScaleUpNamespaceCaptor.getValue());
+            context.assertEquals(connect.getName(), dcScaleUpNameCaptor.getValue());
+            context.assertEquals(newReplicas, dcScaleUpReplicasCaptor.getValue().toString());
+
+            // Verify scaleDown was not called
+            context.assertEquals(0, dcScaleDownNameCaptor.getAllValues().size());
+
+            async.complete();
+        });
+    }
+
+    @Test
+    public void testUpdateClusterScaleDown(TestContext context) {
+        String newReplicas = "2";
+
+        ConfigMapOperations mockCmOps = mock(ConfigMapOperations.class);
+        ServiceOperations mockServiceOps = mock(ServiceOperations.class);
+        DeploymentOperations mockDcOps = mock(DeploymentOperations.class);
+
+        String clusterCmName = "foo";
+        String clusterCmNamespace = "test";
+
+        ConfigMap clusterCm = ResourceUtils.createEmptyKafkaConnectClusterConfigMap(clusterCmNamespace, clusterCmName);
+        KafkaConnectCluster connect = KafkaConnectCluster.fromConfigMap(true, clusterCm);
+        clusterCm.getData().put(KafkaConnectCluster.KEY_REPLICAS, newReplicas); // Change replicas to create ScaleDown
+
+        when(mockCmOps.get(clusterCmNamespace, clusterCmName)).thenReturn(clusterCm);
+        when(mockServiceOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateService());
+        when(mockDcOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateDeployment());
+
+        ArgumentCaptor<String> serviceNamespaceCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> serviceNameCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Service> serviceCaptor = ArgumentCaptor.forClass(Service.class);
+        when(mockServiceOps.patch(serviceNamespaceCaptor.capture(), serviceNameCaptor.capture(), serviceCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        ArgumentCaptor<String> dcNamespaceCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> dcNameCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Deployment> dcCaptor = ArgumentCaptor.forClass(Deployment.class);
+        when(mockDcOps.patch(dcNamespaceCaptor.capture(), dcNameCaptor.capture(), dcCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        ArgumentCaptor<String> dcScaleUpNamespaceCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> dcScaleUpNameCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Integer> dcScaleUpReplicasCaptor = ArgumentCaptor.forClass(Integer.class);
+        when(mockDcOps.scaleUp(dcScaleUpNamespaceCaptor.capture(), dcScaleUpNameCaptor.capture(), dcScaleUpReplicasCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        ArgumentCaptor<String> dcScaleDownNamespaceCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> dcScaleDownNameCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Integer> dcScaleDownReplicasCaptor = ArgumentCaptor.forClass(Integer.class);
+        when(mockDcOps.scaleDown(dcScaleDownNamespaceCaptor.capture(), dcScaleDownNameCaptor.capture(), dcScaleDownReplicasCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        KafkaConnectClusterOperations ops = new KafkaConnectClusterOperations(vertx, true,
+                mockCmOps, mockDcOps, mockServiceOps);
+
+        Async async = context.async();
+        ops.update(clusterCmNamespace, clusterCmName, createResult -> {
+            context.assertTrue(createResult.succeeded());
+
+            // Vertify service
+            List<Service> capturedServices = serviceCaptor.getAllValues();
+            context.assertEquals(0, capturedServices.size());
+
+            // Verify Deployment
+            List<Deployment> capturedDc = dcCaptor.getAllValues();
+            context.assertEquals(0, capturedDc.size());
+
+            // Verify ScaleUp
+            context.assertEquals(0, dcScaleUpNameCaptor.getAllValues().size());
+
+            // Verify scaleDown
+            context.assertEquals(1, dcScaleDownNameCaptor.getAllValues().size());
+            context.assertEquals(clusterCmNamespace, dcScaleDownNamespaceCaptor.getValue());
+            context.assertEquals(connect.getName(), dcScaleDownNameCaptor.getValue());
+            context.assertEquals(newReplicas, dcScaleDownReplicasCaptor.getValue().toString());
+
+            async.complete();
+        });
+    }
+
+    @Test
+    public void testDeleteCluster(TestContext context) {
+        ConfigMapOperations mockCmOps = mock(ConfigMapOperations.class);
+        ServiceOperations mockServiceOps = mock(ServiceOperations.class);
+        DeploymentOperations mockDcOps = mock(DeploymentOperations.class);
+
+        String clusterCmName = "foo";
+        String clusterCmNamespace = "test";
+
+        KafkaConnectCluster connect = KafkaConnectCluster.fromConfigMap(true, ResourceUtils.createEmptyKafkaConnectClusterConfigMap(clusterCmNamespace, clusterCmName));
+
+        when(mockDcOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateDeployment());
+
+        ArgumentCaptor<String> serviceNamespaceCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> serviceNameCaptor = ArgumentCaptor.forClass(String.class);
+        when(mockServiceOps.delete(serviceNamespaceCaptor.capture(), serviceNameCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        ArgumentCaptor<String> dcNamespaceCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> dcNameCaptor = ArgumentCaptor.forClass(String.class);
+        when(mockDcOps.delete(dcNamespaceCaptor.capture(), dcNameCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        KafkaConnectClusterOperations ops = new KafkaConnectClusterOperations(vertx, true,
+                mockCmOps, mockDcOps, mockServiceOps);
+
+        Async async = context.async();
+        ops.delete(clusterCmNamespace, clusterCmName, createResult -> {
+            context.assertTrue(createResult.succeeded());
+
+            // Vertify service
+            context.assertEquals(1, serviceNameCaptor.getAllValues().size());
+            context.assertEquals(clusterCmNamespace, serviceNamespaceCaptor.getValue());
+            context.assertEquals(connect.getName(), serviceNameCaptor.getValue());
+
+            // Vertify Deployment
+            context.assertEquals(1, dcNameCaptor.getAllValues().size());
+            context.assertEquals(clusterCmNamespace, dcNamespaceCaptor.getValue());
+            context.assertEquals(connect.getName(), dcNameCaptor.getValue());
+
+            async.complete();
+        });
+    }
+
+}

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/resources/KafkaConnectClusterTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/resources/KafkaConnectClusterTest.java
@@ -1,0 +1,395 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.strimzi.controller.cluster.resources;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.EnvVarBuilder;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceBuilder;
+import io.fabric8.kubernetes.api.model.extensions.Deployment;
+import io.strimzi.controller.cluster.ClusterController;
+import io.strimzi.controller.cluster.ResourceUtils;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class KafkaConnectClusterTest {
+    private final String namespace = "test";
+    private final String cluster = "foo";
+    private final int replicas = 2;
+    private final String image = "my-image:latest";
+    private final int healthDelay = 100;
+    private final int healthTimeout = 10;
+    private final String bootstrapServers = "my-cluster-kafka:9092";
+    private final String groupID = "my-cluster-group";
+    private final int configReplicationFactor = 1;
+    private final int offsetReplicationFactor = 1;
+    private final int statusReplicationFactor = 1;
+    private final String keyConverter = "org.apache.kafka.connect.json.AvroConverter";
+    private final String valueConverter = "org.apache.kafka.connect.json.AvroConverter";
+    private final boolean keyConverterSchemas = false;
+    private final boolean valuesConverterSchema = false;
+
+    private final ConfigMap cm = ResourceUtils.createKafkaConnectClusterConfigMap(namespace, cluster, replicas, image,
+            healthDelay, healthTimeout, bootstrapServers, groupID, configReplicationFactor, offsetReplicationFactor,
+            statusReplicationFactor, keyConverter, valueConverter, keyConverterSchemas, valuesConverterSchema);
+    private final KafkaConnectCluster kc = KafkaConnectCluster.fromConfigMap(true, cm);
+
+    protected List<EnvVar> getExpectedEnvVars() {
+        List<EnvVar> expected = new ArrayList<EnvVar>();
+        expected.add(new EnvVarBuilder().withName(kc.KEY_BOOTSTRAP_SERVERS).withValue(bootstrapServers).build());
+        expected.add(new EnvVarBuilder().withName(kc.KEY_GROUP_ID).withValue(groupID).build());
+        expected.add(new EnvVarBuilder().withName(kc.KEY_KEY_CONVERTER).withValue(keyConverter).build());
+        expected.add(new EnvVarBuilder().withName(kc.KEY_KEY_CONVERTER_SCHEMAS_EXAMPLE).withValue(Boolean.toString(keyConverterSchemas)).build());
+        expected.add(new EnvVarBuilder().withName(kc.KEY_VALUE_CONVERTER).withValue(valueConverter).build());
+        expected.add(new EnvVarBuilder().withName(kc.KEY_VALUE_CONVERTER_SCHEMAS_EXAMPLE).withValue(Boolean.toString(valuesConverterSchema)).build());
+        expected.add(new EnvVarBuilder().withName(kc.KEY_CONFIG_STORAGE_REPLICATION_FACTOR).withValue(Integer.toString(configReplicationFactor)).build());
+        expected.add(new EnvVarBuilder().withName(kc.KEY_OFFSET_STORAGE_REPLICATION_FACTOR).withValue(Integer.toString(offsetReplicationFactor)).build());
+        expected.add(new EnvVarBuilder().withName(kc.KEY_STATUS_STORAGE_REPLICATION_FACTOR).withValue(Integer.toString(statusReplicationFactor)).build());
+
+        return expected;
+    }
+
+    @Test
+    public void testDefaultValues() {
+        KafkaConnectCluster kc = KafkaConnectCluster.fromConfigMap(true, ResourceUtils.createEmptyKafkaConnectClusterConfigMap(namespace, cluster));
+
+        assertEquals(KafkaConnectCluster.DEFAULT_IMAGE, kc.image);
+        assertEquals(KafkaConnectCluster.DEFAULT_REPLICAS, kc.replicas);
+        assertEquals(KafkaConnectCluster.DEFAULT_HEALTHCHECK_DELAY, kc.healthCheckInitialDelay);
+        assertEquals(KafkaConnectCluster.DEFAULT_HEALTHCHECK_TIMEOUT, kc.healthCheckTimeout);
+        assertEquals(KafkaConnectCluster.DEFAULT_BOOTSTRAP_SERVERS, kc.bootstrapServers);
+        assertEquals(KafkaConnectCluster.DEFAULT_CONFIG_STORAGE_REPLICATION_FACTOR, kc.configStorageReplicationFactor);
+        assertEquals(KafkaConnectCluster.DEFAULT_OFFSET_STORAGE_REPLICATION_FACTOR, kc.offsetStorageReplicationFactor);
+        assertEquals(KafkaConnectCluster.DEFAULT_STATUS_STORAGE_REPLICATION_FACTOR, kc.statusStorageReplicationFactor);
+        assertEquals(KafkaConnectCluster.DEFAULT_GROUP_ID, kc.groupId);
+        assertEquals(KafkaConnectCluster.DEFAULT_KEY_CONVERTER, kc.keyConverter);
+        assertEquals(KafkaConnectCluster.DEFAULT_KEY_CONVERTER_SCHEMAS_EXAMPLE, kc.keyConverterSchemasEnable);
+        assertEquals(KafkaConnectCluster.DEFAULT_VALUE_CONVERTER, kc.valueConverter);
+        assertEquals(KafkaConnectCluster.DEFAULT_VALUE_CONVERTER_SCHEMAS_EXAMPLE, kc.valueConverterSchemasEnable);
+    }
+
+    @Test
+    public void testFromConfigMap() {
+        assertEquals(replicas, kc.replicas);
+        assertEquals(image, kc.image);
+        assertEquals(healthDelay, kc.healthCheckInitialDelay);
+        assertEquals(healthTimeout, kc.healthCheckTimeout);
+        assertEquals(bootstrapServers, kc.bootstrapServers);
+        assertEquals(configReplicationFactor, kc.configStorageReplicationFactor);
+        assertEquals(offsetReplicationFactor, kc.offsetStorageReplicationFactor);
+        assertEquals(statusReplicationFactor, kc.statusStorageReplicationFactor);
+        assertEquals(groupID, kc.groupId);
+        assertEquals(keyConverter, kc.keyConverter);
+        assertEquals(keyConverterSchemas, kc.keyConverterSchemasEnable);
+        assertEquals(valueConverter, kc.valueConverter);
+        assertEquals(valuesConverterSchema, kc.valueConverterSchemasEnable);
+    }
+
+    @Test
+    public void testFromDeployment() {
+        KafkaConnectCluster newKc = KafkaConnectCluster.fromDeployment(namespace, cluster, kc.generateDeployment());
+
+        assertEquals(replicas, newKc.replicas);
+        assertEquals(image, newKc.image);
+        assertEquals(healthDelay, newKc.healthCheckInitialDelay);
+        assertEquals(healthTimeout, newKc.healthCheckTimeout);
+        assertEquals(bootstrapServers, newKc.bootstrapServers);
+        assertEquals(configReplicationFactor, newKc.configStorageReplicationFactor);
+        assertEquals(offsetReplicationFactor, newKc.offsetStorageReplicationFactor);
+        assertEquals(statusReplicationFactor, newKc.statusStorageReplicationFactor);
+        assertEquals(groupID, newKc.groupId);
+        assertEquals(keyConverter, newKc.keyConverter);
+        assertEquals(keyConverterSchemas, newKc.keyConverterSchemasEnable);
+        assertEquals(valueConverter, newKc.valueConverter);
+        assertEquals(valuesConverterSchema, newKc.valueConverterSchemasEnable);
+    }
+
+    @Test
+    public void testFromDeploymentWithDefaultValues() {
+        KafkaConnectCluster defaultsKc = KafkaConnectCluster.fromConfigMap(true, ResourceUtils.createEmptyKafkaConnectClusterConfigMap(namespace, cluster));
+        KafkaConnectCluster newKc = KafkaConnectCluster.fromDeployment(namespace, cluster, defaultsKc.generateDeployment());
+
+        assertEquals(KafkaConnectCluster.DEFAULT_REPLICAS, newKc.replicas);
+        assertEquals(KafkaConnectCluster.DEFAULT_IMAGE, newKc.image);
+        assertEquals(KafkaConnectCluster.DEFAULT_HEALTHCHECK_DELAY, newKc.healthCheckInitialDelay);
+        assertEquals(KafkaConnectCluster.DEFAULT_HEALTHCHECK_TIMEOUT, newKc.healthCheckTimeout);
+        assertEquals(KafkaConnectCluster.DEFAULT_BOOTSTRAP_SERVERS, newKc.bootstrapServers);
+        assertEquals(KafkaConnectCluster.DEFAULT_CONFIG_STORAGE_REPLICATION_FACTOR, newKc.configStorageReplicationFactor);
+        assertEquals(KafkaConnectCluster.DEFAULT_OFFSET_STORAGE_REPLICATION_FACTOR, newKc.offsetStorageReplicationFactor);
+        assertEquals(KafkaConnectCluster.DEFAULT_STATUS_STORAGE_REPLICATION_FACTOR, newKc.statusStorageReplicationFactor);
+        assertEquals(KafkaConnectCluster.DEFAULT_GROUP_ID, newKc.groupId);
+        assertEquals(KafkaConnectCluster.DEFAULT_KEY_CONVERTER, newKc.keyConverter);
+        assertEquals(KafkaConnectCluster.DEFAULT_KEY_CONVERTER_SCHEMAS_EXAMPLE, newKc.keyConverterSchemasEnable);
+        assertEquals(KafkaConnectCluster.DEFAULT_VALUE_CONVERTER, newKc.valueConverter);
+        assertEquals(KafkaConnectCluster.DEFAULT_VALUE_CONVERTER_SCHEMAS_EXAMPLE, newKc.valueConverterSchemasEnable);
+    }
+
+    @Test
+    public void testDiffNoDiffs() {
+        ClusterDiffResult diff = kc.diff(kc.generateDeployment());
+
+        assertFalse(diff.isDifferent());
+        assertFalse(diff.isScaleDown());
+        assertFalse(diff.isScaleUp());
+        assertFalse(diff.isRollingUpdate());
+        assertFalse(diff.isMetricsChanged());
+    }
+
+    @Test
+    public void testDiffScaleUp() {
+        Deployment dep = kc.generateDeployment();
+        dep.getSpec().setReplicas(dep.getSpec().getReplicas()-1);
+        ClusterDiffResult diff = kc.diff(dep);
+
+        assertFalse(diff.isDifferent());
+        assertFalse(diff.isScaleDown());
+        assertTrue(diff.isScaleUp());
+        assertFalse(diff.isRollingUpdate());
+        assertFalse(diff.isMetricsChanged());
+    }
+
+    @Test
+    public void testDiffScaleDown() {
+        Deployment dep = kc.generateDeployment();
+        dep.getSpec().setReplicas(dep.getSpec().getReplicas()+1);
+        ClusterDiffResult diff = kc.diff(dep);
+
+        assertFalse(diff.isDifferent());
+        assertTrue(diff.isScaleDown());
+        assertFalse(diff.isScaleUp());
+        assertFalse(diff.isRollingUpdate());
+        assertFalse(diff.isMetricsChanged());
+    }
+
+    @Test
+    public void testDiffLabels() {
+        ClusterDiffResult diff;
+
+        Deployment dep = kc.generateDeployment();
+        dep.getMetadata().setLabels(Collections.EMPTY_MAP);
+        diff = kc.diff(dep);
+        assertTrue(diff.isDifferent());
+        assertFalse(diff.isScaleDown());
+        assertFalse(diff.isScaleUp());
+        assertFalse(diff.isRollingUpdate());
+        assertFalse(diff.isMetricsChanged());
+    }
+
+    @Test
+    public void testDiffConfigOptions() {
+        KafkaConnectCluster newKc;
+        ClusterDiffResult diff;
+
+        newKc = KafkaConnectCluster.fromConfigMap(true, ResourceUtils.createKafkaConnectClusterConfigMap(namespace, cluster, replicas, image,
+                123, healthTimeout, bootstrapServers, groupID, configReplicationFactor, offsetReplicationFactor,
+                statusReplicationFactor, keyConverter, valueConverter, keyConverterSchemas, valuesConverterSchema));
+        diff = kc.diff(newKc.generateDeployment());
+        assertTrue(diff.isDifferent());
+        assertFalse(diff.isScaleDown());
+        assertFalse(diff.isScaleUp());
+        assertTrue(diff.isRollingUpdate());
+        assertFalse(diff.isMetricsChanged());
+
+        newKc = KafkaConnectCluster.fromConfigMap(true, ResourceUtils.createKafkaConnectClusterConfigMap(namespace, cluster, replicas, image,
+                healthDelay, 123, bootstrapServers, groupID, configReplicationFactor, offsetReplicationFactor,
+                statusReplicationFactor, keyConverter, valueConverter, keyConverterSchemas, valuesConverterSchema));
+        diff = kc.diff(newKc.generateDeployment());
+        assertTrue(diff.isDifferent());
+        assertFalse(diff.isScaleDown());
+        assertFalse(diff.isScaleUp());
+        assertTrue(diff.isRollingUpdate());
+        assertFalse(diff.isMetricsChanged());
+
+        newKc = KafkaConnectCluster.fromConfigMap(true, ResourceUtils.createKafkaConnectClusterConfigMap(namespace, cluster, replicas, image,
+                healthDelay, healthTimeout, "some-kafka-broker:9092", groupID, configReplicationFactor, offsetReplicationFactor,
+                statusReplicationFactor, keyConverter, valueConverter, keyConverterSchemas, valuesConverterSchema));
+        diff = kc.diff(newKc.generateDeployment());
+        assertTrue(diff.isDifferent());
+        assertFalse(diff.isScaleDown());
+        assertFalse(diff.isScaleUp());
+        assertTrue(diff.isRollingUpdate());
+        assertFalse(diff.isMetricsChanged());
+
+        newKc = KafkaConnectCluster.fromConfigMap(true, ResourceUtils.createKafkaConnectClusterConfigMap(namespace, cluster, replicas, image,
+                healthDelay, healthTimeout, bootstrapServers, "some-other-group-id", configReplicationFactor, offsetReplicationFactor,
+                statusReplicationFactor, keyConverter, valueConverter, keyConverterSchemas, valuesConverterSchema));
+        diff = kc.diff(newKc.generateDeployment());
+        assertTrue(diff.isDifferent());
+        assertFalse(diff.isScaleDown());
+        assertFalse(diff.isScaleUp());
+        assertTrue(diff.isRollingUpdate());
+        assertFalse(diff.isMetricsChanged());
+
+        newKc = KafkaConnectCluster.fromConfigMap(true, ResourceUtils.createKafkaConnectClusterConfigMap(namespace, cluster, replicas, image,
+                healthDelay, healthTimeout, bootstrapServers, groupID, 5, offsetReplicationFactor,
+                statusReplicationFactor, keyConverter, valueConverter, keyConverterSchemas, valuesConverterSchema));
+        diff = kc.diff(newKc.generateDeployment());
+        assertTrue(diff.isDifferent());
+        assertFalse(diff.isScaleDown());
+        assertFalse(diff.isScaleUp());
+        assertTrue(diff.isRollingUpdate());
+        assertFalse(diff.isMetricsChanged());
+
+        newKc = KafkaConnectCluster.fromConfigMap(true, ResourceUtils.createKafkaConnectClusterConfigMap(namespace, cluster, replicas, image,
+                healthDelay, healthTimeout, bootstrapServers, groupID, configReplicationFactor, 5,
+                statusReplicationFactor, keyConverter, valueConverter, keyConverterSchemas, valuesConverterSchema));
+        diff = kc.diff(newKc.generateDeployment());
+        assertTrue(diff.isDifferent());
+        assertFalse(diff.isScaleDown());
+        assertFalse(diff.isScaleUp());
+        assertTrue(diff.isRollingUpdate());
+        assertFalse(diff.isMetricsChanged());
+
+        newKc = KafkaConnectCluster.fromConfigMap(true, ResourceUtils.createKafkaConnectClusterConfigMap(namespace, cluster, replicas, image,
+                healthDelay, healthTimeout, bootstrapServers, groupID, configReplicationFactor, offsetReplicationFactor,
+                5, keyConverter, valueConverter, keyConverterSchemas, valuesConverterSchema));
+        diff = kc.diff(newKc.generateDeployment());
+        assertTrue(diff.isDifferent());
+        assertFalse(diff.isScaleDown());
+        assertFalse(diff.isScaleUp());
+        assertTrue(diff.isRollingUpdate());
+        assertFalse(diff.isMetricsChanged());
+
+        newKc = KafkaConnectCluster.fromConfigMap(true, ResourceUtils.createKafkaConnectClusterConfigMap(namespace, cluster, replicas, image,
+                healthDelay, healthTimeout, bootstrapServers, groupID, configReplicationFactor, offsetReplicationFactor,
+                statusReplicationFactor, "some-other-converter", valueConverter, keyConverterSchemas, valuesConverterSchema));
+        diff = kc.diff(newKc.generateDeployment());
+        assertTrue(diff.isDifferent());
+        assertFalse(diff.isScaleDown());
+        assertFalse(diff.isScaleUp());
+        assertTrue(diff.isRollingUpdate());
+        assertFalse(diff.isMetricsChanged());
+
+        newKc = KafkaConnectCluster.fromConfigMap(true, ResourceUtils.createKafkaConnectClusterConfigMap(namespace, cluster, replicas, image,
+                healthDelay, healthTimeout, bootstrapServers, groupID, configReplicationFactor, offsetReplicationFactor,
+                statusReplicationFactor, keyConverter, "some-other-converter", keyConverterSchemas, valuesConverterSchema));
+        diff = kc.diff(newKc.generateDeployment());
+        assertTrue(diff.isDifferent());
+        assertFalse(diff.isScaleDown());
+        assertFalse(diff.isScaleUp());
+        assertTrue(diff.isRollingUpdate());
+        assertFalse(diff.isMetricsChanged());
+
+        newKc = KafkaConnectCluster.fromConfigMap(true, ResourceUtils.createKafkaConnectClusterConfigMap(namespace, cluster, replicas, image,
+                healthDelay, healthTimeout, bootstrapServers, groupID, configReplicationFactor, offsetReplicationFactor,
+                statusReplicationFactor, keyConverter, valueConverter, true, valuesConverterSchema));
+        diff = kc.diff(newKc.generateDeployment());
+        assertTrue(diff.isDifferent());
+        assertFalse(diff.isScaleDown());
+        assertFalse(diff.isScaleUp());
+        assertTrue(diff.isRollingUpdate());
+        assertFalse(diff.isMetricsChanged());
+
+        newKc = KafkaConnectCluster.fromConfigMap(true, ResourceUtils.createKafkaConnectClusterConfigMap(namespace, cluster, replicas, image,
+                healthDelay, healthTimeout, bootstrapServers, groupID, configReplicationFactor, offsetReplicationFactor,
+                statusReplicationFactor, keyConverter, valueConverter, keyConverterSchemas, true));
+        diff = kc.diff(newKc.generateDeployment());
+        assertTrue(diff.isDifferent());
+        assertFalse(diff.isScaleDown());
+        assertFalse(diff.isScaleUp());
+        assertTrue(diff.isRollingUpdate());
+        assertFalse(diff.isMetricsChanged());
+    }
+
+
+    @Test
+    public void testEnvVars()   {
+        assertEquals(getExpectedEnvVars(), kc.getEnvVars());
+    }
+
+    @Test
+    public void testGenerateService()   {
+        Service svc = kc.generateService();
+
+        assertEquals("ClusterIP", svc.getSpec().getType());
+        assertEquals(ResourceUtils.labels(ClusterController.STRIMZI_CLUSTER_LABEL, cluster, ClusterController.STRIMZI_TYPE_LABEL, "kafka-connect", ClusterController.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), svc.getMetadata().getLabels());
+        assertEquals(ResourceUtils.labels(ClusterController.STRIMZI_CLUSTER_LABEL, cluster, ClusterController.STRIMZI_TYPE_LABEL, "kafka-connect", ClusterController.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), svc.getSpec().getSelector());
+        assertEquals(1, svc.getSpec().getPorts().size());
+        assertEquals(new Integer(KafkaConnectCluster.REST_API_PORT), svc.getSpec().getPorts().get(0).getPort());
+        assertEquals(KafkaConnectCluster.REST_API_PORT_NAME, svc.getSpec().getPorts().get(0).getName());
+        assertEquals("TCP", svc.getSpec().getPorts().get(0).getProtocol());
+    }
+
+    @Test
+    public void testPatchService()   {
+        Service orig = new ServiceBuilder()
+                .withNewMetadata()
+                    .withName(kc.kafkaConnectClusterName(cluster))
+                    .withNamespace(namespace)
+                .endMetadata()
+                .withNewSpec()
+                    .withType("ClusterIP")
+                .endSpec()
+                .build();
+
+        Service svc = kc.patchService(orig);
+
+        assertEquals(ResourceUtils.labels(ClusterController.STRIMZI_CLUSTER_LABEL, cluster, ClusterController.STRIMZI_TYPE_LABEL, "kafka-connect", ClusterController.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), svc.getMetadata().getLabels());
+        assertEquals(ResourceUtils.labels(ClusterController.STRIMZI_CLUSTER_LABEL, cluster, ClusterController.STRIMZI_TYPE_LABEL, "kafka-connect", ClusterController.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), svc.getSpec().getSelector());
+    }
+
+    @Test
+    public void testGenerateDeployment()   {
+        Deployment dep = kc.generateDeployment();
+
+        assertEquals(kc.kafkaConnectClusterName(cluster), dep.getMetadata().getName());
+        assertEquals(namespace, dep.getMetadata().getNamespace());
+        assertEquals(ResourceUtils.labels(ClusterController.STRIMZI_CLUSTER_LABEL, cluster, ClusterController.STRIMZI_TYPE_LABEL, "kafka-connect", ClusterController.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), dep.getMetadata().getLabels());
+        assertEquals(new Integer(replicas), dep.getSpec().getReplicas());
+        assertEquals(ResourceUtils.labels(ClusterController.STRIMZI_CLUSTER_LABEL, cluster, ClusterController.STRIMZI_TYPE_LABEL, "kafka-connect", ClusterController.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), dep.getSpec().getTemplate().getMetadata().getLabels());
+        assertEquals(1, dep.getSpec().getTemplate().getSpec().getContainers().size());
+        assertEquals(kc.kafkaConnectClusterName(cluster), dep.getSpec().getTemplate().getSpec().getContainers().get(0).getName());
+        assertEquals(kc.image, dep.getSpec().getTemplate().getSpec().getContainers().get(0).getImage());
+        assertEquals(getExpectedEnvVars(), dep.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv());
+        assertEquals(new Integer(healthDelay), dep.getSpec().getTemplate().getSpec().getContainers().get(0).getLivenessProbe().getInitialDelaySeconds());
+        assertEquals(new Integer(healthTimeout), dep.getSpec().getTemplate().getSpec().getContainers().get(0).getLivenessProbe().getTimeoutSeconds());
+        assertEquals(new Integer(healthDelay), dep.getSpec().getTemplate().getSpec().getContainers().get(0).getReadinessProbe().getInitialDelaySeconds());
+        assertEquals(new Integer(healthTimeout), dep.getSpec().getTemplate().getSpec().getContainers().get(0).getReadinessProbe().getTimeoutSeconds());
+        assertEquals(1, dep.getSpec().getTemplate().getSpec().getContainers().get(0).getPorts().size());
+        assertEquals(new Integer(KafkaConnectCluster.REST_API_PORT), dep.getSpec().getTemplate().getSpec().getContainers().get(0).getPorts().get(0).getContainerPort());
+        assertEquals(KafkaConnectCluster.REST_API_PORT_NAME, dep.getSpec().getTemplate().getSpec().getContainers().get(0).getPorts().get(0).getName());
+        assertEquals("TCP", dep.getSpec().getTemplate().getSpec().getContainers().get(0).getPorts().get(0).getProtocol());
+    }
+
+    @Test
+    public void testPatchDeployment()   {
+        Deployment orig = KafkaConnectCluster.fromConfigMap(true, ResourceUtils.createEmptyKafkaConnectClusterConfigMap(namespace, cluster)).generateDeployment();
+        orig.getMetadata().setLabels(Collections.EMPTY_MAP);
+        orig.getSpec().getTemplate().getMetadata().setLabels(Collections.EMPTY_MAP);
+
+
+        Deployment dep = kc.patchDeployment(orig);
+
+        assertEquals(ResourceUtils.labels(ClusterController.STRIMZI_CLUSTER_LABEL, cluster, ClusterController.STRIMZI_TYPE_LABEL, "kafka-connect", ClusterController.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), dep.getMetadata().getLabels());
+        assertEquals(new Integer(KafkaConnectCluster.DEFAULT_REPLICAS), dep.getSpec().getReplicas());
+        assertEquals(ResourceUtils.labels(ClusterController.STRIMZI_CLUSTER_LABEL, cluster, ClusterController.STRIMZI_TYPE_LABEL, "kafka-connect", ClusterController.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), dep.getSpec().getTemplate().getMetadata().getLabels());
+        assertEquals(new Integer(healthDelay), dep.getSpec().getTemplate().getSpec().getContainers().get(0).getLivenessProbe().getInitialDelaySeconds());
+        assertEquals(new Integer(healthTimeout), dep.getSpec().getTemplate().getSpec().getContainers().get(0).getLivenessProbe().getTimeoutSeconds());
+        assertEquals(new Integer(healthDelay), dep.getSpec().getTemplate().getSpec().getContainers().get(0).getReadinessProbe().getInitialDelaySeconds());
+        assertEquals(new Integer(healthTimeout), dep.getSpec().getTemplate().getSpec().getContainers().get(0).getReadinessProbe().getTimeoutSeconds());
+        assertEquals(getExpectedEnvVars(), dep.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv());
+    }
+}


### PR DESCRIPTION
This PR adds unit tests for Kafka Connect clusters. It uses the same tests as for Kafka Connect S2I clusters only removing the S2I specifics (DeploymentConfigs, ImageStreams and BuildConfigs).