### PR TITLE
Add healthcheck for the Topic Controller deployment

### DIFF
--- a/resources/kubernetes/topic-controller.yaml
+++ b/resources/kubernetes/topic-controller.yaml
@@ -76,3 +76,15 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          livenessProbe:
+            httpGet:
+              path: /healthy
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 30

--- a/resources/openshift/topic-controller-with-template.yaml
+++ b/resources/openshift/topic-controller-with-template.yaml
@@ -111,6 +111,18 @@ objects:
                 valueFrom:
                   fieldRef:
                     fieldPath: metadata.namespace
+            livenessProbe:
+              httpGet:
+                path: /healthy
+                port: 8080
+              initialDelaySeconds: 10
+              periodSeconds: 30
+            readinessProbe:
+              httpGet:
+                path: /ready
+                port: 8080
+              initialDelaySeconds: 10
+              periodSeconds: 30
 ---
 apiVersion: v1
 kind: Template


### PR DESCRIPTION
I left the healtcheck really simple as we have within the cluster controller, so just having an HTTP server set up when the ConfigMap watcher is created successfully.