### PR TITLE
Add configurable periodic reconciliation interval

### DIFF
--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterController.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterController.java
@@ -52,6 +52,7 @@ public class ClusterController extends AbstractVerticle {
     private final KubernetesClient client;
     private final Map<String, String> labels;
     private final String namespace;
+    private final long reconciliationInterval;
     private ConfigMapOperations configMapOperations;
     private StatefulSetOperations statefulSetOperations;
     private DeploymentOperations deploymentOperations;
@@ -69,6 +70,7 @@ public class ClusterController extends AbstractVerticle {
 
         this.namespace = config.getNamespace();
         this.labels = config.getLabels();
+        this.reconciliationInterval = config.getReconciliationInterval();
         this.client = new DefaultKubernetesClient();
     }
 
@@ -112,7 +114,7 @@ public class ClusterController extends AbstractVerticle {
                 configMapWatch = res.result();
 
                 log.info("Setting up periodical reconciliation");
-                this.reconcileTimer = vertx.setPeriodic(120000, res2 -> {
+                this.reconcileTimer = vertx.setPeriodic(this.reconciliationInterval, res2 -> {
                     log.info("Triggering periodic reconciliation ...");
                     reconcile();
                 });

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterControllerConfig.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterControllerConfig.java
@@ -7,18 +7,34 @@ public class ClusterControllerConfig {
 
     public static final String STRIMZI_NAMESPACE = "STRIMZI_NAMESPACE";
     public static final String STRIMZI_CONFIGMAP_LABELS = "STRIMZI_CONFIGMAP_LABELS";
+    public static final String STRIMZI_FULL_RECONCILIATION_INTERVAL = "STRIMZI_FULL_RECONCILIATION_INTERVAL";
+
+    private static final long DEFAULT_FULL_RECONCILIATION_INTERVAL = 120000; // in ms (2 minutes)
 
     private Map<String, String> labels;
     private String namespace;
+    private long reconciliationInterval;
 
-    public ClusterControllerConfig(String namespace, Map<String, String> labels) {
+    public ClusterControllerConfig(String namespace, Map<String, String> labels, long reconciliationInterval) {
         this.namespace = namespace;
         this.labels = labels;
+        this.reconciliationInterval = reconciliationInterval;
+    }
+
+    public ClusterControllerConfig(String namespace, Map<String, String> labels) {
+        this(namespace, labels, DEFAULT_FULL_RECONCILIATION_INTERVAL);
     }
 
     public static ClusterControllerConfig fromEnv() {
+
         String namespace = System.getenv(ClusterControllerConfig.STRIMZI_NAMESPACE);
         String stringLabels = System.getenv(ClusterControllerConfig.STRIMZI_CONFIGMAP_LABELS);
+        long reconciliationInterval = DEFAULT_FULL_RECONCILIATION_INTERVAL;
+
+        String reconciliationIntervalEnvVar = System.getenv(ClusterControllerConfig.STRIMZI_FULL_RECONCILIATION_INTERVAL);
+        if (reconciliationIntervalEnvVar != null) {
+            reconciliationInterval = Long.valueOf(reconciliationIntervalEnvVar);
+        }
 
         Map<String, String> labelsMap = new HashMap<>();
 
@@ -28,7 +44,7 @@ public class ClusterControllerConfig {
             labelsMap.put(fields[0].trim(), fields[1].trim());
         }
 
-        return new ClusterControllerConfig(namespace, labelsMap);
+        return new ClusterControllerConfig(namespace, labelsMap, reconciliationInterval);
     }
 
     public Map<String, String> getLabels() {
@@ -45,5 +61,13 @@ public class ClusterControllerConfig {
 
     public void setNamespace(String namespace) {
         this.namespace = namespace;
+    }
+
+    public long getReconciliationInterval() {
+        return reconciliationInterval;
+    }
+
+    public void setReconciliationInterval(long reconciliationInterval) {
+        this.reconciliationInterval = reconciliationInterval;
     }
 }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterControllerConfig.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterControllerConfig.java
@@ -12,7 +12,7 @@ public class ClusterControllerConfig {
     public static final String STRIMZI_CONFIGMAP_LABELS = "STRIMZI_CONFIGMAP_LABELS";
     public static final String STRIMZI_FULL_RECONCILIATION_INTERVAL = "STRIMZI_FULL_RECONCILIATION_INTERVAL";
 
-    private static final long DEFAULT_FULL_RECONCILIATION_INTERVAL = 120000; // in ms (2 minutes)
+    private static final long DEFAULT_FULL_RECONCILIATION_INTERVAL = 120_000; // in ms (2 minutes)
 
     private Map<String, String> labels;
     private String namespace;
@@ -42,17 +42,18 @@ public class ClusterControllerConfig {
     }
 
     /**
-     * Loads configuration parameters from related environment variables
+     * Loads configuration parameters from a related map
      *
+     * @param map   map from which loading configuration parameters
      * @return  Cluster Controller configuration instance
      */
-    public static ClusterControllerConfig fromEnv() {
+    public static ClusterControllerConfig fromMap(Map<String, String> map) {
 
-        String namespace = System.getenv(ClusterControllerConfig.STRIMZI_NAMESPACE);
-        String stringLabels = System.getenv(ClusterControllerConfig.STRIMZI_CONFIGMAP_LABELS);
-        long reconciliationInterval = DEFAULT_FULL_RECONCILIATION_INTERVAL;
+        String namespace = map.get(ClusterControllerConfig.STRIMZI_NAMESPACE);
+        String stringLabels = map.get(ClusterControllerConfig.STRIMZI_CONFIGMAP_LABELS);
+        Long reconciliationInterval = DEFAULT_FULL_RECONCILIATION_INTERVAL;
 
-        String reconciliationIntervalEnvVar = System.getenv(ClusterControllerConfig.STRIMZI_FULL_RECONCILIATION_INTERVAL);
+        String reconciliationIntervalEnvVar = map.get(ClusterControllerConfig.STRIMZI_FULL_RECONCILIATION_INTERVAL);
         if (reconciliationIntervalEnvVar != null) {
             reconciliationInterval = Long.valueOf(reconciliationIntervalEnvVar);
         }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterControllerConfig.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterControllerConfig.java
@@ -3,6 +3,9 @@ package io.strimzi.controller.cluster;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Cluster Controller configuration
+ */
 public class ClusterControllerConfig {
 
     public static final String STRIMZI_NAMESPACE = "STRIMZI_NAMESPACE";
@@ -15,16 +18,34 @@ public class ClusterControllerConfig {
     private String namespace;
     private long reconciliationInterval;
 
+    /**
+     * Constructor
+     *
+     * @param namespace namespace in which the controller will run and create resources
+     * @param labels    labels used for watching the cluster ConfigMap
+     * @param reconciliationInterval    specify every how many milliseconds the reconciliation runs
+     */
     public ClusterControllerConfig(String namespace, Map<String, String> labels, long reconciliationInterval) {
         this.namespace = namespace;
         this.labels = labels;
         this.reconciliationInterval = reconciliationInterval;
     }
 
+    /**
+     * Constructor which provide a configuration with a default (120000 ms) reconciliation interval
+     *
+     * @param namespace namespace in which the controller will run and create resources
+     * @param labels    labels used for watching the cluster ConfigMap
+     */
     public ClusterControllerConfig(String namespace, Map<String, String> labels) {
         this(namespace, labels, DEFAULT_FULL_RECONCILIATION_INTERVAL);
     }
 
+    /**
+     * Loads configuration parameters from related environment variables
+     *
+     * @return  Cluster Controller configuration instance
+     */
     public static ClusterControllerConfig fromEnv() {
 
         String namespace = System.getenv(ClusterControllerConfig.STRIMZI_NAMESPACE);
@@ -47,27 +68,60 @@ public class ClusterControllerConfig {
         return new ClusterControllerConfig(namespace, labelsMap, reconciliationInterval);
     }
 
+    /**
+     * @return  labels used for watching the cluster ConfigMap
+     */
     public Map<String, String> getLabels() {
         return labels;
     }
 
+    /**
+     * Set the labels used for watching the cluster ConfigMap
+     *
+     * @param labels    labels used for watching the cluster ConfigMap
+     */
     public void setLabels(Map<String, String> labels) {
         this.labels = labels;
     }
 
+    /**
+     * @return  namespace in which the controller runs and creates resources
+     */
     public String getNamespace() {
         return namespace;
     }
 
+    /**
+     * Set the namespace in which the controller runs and creates resources
+     *
+     * @param namespace namespace in which the controller runs and creates resources
+     */
     public void setNamespace(String namespace) {
         this.namespace = namespace;
     }
 
+    /**
+     * @return  how many milliseconds the reconciliation runs
+     */
     public long getReconciliationInterval() {
         return reconciliationInterval;
     }
 
+    /**
+     * Set how many milliseconds the reconciliation runs
+     *
+     * @param reconciliationInterval    how many milliseconds the reconciliation runs
+     */
     public void setReconciliationInterval(long reconciliationInterval) {
         this.reconciliationInterval = reconciliationInterval;
+    }
+
+    @Override
+    public String toString() {
+        return "ClusterControllerConfig(" +
+                "namespace=" + namespace +
+                ",labels=" + labels +
+                ",reconciliationInterval=" + reconciliationInterval +
+                ")";
     }
 }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterControllerConfig.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterControllerConfig.java
@@ -12,7 +12,7 @@ public class ClusterControllerConfig {
     public static final String STRIMZI_CONFIGMAP_LABELS = "STRIMZI_CONFIGMAP_LABELS";
     public static final String STRIMZI_FULL_RECONCILIATION_INTERVAL = "STRIMZI_FULL_RECONCILIATION_INTERVAL";
 
-    private static final long DEFAULT_FULL_RECONCILIATION_INTERVAL = 120_000; // in ms (2 minutes)
+    public static final long DEFAULT_FULL_RECONCILIATION_INTERVAL = 120_000; // in ms (2 minutes)
 
     private Map<String, String> labels;
     private String namespace;
@@ -50,7 +50,13 @@ public class ClusterControllerConfig {
     public static ClusterControllerConfig fromMap(Map<String, String> map) {
 
         String namespace = map.get(ClusterControllerConfig.STRIMZI_NAMESPACE);
+        if (namespace == null) {
+            throw new IllegalArgumentException("Namespace cannot be null");
+        }
         String stringLabels = map.get(ClusterControllerConfig.STRIMZI_CONFIGMAP_LABELS);
+        if (stringLabels == null) {
+            throw new IllegalArgumentException("Labels to watch cannot be null");
+        }
         Long reconciliationInterval = DEFAULT_FULL_RECONCILIATION_INTERVAL;
 
         String reconciliationIntervalEnvVar = map.get(ClusterControllerConfig.STRIMZI_FULL_RECONCILIATION_INTERVAL);

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/Main.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/Main.java
@@ -10,7 +10,7 @@ public class Main {
     public static void main(String args[]) {
         try {
             Vertx vertx = Vertx.vertx();
-            vertx.deployVerticle(new ClusterController(ClusterControllerConfig.fromEnv()), res -> {
+            vertx.deployVerticle(new ClusterController(ClusterControllerConfig.fromMap(System.getenv())), res -> {
                 if (res.succeeded())    {
                     log.info("Cluster Controller verticle started");
                 }

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/ClusterControllerConfigTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/ClusterControllerConfigTest.java
@@ -1,0 +1,52 @@
+package io.strimzi.controller.cluster;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+
+import static org.junit.Assert.assertEquals;
+
+public class ClusterControllerConfigTest {
+
+    private static Map<String, String> labels = new HashMap<>(1);
+
+    static {
+        labels.put("strimzi.io/kind", "cluster");
+    }
+
+    @Test
+    public void testDefaultConfig() {
+        ClusterControllerConfig config = new ClusterControllerConfig("namespace", labels);
+
+        assertEquals("namespace", config.getNamespace());
+        assertEquals(labels, config.getLabels());
+        assertEquals(120_000, config.getReconciliationInterval());
+    }
+
+    @Test
+    public void testReconciliationInterval() {
+
+        ClusterControllerConfig config = new ClusterControllerConfig("namespace", labels, 60000);
+
+        assertEquals("namespace", config.getNamespace());
+        assertEquals(labels, config.getLabels());
+        assertEquals(60_000, config.getReconciliationInterval());
+    }
+
+    @Test
+    public void testEnvVars() {
+
+        Map<String, String> envVars = new HashMap<>(2);
+        envVars.put(ClusterControllerConfig.STRIMZI_NAMESPACE, "namespace");
+        envVars.put(ClusterControllerConfig.STRIMZI_CONFIGMAP_LABELS, "strimzi.io/kind=cluster");
+        envVars.put(ClusterControllerConfig.STRIMZI_FULL_RECONCILIATION_INTERVAL, "30000");
+
+        ClusterControllerConfig config = ClusterControllerConfig.fromMap(envVars);
+
+        assertEquals("namespace", config.getNamespace());
+        assertEquals(labels, config.getLabels());
+        assertEquals(30_000, config.getReconciliationInterval());
+    }
+}

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/ClusterControllerConfigTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/ClusterControllerConfigTest.java
@@ -2,6 +2,7 @@ package io.strimzi.controller.cluster;
 
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -11,18 +12,24 @@ import static org.junit.Assert.assertEquals;
 public class ClusterControllerConfigTest {
 
     private static Map<String, String> labels = new HashMap<>(1);
+    private static Map<String, String> envVars = new HashMap<>(3);
 
     static {
         labels.put("strimzi.io/kind", "cluster");
+
+        envVars.put(ClusterControllerConfig.STRIMZI_NAMESPACE, "namespace");
+        envVars.put(ClusterControllerConfig.STRIMZI_CONFIGMAP_LABELS, "strimzi.io/kind=cluster");
+        envVars.put(ClusterControllerConfig.STRIMZI_FULL_RECONCILIATION_INTERVAL, "30000");
     }
 
     @Test
     public void testDefaultConfig() {
+
         ClusterControllerConfig config = new ClusterControllerConfig("namespace", labels);
 
         assertEquals("namespace", config.getNamespace());
         assertEquals(labels, config.getLabels());
-        assertEquals(120_000, config.getReconciliationInterval());
+        assertEquals(ClusterControllerConfig.DEFAULT_FULL_RECONCILIATION_INTERVAL, config.getReconciliationInterval());
     }
 
     @Test
@@ -38,15 +45,48 @@ public class ClusterControllerConfigTest {
     @Test
     public void testEnvVars() {
 
-        Map<String, String> envVars = new HashMap<>(2);
-        envVars.put(ClusterControllerConfig.STRIMZI_NAMESPACE, "namespace");
-        envVars.put(ClusterControllerConfig.STRIMZI_CONFIGMAP_LABELS, "strimzi.io/kind=cluster");
-        envVars.put(ClusterControllerConfig.STRIMZI_FULL_RECONCILIATION_INTERVAL, "30000");
-
         ClusterControllerConfig config = ClusterControllerConfig.fromMap(envVars);
 
         assertEquals("namespace", config.getNamespace());
         assertEquals(labels, config.getLabels());
         assertEquals(30_000, config.getReconciliationInterval());
+    }
+
+    @Test
+    public void testEnvVarsDefault() {
+
+        Map<String, String> envVars = new HashMap<>(2);
+        envVars.put(ClusterControllerConfig.STRIMZI_NAMESPACE, "namespace");
+        envVars.put(ClusterControllerConfig.STRIMZI_CONFIGMAP_LABELS, "strimzi.io/kind=cluster");
+
+        ClusterControllerConfig config = ClusterControllerConfig.fromMap(envVars);
+
+        assertEquals("namespace", config.getNamespace());
+        assertEquals(labels, config.getLabels());
+        assertEquals(ClusterControllerConfig.DEFAULT_FULL_RECONCILIATION_INTERVAL, config.getReconciliationInterval());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNoNamespace() {
+
+        Map<String, String> envVars = new HashMap<>(1);
+        envVars.put(ClusterControllerConfig.STRIMZI_CONFIGMAP_LABELS, "strimzi.io/kind=cluster");
+
+        ClusterControllerConfig.fromMap(envVars);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNoLabels() {
+
+        Map<String, String> envVars = new HashMap<>(1);
+        envVars.put(ClusterControllerConfig.STRIMZI_NAMESPACE, "namespace");
+
+        ClusterControllerConfig.fromMap(envVars);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testEmptyEnvVars() {
+
+        ClusterControllerConfig.fromMap(Collections.emptyMap());
     }
 }


### PR DESCRIPTION
In my opinion it could make sense trying to factor out some common parts with the `Config` class we have in the topic controller in order to handle configuration in a consistent way across topic and cluster controller.
This PR doesn't do that but just add a new parameter to the current configuration.
A refactoring based on the topic controller `Config` class could be part of a new issue and future PR.
By the way, I'm going to add few summary and comments to the current PR.