### PR TITLE
Wait for Zookeeper - Issue #118

### DIFF
--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterController.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterController.java
@@ -72,7 +72,7 @@ public class ClusterController extends AbstractVerticle {
         log.info("Starting ClusterController");
 
         // Configure the executor here, but it is used only in other places
-        getVertx().createSharedWorkerExecutor("kubernetes-ops-pool", 5, TimeUnit.SECONDS.toNanos(120));
+        getVertx().createSharedWorkerExecutor("kubernetes-ops-pool", 10, TimeUnit.SECONDS.toNanos(120));
 
         createConfigMapWatch(res -> {
             if (res.succeeded())    {

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/Main.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/Main.java
@@ -13,6 +13,7 @@ import io.strimzi.controller.cluster.operations.resource.BuildConfigOperations;
 import io.strimzi.controller.cluster.operations.resource.ConfigMapOperations;
 import io.strimzi.controller.cluster.operations.resource.DeploymentConfigOperations;
 import io.strimzi.controller.cluster.operations.resource.DeploymentOperations;
+import io.strimzi.controller.cluster.operations.resource.EndpointOperations;
 import io.strimzi.controller.cluster.operations.resource.ImageStreamOperations;
 import io.strimzi.controller.cluster.operations.resource.PodOperations;
 import io.strimzi.controller.cluster.operations.resource.PvcOperations;
@@ -36,9 +37,10 @@ public class Main {
             PvcOperations pvcOperations = new PvcOperations(vertx, client);
             DeploymentOperations deploymentOperations = new DeploymentOperations(vertx, client);
             PodOperations podOperations = new PodOperations(vertx, client);
+            EndpointOperations endpointOperations = new EndpointOperations(vertx, client);
 
             boolean isOpenShift = Boolean.TRUE.equals(client.isAdaptable(OpenShiftClient.class));
-            KafkaClusterOperations kafkaClusterOperations = new KafkaClusterOperations(vertx, isOpenShift, configMapOperations, serviceOperations, statefulSetOperations, pvcOperations, podOperations);
+            KafkaClusterOperations kafkaClusterOperations = new KafkaClusterOperations(vertx, isOpenShift, configMapOperations, serviceOperations, statefulSetOperations, pvcOperations, podOperations, endpointOperations);
             KafkaConnectClusterOperations kafkaConnectClusterOperations = new KafkaConnectClusterOperations(vertx, isOpenShift, configMapOperations, deploymentOperations, serviceOperations);
 
             DeploymentConfigOperations deploymentConfigOperations = null;

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/Main.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/Main.java
@@ -14,6 +14,7 @@ import io.strimzi.controller.cluster.operations.resource.ConfigMapOperations;
 import io.strimzi.controller.cluster.operations.resource.DeploymentConfigOperations;
 import io.strimzi.controller.cluster.operations.resource.DeploymentOperations;
 import io.strimzi.controller.cluster.operations.resource.ImageStreamOperations;
+import io.strimzi.controller.cluster.operations.resource.PodOperations;
 import io.strimzi.controller.cluster.operations.resource.PvcOperations;
 import io.strimzi.controller.cluster.operations.resource.ServiceOperations;
 import io.strimzi.controller.cluster.operations.resource.StatefulSetOperations;
@@ -34,9 +35,10 @@ public class Main {
             ConfigMapOperations configMapOperations = new ConfigMapOperations(vertx, client);
             PvcOperations pvcOperations = new PvcOperations(vertx, client);
             DeploymentOperations deploymentOperations = new DeploymentOperations(vertx, client);
+            PodOperations podOperations = new PodOperations(vertx, client);
 
             boolean isOpenShift = Boolean.TRUE.equals(client.isAdaptable(OpenShiftClient.class));
-            KafkaClusterOperations kafkaClusterOperations = new KafkaClusterOperations(vertx, isOpenShift, configMapOperations, serviceOperations, statefulSetOperations, pvcOperations);
+            KafkaClusterOperations kafkaClusterOperations = new KafkaClusterOperations(vertx, isOpenShift, configMapOperations, serviceOperations, statefulSetOperations, pvcOperations, podOperations);
             KafkaConnectClusterOperations kafkaConnectClusterOperations = new KafkaConnectClusterOperations(vertx, isOpenShift, configMapOperations, deploymentOperations, serviceOperations);
 
             DeploymentConfigOperations deploymentConfigOperations = null;

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperations.java
@@ -143,12 +143,12 @@ public class KafkaClusterOperations extends AbstractClusterOperations<KafkaClust
 
                     return CompositeFuture.join(waitPodResult);
                 })
-                    .compose(res -> {
-                        List<Future> waitServiceResult = new ArrayList<>(1);
-                        waitServiceResult.add(serviceOperations.waitUntilReady(namespace, zk.getName(), 60, TimeUnit.SECONDS));
-                        waitServiceResult.add(serviceOperations.waitUntilReady(namespace, zk.getHeadlessName(), 60, TimeUnit.SECONDS));
-                        return CompositeFuture.join(waitServiceResult);
-                    })
+                .compose(res -> {
+                    List<Future> waitServiceResult = new ArrayList<>(2);
+                    waitServiceResult.add(serviceOperations.waitUntilReady(namespace, zk.getName(), 60, TimeUnit.SECONDS));
+                    waitServiceResult.add(serviceOperations.waitUntilReady(namespace, zk.getHeadlessName(), 60, TimeUnit.SECONDS));
+                    return CompositeFuture.join(waitServiceResult);
+                })
                 .compose(res -> {
                     fut.complete();
                 }, fut);

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperations.java
@@ -138,7 +138,8 @@ public class KafkaClusterOperations extends AbstractClusterOperations<KafkaClust
                     List<Future> waitPodResult = new ArrayList<>(zk.getReplicas());
 
                     for (int i = 0; i < zk.getReplicas(); i++) {
-                        waitPodResult.add(podOperations.waitUntilReady(namespace, zk.getName() + "-" + i, 60, TimeUnit.SECONDS));
+                        String podName = zk.getName() + "-" + i;
+                        waitPodResult.add(podOperations.waitUntilReady(namespace, podName, 60, TimeUnit.SECONDS));
                     }
 
                     return CompositeFuture.join(waitPodResult);

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/resource/EndpointOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/resource/EndpointOperations.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.controller.cluster.operations.resource;
+
+import io.fabric8.kubernetes.api.model.DoneableEndpoints;
+import io.fabric8.kubernetes.api.model.DoneableService;
+import io.fabric8.kubernetes.api.model.Endpoints;
+import io.fabric8.kubernetes.api.model.EndpointsList;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.vertx.core.Vertx;
+
+/**
+ * Operations for {@code Endpoint}s.
+ */
+public class EndpointOperations extends AbstractOperations<KubernetesClient, Endpoints, EndpointsList, DoneableEndpoints, Resource<Endpoints, DoneableEndpoints>> {
+    /**
+     * Constructor
+     * @param vertx The Vertx instance
+     * @param client The Kubernetes client
+     */
+    public EndpointOperations(Vertx vertx, KubernetesClient client) {
+        super(vertx, client, "Endpoints");
+    }
+
+    @Override
+    protected MixedOperation<Endpoints, EndpointsList, DoneableEndpoints, Resource<Endpoints, DoneableEndpoints>> operation() {
+        return client.endpoints();
+    }
+}

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/resource/TimeoutException.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/resource/TimeoutException.java
@@ -1,0 +1,7 @@
+package io.strimzi.controller.cluster.operations.resource;
+
+/**
+ * Thrown to indicate that timeout has been exceeded.
+ */
+public class TimeoutException extends RuntimeException {
+}

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/resource/TimeoutException.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/resource/TimeoutException.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2017-2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
 package io.strimzi.controller.cluster.operations.resource;
 
 /**

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/AbstractCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/AbstractCluster.java
@@ -322,11 +322,16 @@ public abstract class AbstractCluster {
     }
 
     protected Service createHeadlessService(String name, List<ServicePort> ports) {
+        return createHeadlessService(name, ports, Collections.EMPTY_MAP);
+    }
+
+    protected Service createHeadlessService(String name, List<ServicePort> ports, Map<String, String> annotations) {
         Service service = new ServiceBuilder()
                 .withNewMetadata()
                     .withName(name)
                     .withLabels(getLabelsWithName(name))
                     .withNamespace(namespace)
+                    .withAnnotations(annotations)
                 .endMetadata()
                 .withNewSpec()
                     .withType("ClusterIP")

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/ZookeeperCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/ZookeeperCluster.java
@@ -266,8 +266,8 @@ public class ZookeeperCluster extends AbstractCluster {
     }
 
     public Service generateHeadlessService() {
-
-        return createHeadlessService(headlessName, getServicePortList());
+        Map<String, String> annotations = Collections.singletonMap("service.alpha.kubernetes.io/tolerate-unready-endpoints", "true");
+        return createHeadlessService(headlessName, getServicePortList(), annotations);
     }
 
     public Service patchHeadlessService(Service svc) {

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperationsTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperationsTest.java
@@ -10,6 +10,7 @@ import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.extensions.StatefulSet;
 import io.strimzi.controller.cluster.ResourceUtils;
 import io.strimzi.controller.cluster.operations.resource.ConfigMapOperations;
+import io.strimzi.controller.cluster.operations.resource.PodOperations;
 import io.strimzi.controller.cluster.operations.resource.PvcOperations;
 import io.strimzi.controller.cluster.operations.resource.ServiceOperations;
 import io.strimzi.controller.cluster.operations.resource.StatefulSetOperations;
@@ -135,6 +136,7 @@ public class KafkaClusterOperationsTest {
         ServiceOperations mockServiceOps = mock(ServiceOperations.class);
         StatefulSetOperations mockSsOps = mock(StatefulSetOperations.class);
         PvcOperations mockPvcOps = mock(PvcOperations.class);
+        PodOperations mockPodOps = mock(PodOperations.class);
 
         // Create a CM
         String clusterCmName = clusterCm.getMetadata().getName();
@@ -154,7 +156,7 @@ public class KafkaClusterOperationsTest {
         KafkaClusterOperations ops = new KafkaClusterOperations(vertx, openShift,
                 mockCmOps,
                 mockServiceOps, mockSsOps,
-                mockPvcOps);
+                mockPvcOps, mockPodOps);
 
         // Now try to create a KafkaCluster based on this CM
         Async async = context.async();

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperationsTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperationsTest.java
@@ -384,6 +384,7 @@ public class KafkaClusterOperationsTest {
         StatefulSetOperations mockSsOps = mock(StatefulSetOperations.class);
         PvcOperations mockPvcOps = mock(PvcOperations.class);
         PodOperations mockPodOps = mock(PodOperations.class);
+        EndpointOperations mockEndpointOps = mock(EndpointOperations.class);
 
         String clusterCmName = clusterCm.getMetadata().getName();
         String clusterCmNamespace = clusterCm.getMetadata().getNamespace();
@@ -461,7 +462,7 @@ public class KafkaClusterOperationsTest {
         KafkaClusterOperations ops = new KafkaClusterOperations(vertx, openShift,
                 mockCmOps,
                 mockServiceOps, mockSsOps,
-                mockPvcOps, mockPodOps);
+                mockPvcOps, mockPodOps, mockEndpointOps);
 
         // Now try to create a KafkaCluster based on this CM
         Async async = context.async();
@@ -547,6 +548,7 @@ public class KafkaClusterOperationsTest {
         StatefulSetOperations mockSsOps = mock(StatefulSetOperations.class);
         PvcOperations mockPvcOps = mock(PvcOperations.class);
         PodOperations mockPodOps = mock(PodOperations.class);
+        EndpointOperations mockEndpointOps = mock(EndpointOperations.class);
 
         String clusterCmName = clusterCm.getMetadata().getName();
         String clusterCmNamespace = clusterCm.getMetadata().getNamespace();
@@ -569,7 +571,7 @@ public class KafkaClusterOperationsTest {
         KafkaClusterOperations ops = new KafkaClusterOperations(vertx, openShift,
                 mockCmOps,
                 mockServiceOps, mockSsOps,
-                mockPvcOps, mockPodOps) {
+                mockPvcOps, mockPodOps, mockEndpointOps) {
             @Override
             public void create(String namespace, String name) {
                 created.add(name);

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/resource/EndpointOperationsMockTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/resource/EndpointOperationsMockTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.controller.cluster.operations.resource;
+
+import io.fabric8.kubernetes.api.model.DoneableEndpoints;
+import io.fabric8.kubernetes.api.model.DoneableService;
+import io.fabric8.kubernetes.api.model.Endpoints;
+import io.fabric8.kubernetes.api.model.EndpointsBuilder;
+import io.fabric8.kubernetes.api.model.EndpointsList;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceBuilder;
+import io.fabric8.kubernetes.api.model.ServiceList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.vertx.core.Vertx;
+
+import static org.mockito.Mockito.when;
+
+public class EndpointOperationsMockTest extends ResourceOperationsMockTest<KubernetesClient, Endpoints, EndpointsList, DoneableEndpoints, Resource<Endpoints, DoneableEndpoints>> {
+
+    @Override
+    protected Class<KubernetesClient> clientType() {
+        return KubernetesClient.class;
+    }
+
+    @Override
+    protected Class<Resource> resourceType() {
+        return Resource.class;
+    }
+
+    @Override
+    protected Endpoints resource() {
+        return new EndpointsBuilder().withNewMetadata().withNamespace(NAMESPACE).withName(RESOURCE_NAME).endMetadata().build();
+    }
+
+    @Override
+    protected void mocker(KubernetesClient mockClient, MixedOperation op) {
+        when(mockClient.endpoints()).thenReturn(op);
+    }
+
+    @Override
+    protected EndpointOperations createResourceOperations(Vertx vertx, KubernetesClient mockClient) {
+        return new EndpointOperations(vertx, mockClient);
+    }
+}

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/resource/ResourceOperationsMockTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/resource/ResourceOperationsMockTest.java
@@ -23,8 +23,10 @@ import org.junit.runner.RunWith;
 
 import java.util.concurrent.TimeUnit;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -318,6 +320,7 @@ public abstract class ResourceOperationsMockTest<C extends KubernetesClient, T e
         Future<Void> fut = op.waitUntilReady(NAMESPACE, RESOURCE_NAME, 2, TimeUnit.SECONDS);
         fut.setHandler(ar -> {
             assertTrue(ar.failed());
+            assertThat(ar.cause(), instanceOf(TimeoutException.class));
             verify(mockResource, atLeastOnce()).get();
             verify(mockResource, never()).isReady();
             async.complete();
@@ -346,6 +349,7 @@ public abstract class ResourceOperationsMockTest<C extends KubernetesClient, T e
         Async async = context.async();
         op.waitUntilReady(NAMESPACE, RESOURCE_NAME, 2, TimeUnit.SECONDS).setHandler(ar -> {
             assertTrue(ar.failed());
+            assertThat(ar.cause(), instanceOf(TimeoutException.class));
             verify(mockResource, never()).isReady();
             async.complete();
         });
@@ -407,6 +411,7 @@ public abstract class ResourceOperationsMockTest<C extends KubernetesClient, T e
         Async async = context.async();
         op.waitUntilReady(NAMESPACE, RESOURCE_NAME, 2, TimeUnit.SECONDS).setHandler(ar -> {
             assertTrue(ar.failed());
+            assertThat(ar.cause(), instanceOf(TimeoutException.class));
             verify(mockResource, atLeastOnce()).get();
             verify(mockResource, atLeastOnce()).isReady();
             async.complete();
@@ -441,6 +446,7 @@ public abstract class ResourceOperationsMockTest<C extends KubernetesClient, T e
         Async async = context.async();
         op.waitUntilReady(NAMESPACE, RESOURCE_NAME, 2, TimeUnit.SECONDS).setHandler(ar -> {
             assertTrue(ar.failed());
+            assertThat(ar.cause(), instanceOf(TimeoutException.class));
             async.complete();
         });
     }

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/resources/KafkaClusterTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/resources/KafkaClusterTest.java
@@ -46,9 +46,11 @@ public class KafkaClusterTest {
     private void checkService(Service headful) {
         assertEquals("ClusterIP", headful.getSpec().getType());
         assertEquals(ResourceUtils.labels("strimzi.io/cluster", cluster, "strimzi.io/type", "kafka", "strimzi.io/kind", "cluster", "strimzi.io/name", cluster + "-kafka"), headful.getSpec().getSelector());
-        assertEquals(1, headful.getSpec().getPorts().size());
-        assertEquals("clients", headful.getSpec().getPorts().get(0).getName());
-        assertEquals(new Integer(9092), headful.getSpec().getPorts().get(0).getPort());
+        assertEquals(2, headful.getSpec().getPorts().size());
+        assertEquals(KafkaCluster.CLIENT_PORT_NAME, headful.getSpec().getPorts().get(0).getName());
+        assertEquals(new Integer(KafkaCluster.CLIENT_PORT), headful.getSpec().getPorts().get(0).getPort());
+        assertEquals(KafkaCluster.REPLICATION_PORT_NAME, headful.getSpec().getPorts().get(1).getName());
+        assertEquals(new Integer(KafkaCluster.REPLICATION_PORT), headful.getSpec().getPorts().get(1).getPort());
         assertEquals("TCP", headful.getSpec().getPorts().get(0).getProtocol());
     }
 
@@ -63,9 +65,11 @@ public class KafkaClusterTest {
         assertEquals("ClusterIP", headless.getSpec().getType());
         assertEquals("None", headless.getSpec().getClusterIP());
         assertEquals(labels("strimzi.io/cluster", cluster, "strimzi.io/type", "kafka", "strimzi.io/kind", "cluster", "strimzi.io/name", KafkaCluster.kafkaClusterName(cluster)), headless.getSpec().getSelector());
-        assertEquals(1, headless.getSpec().getPorts().size());
-        assertEquals("clients", headless.getSpec().getPorts().get(0).getName());
-        assertEquals(new Integer(9092), headless.getSpec().getPorts().get(0).getPort());
+        assertEquals(2, headless.getSpec().getPorts().size());
+        assertEquals(KafkaCluster.CLIENT_PORT_NAME, headless.getSpec().getPorts().get(0).getName());
+        assertEquals(new Integer(KafkaCluster.CLIENT_PORT), headless.getSpec().getPorts().get(0).getPort());
+        assertEquals(KafkaCluster.REPLICATION_PORT_NAME, headless.getSpec().getPorts().get(1).getName());
+        assertEquals(new Integer(KafkaCluster.REPLICATION_PORT), headless.getSpec().getPorts().get(1).getPort());
         assertEquals("TCP", headless.getSpec().getPorts().get(0).getProtocol());
     }
 

--- a/docker-images/kafka/Dockerfile
+++ b/docker-images/kafka/Dockerfile
@@ -1,6 +1,6 @@
 FROM strimzi/kafka-base:latest
 
-EXPOSE 9092
+EXPOSE 9091 9092
 
 # copy configuration files
 COPY ./config/ $KAFKA_HOME/config/


### PR DESCRIPTION
This PR makes sure that Kafka is deployed only after Zookeeper is in the ready state. After creating Zookeeper, it first checks:
- Readiness of the StatefulSet
- Readiness of all Zookeeper pods
- Readiness of all services

In order to make the Zookeeper cluster bootstrapping more efficient, it configures the headless Zookeeper service to expose Pods even when they are not ready. It also increases the number of worker threads because the number of parallel operations increased.

This PR also adds to all Kubernetes operations  new `waitUntilReady` method which is used to detect readiness.

The timeouts as well as number of worker threads should become configurable - this will be done later in separate PR.