### PR TITLE
Checkstyle

### DIFF
--- a/.checkstyle/checkstyle.xml
+++ b/.checkstyle/checkstyle.xml
@@ -117,8 +117,8 @@
         </module>
     </module>
 
-    <!--<module name="SuppressionFilter">
-        <property name="file" value="checkstyle/suppressions.xml"/>
-    </module>-->
+    <module name="SuppressionFilter">
+        <property name="file" value="${checkstyle.suppressions.file}"/>
+    </module>
 </module>
 

--- a/.checkstyle/checkstyle.xml
+++ b/.checkstyle/checkstyle.xml
@@ -4,9 +4,121 @@
         "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
 
 <module name = "Checker">
+
+    <property name="localeLanguage" value="en"/>
+
+    <module name="FileTabCharacter"/>
+
+    <!-- header -->
     <module name="RegexpHeader">
         <property name="headerFile" value="${checkstyle.header.file}"/>
         <property name="fileExtensions" value="java"/>
     </module>
+
+    <module name="TreeWalker">
+
+        <!-- code cleanup -->
+        <module name="UnusedImports">
+            <property name="processJavadoc" value="true" />
+        </module>
+        <module name="RedundantImport"/>
+        <module name="IllegalImport" />
+        <module name="EqualsHashCode"/>
+        <module name="SimplifyBooleanExpression"/>
+        <module name="OneStatementPerLine"/>
+        <module name="UnnecessaryParentheses" />
+        <module name="SimplifyBooleanReturn"/>
+
+        <!-- style -->
+        <module name="DefaultComesLast"/>
+        <module name="EmptyStatement"/>
+        <module name="ArrayTypeStyle"/>
+        <module name="UpperEll"/>
+        <module name="LeftCurly"/>
+        <module name="RightCurly"/>
+        <module name="EmptyStatement"/>
+        <module name="ConstantName">
+            <property name="format" value="(^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$)|(^log$)"/>
+        </module>
+        <module name="LocalVariableName"/>
+        <module name="LocalFinalVariableName"/>
+        <module name="MemberName"/>
+        <module name="ClassTypeParameterName">
+            <property name="format" value="^[A-Z][a-zA-Z0-9]*$$"/>
+        </module>
+        <module name="MethodTypeParameterName">
+            <property name="format" value="^[A-Z][a-zA-Z0-9]*$$"/>
+        </module>
+        <module name="InterfaceTypeParameterName">
+            <property name="format" value="^[A-Z][a-zA-Z0-9]*$$"/>
+        </module>
+        <module name="PackageName"/>
+        <module name="ParameterName"/>
+        <module name="StaticVariableName"/>
+        <module name="TypeName"/>
+        <module name="AvoidStarImport"/>
+
+        <!-- dependencies -->
+        <!--<module name="ImportControl">
+            <property name="file" value="${importControlFile}"/>
+        </module>-->
+
+        <!-- whitespace -->
+        <module name="GenericWhitespace"/>
+        <module name="NoWhitespaceBefore"/>
+        <module name="WhitespaceAfter" />
+        <module name="NoWhitespaceAfter"/>
+        <module name="WhitespaceAround">
+            <property name="allowEmptyConstructors" value="true"/>
+            <property name="allowEmptyMethods" value="true"/>
+        </module>
+        <module name="Indentation"/>
+        <module name="MethodParamPad"/>
+        <module name="ParenPad"/>
+        <module name="TypecastParenPad"/>
+
+        <!-- locale-sensitive methods should specify locale -->
+        <module name="Regexp">
+            <property name="format" value="\.to(Lower|Upper)Case\(\)"/>
+            <property name="illegalPattern" value="true"/>
+            <property name="ignoreComments" value="true"/>
+        </module>
+
+        <!-- code quality -->
+        <module name="MethodLength"/>
+        <module name="ParameterNumber">
+            <!-- default is 8 -->
+            <property name="max" value="13"/>
+        </module>
+        <module name="ClassDataAbstractionCoupling">
+            <!-- default is 7 -->
+            <property name="max" value="20"/>
+        </module>
+        <module name="BooleanExpressionComplexity">
+            <!-- default is 3 -->
+            <property name="max" value="5"/>
+        </module>
+
+        <module name="ClassFanOutComplexity">
+            <!-- default is 20 -->
+            <property name="max" value="40"/>
+        </module>
+        <module name="CyclomaticComplexity">
+            <!-- default is 10-->
+            <property name="max" value="16"/>
+        </module>
+        <module name="JavaNCSS">
+            <!-- default is 50 -->
+            <property name="methodMaximum" value="100"/>
+        </module>
+        <module name="NPathComplexity">
+            <!-- default is 200 -->
+            <property name="max" value="500"/>
+        </module>
+    </module>
+
+    <!--<module name="SuppressionFilter">
+        <property name="file" value="checkstyle/suppressions.xml"/>
+    </module>-->
 </module>
 

--- a/.checkstyle/suppressions.xml
+++ b/.checkstyle/suppressions.xml
@@ -9,11 +9,11 @@
     <!-- Note that [/\\] must be used as the path separator for cross-platform support -->
 
     <suppress checks="ParameterNumber"
-              files="ResourceUtils.java"/>
+              files="io[/\\]strimzi[/\\]controller[/\\]cluster[/\\]ResourceUtils.java"/>
 
     <suppress checks="MethodLength"
-              files="KafkaClusterOperationsTest.java"/>
+              files="io[/\\]strimzi[/\\]controller[/\\]cluster[/\\]operations[/\\]cluster[/\\]KafkaClusterOperationsTest.java"/>
 
     <suppress checks="NPathComplexity"
-              files="KafkaClusterOperationsTest.java"/>
+              files="io[/\\]strimzi[/\\]controller[/\\]cluster[/\\]operations[/\\]cluster[/\\]KafkaClusterOperationsTest.java"/>
 </suppressions>

--- a/.checkstyle/suppressions.xml
+++ b/.checkstyle/suppressions.xml
@@ -8,12 +8,23 @@
 
     <!-- Note that [/\\] must be used as the path separator for cross-platform support -->
 
+    <!-- cluster-controller -->
     <suppress checks="ParameterNumber"
               files="io[/\\]strimzi[/\\]controller[/\\]cluster[/\\]ResourceUtils.java"/>
 
-    <suppress checks="MethodLength"
+    <suppress checks="MethodLength|NPathComplexity"
               files="io[/\\]strimzi[/\\]controller[/\\]cluster[/\\]operations[/\\]cluster[/\\]KafkaClusterOperationsTest.java"/>
 
-    <suppress checks="NPathComplexity"
-              files="io[/\\]strimzi[/\\]controller[/\\]cluster[/\\]operations[/\\]cluster[/\\]KafkaClusterOperationsTest.java"/>
+    <suppress checks="CyclomaticComplexity|NPathComplexity"
+              files="io[/\\]strimzi[/\\]controller[/\\]cluster[/\\]resources[/\\].*Cluster.java"/>
+
+    <suppress checks="BooleanExpressionComplexity"
+              files="io[/\\]strimzi[/\\]controller[/\\]cluster[/\\]resources[/\\]KafkaConnect(S2I)?Cluster.java"/>
+
+    <!-- topic controller -->
+    <suppress checks="NPathComplexity|CyclomaticComplexity"
+              files="io[/\\]strimzi[/\\]controller[/\\]topic[/\\]Controller.java"/>
+
+    <suppress checks="NPathComplexity|CyclomaticComplexity"
+              files="io[/\\]strimzi[/\\]controller[/\\]topic[/\\]TopicName.java"/>
 </suppressions>

--- a/.checkstyle/suppressions.xml
+++ b/.checkstyle/suppressions.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE suppressions PUBLIC
+        "-//Puppy Crawl//DTD Suppressions 1.1//EN"
+        "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+
+<suppressions>
+
+    <!-- Note that [/\\] must be used as the path separator for cross-platform support -->
+
+    <suppress checks="ParameterNumber"
+              files="ResourceUtils.java"/>
+
+    <suppress checks="MethodLength"
+              files="KafkaClusterOperationsTest.java"/>
+
+    <suppress checks="NPathComplexity"
+              files="KafkaClusterOperationsTest.java"/>
+</suppressions>

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/Main.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/Main.java
@@ -19,14 +19,14 @@ import io.strimzi.controller.cluster.operations.resource.PodOperations;
 import io.strimzi.controller.cluster.operations.resource.PvcOperations;
 import io.strimzi.controller.cluster.operations.resource.ServiceOperations;
 import io.strimzi.controller.cluster.operations.resource.StatefulSetOperations;
-import io.vertx.core.*;
+import io.vertx.core.Vertx;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class Main {
     private static final Logger log = LoggerFactory.getLogger(Main.class.getName());
 
-    public static void main(String args[]) {
+    public static void main(String[] args) {
         try {
             Vertx vertx = Vertx.vertx();
             DefaultKubernetesClient client = new DefaultKubernetesClient();
@@ -57,15 +57,15 @@ public class Main {
 
             ClusterControllerConfig config = ClusterControllerConfig.fromMap(System.getenv());
             vertx.deployVerticle(new ClusterController(config, kafkaClusterOperations,
-                    kafkaConnectClusterOperations, kafkaConnectS2IClusterOperations), res -> {
-                if (res.succeeded())    {
-                    log.info("Cluster Controller verticle started");
-                }
-                else {
-                    log.error("Cluster Controller verticle failed to start", res.cause());
-                    System.exit(1);
-                }
-            });
+                kafkaConnectClusterOperations, kafkaConnectS2IClusterOperations),
+                res -> {
+                    if (res.succeeded())    {
+                        log.info("Cluster Controller verticle started");
+                    } else {
+                        log.error("Cluster Controller verticle failed to start", res.cause());
+                        System.exit(1);
+                    }
+                });
         } catch (IllegalArgumentException e) {
             log.error("Unable to parse arguments", e);
             System.exit(1);

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/AbstractClusterOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/AbstractClusterOperations.java
@@ -4,12 +4,12 @@
  */
 package io.strimzi.controller.cluster.operations.cluster;
 
+import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.strimzi.controller.cluster.ClusterController;
 import io.strimzi.controller.cluster.operations.resource.ConfigMapOperations;
 import io.strimzi.controller.cluster.resources.AbstractCluster;
 import io.strimzi.controller.cluster.resources.ClusterDiffResult;
-import io.strimzi.controller.cluster.resources.KafkaConnectS2ICluster;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/AbstractClusterOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/AbstractClusterOperations.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.controller.cluster.operations.cluster;
 
-import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.strimzi.controller.cluster.ClusterController;
 import io.strimzi.controller.cluster.operations.resource.ConfigMapOperations;
@@ -45,7 +44,7 @@ public abstract class AbstractClusterOperations<C extends AbstractCluster,
     protected static final String OP_DELETE = "delete";
     protected static final String OP_UPDATE = "update";
 
-    protected final int LOCK_TIMEOUT = 60000;
+    protected static final int LOCK_TIMEOUT = 60000;
 
     protected final Vertx vertx;
     protected final boolean isOpenShift;
@@ -68,7 +67,7 @@ public abstract class AbstractClusterOperations<C extends AbstractCluster,
     }
 
     protected final String getLockName(String clusterType, String namespace, String name) {
-        return "lock::"+ clusterType +"::" + namespace + "::" + name;
+        return "lock::" + clusterType + "::" + namespace + "::" + name;
     }
 
     protected static class ClusterOperation<C extends AbstractCluster> {
@@ -132,7 +131,7 @@ public abstract class AbstractClusterOperations<C extends AbstractCluster,
                 });
             } else {
                 log.error("Failed to acquire lock to {} {} cluster {}", operationType, clusterType, lockName);
-                handler.handle(Future.failedFuture("Failed to acquire lock to " + operationType + " "+ clusterType + " cluster"));
+                handler.handle(Future.failedFuture("Failed to acquire lock to " + operationType + " " + clusterType + " cluster"));
             }
         });
     }
@@ -145,8 +144,7 @@ public abstract class AbstractClusterOperations<C extends AbstractCluster,
         create(namespace, name, res -> {
             if (res.succeeded()) {
                 log.info("{} cluster added {}", clusterDescription, name);
-            }
-            else {
+            } else {
                 log.error("Failed to add {} cluster {}.", clusterDescription, name);
             }
         });
@@ -159,8 +157,7 @@ public abstract class AbstractClusterOperations<C extends AbstractCluster,
         delete(namespace, name, res -> {
             if (res.succeeded()) {
                 log.info("{} cluster deleted {} in namespace {}", clusterDescription, name, namespace);
-            }
-            else {
+            } else {
                 log.error("Failed to delete {} cluster {} in namespace {}", clusterDescription, name, namespace);
             }
         });
@@ -174,8 +171,7 @@ public abstract class AbstractClusterOperations<C extends AbstractCluster,
         update(namespace, name, res2 -> {
             if (res2.succeeded()) {
                 log.info("{} cluster updated {}", clusterDescription, name);
-            }
-            else {
+            } else {
                 log.error("Failed to update {} cluster {}.", clusterDescription, name);
             }
         });

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperations.java
@@ -82,12 +82,12 @@ public class KafkaClusterOperations extends AbstractClusterOperations<KafkaClust
     private final CompositeOperation<KafkaCluster> createKafka = new CompositeOperation<KafkaCluster>() {
 
         @Override
-        public ClusterOperation<KafkaCluster> getCluster(String namespace, String name){
+        public ClusterOperation<KafkaCluster> getCluster(String namespace, String name) {
             return new ClusterOperation<>(KafkaCluster.fromConfigMap(configMapOperations.get(namespace, name)), null);
         }
 
         @Override
-        public Future<?> composite(String namespace, ClusterOperation<KafkaCluster> clusterOp){
+        public Future<?> composite(String namespace, ClusterOperation<KafkaCluster> clusterOp) {
             KafkaCluster kafka = clusterOp.cluster();
             List<Future> result = new ArrayList<>(4);
             // start creating configMap operation only if metrics are enabled,
@@ -281,11 +281,10 @@ public class KafkaClusterOperations extends AbstractClusterOperations<KafkaClust
 
 
         private Future<Void> scaleDown(KafkaCluster kafka, String namespace, ClusterDiffResult diff) {
-            if (diff.isScaleDown())    {
+            if (diff.isScaleDown()) {
                 log.info("Scaling down stateful set {} in namespace {}", kafka.getName(), namespace);
                 return statefulSetOperations.scaleDown(namespace, kafka.getName(), kafka.getReplicas());
-            }
-            else {
+            } else {
                 return Future.succeededFuture();
             }
         }
@@ -293,9 +292,7 @@ public class KafkaClusterOperations extends AbstractClusterOperations<KafkaClust
         private Future<Void> patchService(KafkaCluster kafka, String namespace, ClusterDiffResult diff) {
             if (diff.isDifferent()) {
                 return serviceOperations.patch(namespace, kafka.getName(), kafka.patchService(serviceOperations.get(namespace, kafka.getName())));
-            }
-            else
-            {
+            } else {
                 return Future.succeededFuture();
             }
         }
@@ -304,9 +301,7 @@ public class KafkaClusterOperations extends AbstractClusterOperations<KafkaClust
             if (diff.isDifferent()) {
                 return serviceOperations.patch(namespace, kafka.getHeadlessName(),
                         kafka.patchHeadlessService(serviceOperations.get(namespace, kafka.getHeadlessName())));
-            }
-            else
-            {
+            } else {
                 return Future.succeededFuture();
             }
         }
@@ -335,8 +330,7 @@ public class KafkaClusterOperations extends AbstractClusterOperations<KafkaClust
             if (diff.isRollingUpdate()) {
                 statefulSetOperations.rollingUpdate(namespace, kafka.getName(),
                         rollingUpdate.completer());
-            }
-            else {
+            } else {
                 rollingUpdate.complete();
             }
 
@@ -346,8 +340,7 @@ public class KafkaClusterOperations extends AbstractClusterOperations<KafkaClust
         private Future<Void> scaleUp(KafkaCluster kafka, String namespace, ClusterDiffResult diff) {
             if (diff.isScaleUp()) {
                 return statefulSetOperations.scaleUp(namespace, kafka.getName(), kafka.getReplicas());
-            }
-            else {
+            } else {
                 return Future.succeededFuture();
             }
         }
@@ -373,11 +366,10 @@ public class KafkaClusterOperations extends AbstractClusterOperations<KafkaClust
         }
 
         private Future<Void> scaleDown(ZookeeperCluster zk, String namespace, ClusterDiffResult diff) {
-            if (diff.isScaleDown())    {
+            if (diff.isScaleDown()) {
                 log.info("Scaling down stateful set {} in namespace {}", zk.getName(), namespace);
                 return statefulSetOperations.scaleDown(namespace, zk.getName(), zk.getReplicas());
-            }
-            else {
+            } else {
                 return Future.succeededFuture();
             }
         }
@@ -386,9 +378,7 @@ public class KafkaClusterOperations extends AbstractClusterOperations<KafkaClust
             if (diff.isDifferent()) {
                 return serviceOperations.patch(namespace, zk.getName(),
                         zk.patchService(serviceOperations.get(namespace, zk.getName())));
-            }
-            else
-            {
+            } else {
                 return Future.succeededFuture();
             }
         }
@@ -397,9 +387,7 @@ public class KafkaClusterOperations extends AbstractClusterOperations<KafkaClust
             if (diff.isDifferent()) {
                 return serviceOperations.patch(namespace, zk.getHeadlessName(),
                         zk.patchHeadlessService(serviceOperations.get(namespace, zk.getHeadlessName())));
-            }
-            else
-            {
+            } else {
                 return Future.succeededFuture();
             }
         }
@@ -408,9 +396,7 @@ public class KafkaClusterOperations extends AbstractClusterOperations<KafkaClust
             if (diff.isDifferent()) {
                 return statefulSetOperations.patch(namespace, zk.getName(), false,
                         zk.patchStatefulSet(statefulSetOperations.get(namespace, zk.getName())));
-            }
-            else
-            {
+            } else {
                 return Future.succeededFuture();
             }
         }
@@ -430,8 +416,7 @@ public class KafkaClusterOperations extends AbstractClusterOperations<KafkaClust
             if (diff.isRollingUpdate()) {
                 statefulSetOperations.rollingUpdate(namespace, zk.getName(),
                         rollingUpdate.completer());
-            }
-            else {
+            } else {
                 rollingUpdate.complete();
             }
 
@@ -441,8 +426,7 @@ public class KafkaClusterOperations extends AbstractClusterOperations<KafkaClust
         private Future<Void> scaleUp(ZookeeperCluster zk, String namespace, ClusterDiffResult diff) {
             if (diff.isScaleUp()) {
                 return statefulSetOperations.scaleUp(namespace, zk.getName(), zk.getReplicas());
-            }
-            else {
+            } else {
                 return Future.succeededFuture();
             }
         }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperations.java
@@ -27,7 +27,6 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 /**
  * CRUD-style operations on a Kafka cluster

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectClusterOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectClusterOperations.java
@@ -130,8 +130,7 @@ public class KafkaConnectClusterOperations extends AbstractClusterOperations<Kaf
         if (diff.isScaleDown())    {
             log.info("Scaling down deployment {} in namespace {}", connect.getName(), namespace);
             return deploymentOperations.scaleDown(namespace, connect.getName(), connect.getReplicas());
-        }
-        else {
+        } else {
             return Future.succeededFuture();
         }
     }
@@ -139,10 +138,8 @@ public class KafkaConnectClusterOperations extends AbstractClusterOperations<Kaf
     private Future<Void> patchService(KafkaConnectCluster connect, String namespace, ClusterDiffResult diff) {
         if (diff.isDifferent()) {
             return serviceOperations.patch(namespace, connect.getName(),
-                    connect.patchService(serviceOperations.get(namespace, connect.getName())));
-        }
-        else
-        {
+                connect.patchService(serviceOperations.get(namespace, connect.getName())));
+        } else {
             return Future.succeededFuture();
         }
     }
@@ -151,9 +148,7 @@ public class KafkaConnectClusterOperations extends AbstractClusterOperations<Kaf
         if (diff.isDifferent()) {
             return deploymentOperations.patch(namespace, connect.getName(),
                     connect.patchDeployment(deploymentOperations.get(namespace, connect.getName())));
-        }
-        else
-        {
+        } else {
             return Future.succeededFuture();
         }
     }
@@ -161,8 +156,7 @@ public class KafkaConnectClusterOperations extends AbstractClusterOperations<Kaf
     private Future<Void> scaleUp(KafkaConnectCluster connect, String namespace, ClusterDiffResult diff) {
         if (diff.isScaleUp()) {
             return deploymentOperations.scaleUp(namespace, connect.getName(), connect.getReplicas());
-        }
-        else {
+        } else {
             return Future.succeededFuture();
         }
     }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectS2IClusterOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectS2IClusterOperations.java
@@ -182,8 +182,7 @@ public class KafkaConnectS2IClusterOperations extends AbstractClusterOperations<
             if (diff.isScaleDown())    {
                 log.info("Scaling down {} deployment {} in namespace {}", clusterDescription, connect.getName(), namespace);
                 return deploymentConfigOperations.scaleDown(namespace, connect.getName(), connect.getReplicas());
-            }
-            else {
+            } else {
                 return Future.succeededFuture();
             }
         }
@@ -192,9 +191,7 @@ public class KafkaConnectS2IClusterOperations extends AbstractClusterOperations<
             if (diff.isDifferent()) {
                 return serviceOperations.patch(namespace, connect.getName(),
                         connect.patchService(serviceOperations.get(namespace, connect.getName())));
-            }
-            else
-            {
+            } else {
                 return Future.succeededFuture();
             }
         }
@@ -203,9 +200,7 @@ public class KafkaConnectS2IClusterOperations extends AbstractClusterOperations<
             if (diff.isDifferent()) {
                 return deploymentConfigOperations.patch(namespace, connect.getName(),
                         connect.patchDeploymentConfig(deploymentConfigOperations.get(namespace, connect.getName())));
-            }
-            else
-            {
+            } else {
                 return Future.succeededFuture();
             }
         }
@@ -214,9 +209,7 @@ public class KafkaConnectS2IClusterOperations extends AbstractClusterOperations<
             if (diff.isDifferent()) {
                 return buildConfigOperations.patch(namespace, connect.getName(),
                         connect.patchBuildConfig(buildConfigOperations.get(namespace, connect.getName())));
-            }
-            else
-            {
+            } else {
                 return Future.succeededFuture();
             }
         }
@@ -225,9 +218,7 @@ public class KafkaConnectS2IClusterOperations extends AbstractClusterOperations<
             if (diff.isDifferent()) {
                 return imagesStreamOperations.patch(namespace, connect.getSourceImageStreamName(),
                         connect.patchSourceImageStream(imagesStreamOperations.get(namespace, connect.getSourceImageStreamName())));
-            }
-            else
-            {
+            } else {
                 return Future.succeededFuture();
             }
         }
@@ -236,9 +227,7 @@ public class KafkaConnectS2IClusterOperations extends AbstractClusterOperations<
             if (diff.isDifferent()) {
                 return imagesStreamOperations.patch(namespace, connect.getName(),
                         connect.patchTargetImageStream(imagesStreamOperations.get(namespace, connect.getName())));
-            }
-            else
-            {
+            } else {
                 return Future.succeededFuture();
             }
         }
@@ -246,8 +235,7 @@ public class KafkaConnectS2IClusterOperations extends AbstractClusterOperations<
         private Future<Void> scaleUp(KafkaConnectS2ICluster connect, String namespace, ClusterDiffResult diff) {
             if (diff.isScaleUp()) {
                 return deploymentConfigOperations.scaleUp(namespace, connect.getName(), connect.getReplicas());
-            }
-            else {
+            } else {
                 return Future.succeededFuture();
             }
         }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectS2IClusterOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectS2IClusterOperations.java
@@ -8,7 +8,6 @@ import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.openshift.api.model.BuildConfig;
 import io.fabric8.openshift.api.model.DeploymentConfig;
 import io.fabric8.openshift.api.model.ImageStream;
-import io.strimzi.controller.cluster.ClusterController;
 import io.strimzi.controller.cluster.operations.resource.BuildConfigOperations;
 import io.strimzi.controller.cluster.operations.resource.ConfigMapOperations;
 import io.strimzi.controller.cluster.operations.resource.DeploymentConfigOperations;
@@ -25,11 +24,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * CRUD-style operations on a Kafka Connect cluster

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/resource/AbstractScalableOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/resource/AbstractScalableOperations.java
@@ -52,19 +52,18 @@ public abstract class AbstractScalableOperations<C, T extends HasMetadata, L ext
     public Future<Void> scaleUp(String namespace, String name, int scaleTo) {
         Future<Void> fut = Future.future();
         vertx.createSharedWorkerExecutor("kubernetes-ops-pool").executeBlocking(
-                future -> {
-                    try {
-                        log.info("Scaling up to {} replicas", scaleTo);
-                        resource(namespace, name).scale(scaleTo, true);
-                        future.complete();
-                    }
-                    catch (Exception e) {
-                        log.error("Caught exception while scaling up", e);
-                        future.fail(e);
-                    }
-                },
-                false,
-                fut.completer()
+            future -> {
+                try {
+                    log.info("Scaling up to {} replicas", scaleTo);
+                    resource(namespace, name).scale(scaleTo, true);
+                    future.complete();
+                } catch (Exception e) {
+                    log.error("Caught exception while scaling up", e);
+                    future.fail(e);
+                }
+            },
+            false,
+            fut.completer()
         );
         return fut;
     }
@@ -79,37 +78,36 @@ public abstract class AbstractScalableOperations<C, T extends HasMetadata, L ext
     public Future<Void> scaleDown(String namespace, String name, int scaleTo) {
         Future<Void> fut = Future.future();
         vertx.createSharedWorkerExecutor("kubernetes-ops-pool").executeBlocking(
-                future -> {
-                    try {
-                        Object gettable = resource(namespace, name).get();
-                        int nextReplicas;
+            future -> {
+                try {
+                    Object gettable = resource(namespace, name).get();
+                    int nextReplicas;
 
-                        if (gettable instanceof StatefulSet) {
-                            nextReplicas = ((StatefulSet) resource(namespace, name).get()).getSpec().getReplicas();
-                        } else if (gettable instanceof Deployment) {
-                            nextReplicas = ((Deployment) resource(namespace, name).get()).getSpec().getReplicas();
-                        } else if (gettable instanceof DeploymentConfig) {
-                            nextReplicas = ((DeploymentConfig) resource(namespace, name).get()).getSpec().getReplicas();
-                        } else {
-                            future.fail("Unknown resource type: " + gettable.getClass().getCanonicalName());
-                            return;
-                        }
-
-                        while (nextReplicas > scaleTo) {
-                            nextReplicas--;
-                            log.info("Scaling down from {} to {}", nextReplicas+1, nextReplicas);
-                            resource(namespace, name).scale(nextReplicas, true);
-                        }
-
-                        future.complete();
+                    if (gettable instanceof StatefulSet) {
+                        nextReplicas = ((StatefulSet) resource(namespace, name).get()).getSpec().getReplicas();
+                    } else if (gettable instanceof Deployment) {
+                        nextReplicas = ((Deployment) resource(namespace, name).get()).getSpec().getReplicas();
+                    } else if (gettable instanceof DeploymentConfig) {
+                        nextReplicas = ((DeploymentConfig) resource(namespace, name).get()).getSpec().getReplicas();
+                    } else {
+                        future.fail("Unknown resource type: " + gettable.getClass().getCanonicalName());
+                        return;
                     }
-                    catch (Exception e) {
-                        log.error("Caught exception while scaling down", e);
-                        future.fail(e);
+
+                    while (nextReplicas > scaleTo) {
+                        nextReplicas--;
+                        log.info("Scaling down from {} to {}", nextReplicas + 1, nextReplicas);
+                        resource(namespace, name).scale(nextReplicas, true);
                     }
-                },
-                false,
-                fut.completer()
+
+                    future.complete();
+                } catch (Exception e) {
+                    log.error("Caught exception while scaling down", e);
+                    future.fail(e);
+                }
+            },
+            false,
+            fut.completer()
         );
         return fut;
     }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/resource/EndpointOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/resource/EndpointOperations.java
@@ -5,11 +5,8 @@
 package io.strimzi.controller.cluster.operations.resource;
 
 import io.fabric8.kubernetes.api.model.DoneableEndpoints;
-import io.fabric8.kubernetes.api.model.DoneableService;
 import io.fabric8.kubernetes.api.model.Endpoints;
 import io.fabric8.kubernetes.api.model.EndpointsList;
-import io.fabric8.kubernetes.api.model.Service;
-import io.fabric8.kubernetes.api.model.ServiceList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/resource/PvcOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/resource/PvcOperations.java
@@ -33,11 +33,11 @@ public class PvcOperations extends AbstractOperations<KubernetesClient, Persiste
 
     @Override
     public Future<Void> create(PersistentVolumeClaim resource) {
-        throw new UnsupportedOperationException();// should never happen
+        throw new UnsupportedOperationException(); // should never happen
     }
 
     @Override
     public Future<Void> patch(String namespace, String name, PersistentVolumeClaim patch) {
-        throw new UnsupportedOperationException();// should never happen
+        throw new UnsupportedOperationException(); // should never happen
     }
 }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/AbstractCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/AbstractCluster.java
@@ -4,7 +4,32 @@
  */
 package io.strimzi.controller.cluster.resources;
 
-import io.fabric8.kubernetes.api.model.*;
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.api.model.ConfigMapVolumeSource;
+import io.fabric8.kubernetes.api.model.ConfigMapVolumeSourceBuilder;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.ContainerPort;
+import io.fabric8.kubernetes.api.model.ContainerPortBuilder;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaimBuilder;
+import io.fabric8.kubernetes.api.model.PodSecurityContext;
+import io.fabric8.kubernetes.api.model.PodSecurityContextBuilder;
+import io.fabric8.kubernetes.api.model.Probe;
+import io.fabric8.kubernetes.api.model.ProbeBuilder;
+import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceBuilder;
+import io.fabric8.kubernetes.api.model.ServicePort;
+import io.fabric8.kubernetes.api.model.ServicePortBuilder;
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeBuilder;
+import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
 import io.fabric8.kubernetes.api.model.extensions.Deployment;
 import io.fabric8.kubernetes.api.model.extensions.DeploymentBuilder;
 import io.fabric8.kubernetes.api.model.extensions.DeploymentStrategyBuilder;

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/KafkaCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/KafkaCluster.java
@@ -34,9 +34,9 @@ public class KafkaCluster extends AbstractCluster {
     protected static final int REPLICATION_PORT = 9091;
     protected static final String REPLICATION_PORT_NAME = "replication";
 
-    private static String NAME_SUFFIX = "-kafka";
-    private static String HEADLESS_NAME_SUFFIX = NAME_SUFFIX + "-headless";
-    private static String METRICS_CONFIG_SUFFIX = NAME_SUFFIX + "-metrics-config";
+    private static final String NAME_SUFFIX = "-kafka";
+    private static final String HEADLESS_NAME_SUFFIX = NAME_SUFFIX + "-headless";
+    private static final String METRICS_CONFIG_SUFFIX = NAME_SUFFIX + "-metrics-config";
 
     // Kafka configuration
     private String zookeeperConnect = DEFAULT_KAFKA_ZOOKEEPER_CONNECT;
@@ -45,17 +45,17 @@ public class KafkaCluster extends AbstractCluster {
     private int transactionStateLogReplicationFactor = DEFAULT_KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR;
 
     // Configuration defaults
-    private static String DEFAULT_IMAGE = "strimzi/kafka:latest";
-    private static int DEFAULT_REPLICAS = 3;
-    private static int DEFAULT_HEALTHCHECK_DELAY = 15;
-    private static int DEFAULT_HEALTHCHECK_TIMEOUT = 5;
-    private static boolean DEFAULT_KAFKA_METRICS_ENABLED = false;
+    private static final String DEFAULT_IMAGE = "strimzi/kafka:latest";
+    private static final int DEFAULT_REPLICAS = 3;
+    private static final int DEFAULT_HEALTHCHECK_DELAY = 15;
+    private static final int DEFAULT_HEALTHCHECK_TIMEOUT = 5;
+    private static final boolean DEFAULT_KAFKA_METRICS_ENABLED = false;
 
     // Kafka configuration defaults
-    private static String DEFAULT_KAFKA_ZOOKEEPER_CONNECT = "zookeeper:2181";
-    private static int DEFAULT_KAFKA_DEFAULT_REPLICATION_FACTOR = 3;
-    private static int DEFAULT_KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR = 3;
-    private static int DEFAULT_KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR = 3;
+    private static final String DEFAULT_KAFKA_ZOOKEEPER_CONNECT = "zookeeper:2181";
+    private static final int DEFAULT_KAFKA_DEFAULT_REPLICATION_FACTOR = 3;
+    private static final int DEFAULT_KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR = 3;
+    private static final int DEFAULT_KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR = 3;
 
     // Configuration keys
     public static final String KEY_IMAGE = "kafka-image";
@@ -66,11 +66,11 @@ public class KafkaCluster extends AbstractCluster {
     public static final String KEY_STORAGE = "kafka-storage";
 
     // Kafka configuration keys
-    private static String KEY_KAFKA_ZOOKEEPER_CONNECT = "KAFKA_ZOOKEEPER_CONNECT";
-    private static String KEY_KAFKA_DEFAULT_REPLICATION_FACTOR = "KAFKA_DEFAULT_REPLICATION_FACTOR";
-    private static String KEY_KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR = "KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR";
-    private static String KEY_KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR = "KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR";
-    private static String KEY_KAFKA_METRICS_ENABLED = "KAFKA_METRICS_ENABLED";
+    private static final String KEY_KAFKA_ZOOKEEPER_CONNECT = "KAFKA_ZOOKEEPER_CONNECT";
+    private static final String KEY_KAFKA_DEFAULT_REPLICATION_FACTOR = "KAFKA_DEFAULT_REPLICATION_FACTOR";
+    private static final String KEY_KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR = "KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR";
+    private static final String KEY_KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR = "KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR";
+    private static final String KEY_KAFKA_METRICS_ENABLED = "KAFKA_METRICS_ENABLED";
 
     /**
      * Constructor
@@ -208,8 +208,7 @@ public class KafkaCluster extends AbstractCluster {
         if (replicas > ss.getSpec().getReplicas()) {
             log.info("Diff: Expected replicas {}, actual replicas {}", replicas, ss.getSpec().getReplicas());
             scaleUp = true;
-        }
-        else if (replicas < ss.getSpec().getReplicas()) {
+        } else if (replicas < ss.getSpec().getReplicas()) {
             log.info("Diff: Expected replicas {}, actual replicas {}", replicas, ss.getSpec().getReplicas());
             scaleDown = true;
         }
@@ -233,8 +232,7 @@ public class KafkaCluster extends AbstractCluster {
         if (!zookeeperConnect.equals(vars.getOrDefault(KEY_KAFKA_ZOOKEEPER_CONNECT, DEFAULT_KAFKA_ZOOKEEPER_CONNECT))
                 || defaultReplicationFactor != Integer.parseInt(vars.getOrDefault(KEY_KAFKA_DEFAULT_REPLICATION_FACTOR, String.valueOf(DEFAULT_KAFKA_DEFAULT_REPLICATION_FACTOR)))
                 || offsetsTopicReplicationFactor != Integer.parseInt(vars.getOrDefault(KEY_KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR, String.valueOf(DEFAULT_KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR)))
-                || transactionStateLogReplicationFactor != Integer.parseInt(vars.getOrDefault(KEY_KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR, String.valueOf(DEFAULT_KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR)))
-                ) {
+                || transactionStateLogReplicationFactor != Integer.parseInt(vars.getOrDefault(KEY_KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR, String.valueOf(DEFAULT_KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR)))) {
             log.info("Diff: Kafka options changed");
             different = true;
             rollingUpdate = true;
@@ -278,8 +276,8 @@ public class KafkaCluster extends AbstractCluster {
         Storage.StorageDiffResult storageDiffResult = storage.diff(ssStorage);
 
         // check for all the not allowed changes to the storage
-        boolean isStorageRejected = (storageDiffResult.isType() || storageDiffResult.isSize() ||
-                storageDiffResult.isStorageClass() || storageDiffResult.isSelector());
+        boolean isStorageRejected = storageDiffResult.isType() || storageDiffResult.isSize() ||
+                storageDiffResult.isStorageClass() || storageDiffResult.isSelector();
 
         // only delete-claim flag can be changed
         if (!isStorageRejected && (storage.type() == Storage.StorageType.PERSISTENT_CLAIM)) {

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/KafkaCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/KafkaCluster.java
@@ -18,7 +18,6 @@ import io.strimzi.controller.cluster.ClusterController;
 import io.vertx.core.json.JsonObject;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/KafkaCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/KafkaCluster.java
@@ -18,6 +18,7 @@ import io.strimzi.controller.cluster.ClusterController;
 import io.vertx.core.json.JsonObject;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/KafkaConnectCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/KafkaConnectCluster.java
@@ -198,7 +198,7 @@ public class KafkaConnectCluster extends AbstractCluster {
                 || !keyConverter.equals(vars.getOrDefault(KEY_KEY_CONVERTER, DEFAULT_KEY_CONVERTER))
                 || keyConverterSchemasEnable != Boolean.parseBoolean(vars.getOrDefault(KEY_KEY_CONVERTER_SCHEMAS_EXAMPLE, String.valueOf(DEFAULT_KEY_CONVERTER_SCHEMAS_EXAMPLE)))
                 || !valueConverter.equals(vars.getOrDefault(KEY_VALUE_CONVERTER, DEFAULT_VALUE_CONVERTER))
-                || keyConverterSchemasEnable != Boolean.parseBoolean(vars.getOrDefault(KEY_VALUE_CONVERTER_SCHEMAS_EXAMPLE, String.valueOf(DEFAULT_VALUE_CONVERTER_SCHEMAS_EXAMPLE)))
+                || valueConverterSchemasEnable != Boolean.parseBoolean(vars.getOrDefault(KEY_VALUE_CONVERTER_SCHEMAS_EXAMPLE, String.valueOf(DEFAULT_VALUE_CONVERTER_SCHEMAS_EXAMPLE)))
                 || configStorageReplicationFactor != Integer.parseInt(vars.getOrDefault(KEY_CONFIG_STORAGE_REPLICATION_FACTOR, String.valueOf(DEFAULT_CONFIG_STORAGE_REPLICATION_FACTOR)))
                 || offsetStorageReplicationFactor != Integer.parseInt(vars.getOrDefault(KEY_OFFSET_STORAGE_REPLICATION_FACTOR, String.valueOf(DEFAULT_OFFSET_STORAGE_REPLICATION_FACTOR)))
                 || statusStorageReplicationFactor != Integer.parseInt(vars.getOrDefault(KEY_STATUS_STORAGE_REPLICATION_FACTOR, String.valueOf(DEFAULT_STATUS_STORAGE_REPLICATION_FACTOR)))) {

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/KafkaConnectCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/KafkaConnectCluster.java
@@ -9,7 +9,6 @@ import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.extensions.Deployment;
-import io.strimzi.controller.cluster.operations.resource.DeploymentOperations;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -25,7 +24,7 @@ public class KafkaConnectCluster extends AbstractCluster {
     protected static final int REST_API_PORT = 8083;
     protected static final String REST_API_PORT_NAME = "rest-api";
 
-    private static String NAME_SUFFIX = "-connect";
+    private static final String NAME_SUFFIX = "-connect";
 
     // Kafka Connect configuration
     protected String bootstrapServers = DEFAULT_BOOTSTRAP_SERVERS;
@@ -128,7 +127,6 @@ public class KafkaConnectCluster extends AbstractCluster {
      * @param namespace Kubernetes/OpenShift namespace where cluster resources belong to
      * @param cluster   overall cluster name
      * @param dep The deployment from which to recover the cluster state
-     * @param imageStreamOperations ImageStream operations (may be null)
      * @return  Kafka Connect cluster instance
      */
     public static KafkaConnectCluster fromDeployment(
@@ -176,8 +174,7 @@ public class KafkaConnectCluster extends AbstractCluster {
         if (replicas > dep.getSpec().getReplicas()) {
             log.info("Diff: Expected replicas {}, actual replicas {}", replicas, dep.getSpec().getReplicas());
             scaleUp = true;
-        }
-        else if (replicas < dep.getSpec().getReplicas()) {
+        } else if (replicas < dep.getSpec().getReplicas()) {
             log.info("Diff: Expected replicas {}, actual replicas {}", replicas, dep.getSpec().getReplicas());
             scaleDown = true;
         }
@@ -204,8 +201,7 @@ public class KafkaConnectCluster extends AbstractCluster {
                 || keyConverterSchemasEnable != Boolean.parseBoolean(vars.getOrDefault(KEY_VALUE_CONVERTER_SCHEMAS_EXAMPLE, String.valueOf(DEFAULT_VALUE_CONVERTER_SCHEMAS_EXAMPLE)))
                 || configStorageReplicationFactor != Integer.parseInt(vars.getOrDefault(KEY_CONFIG_STORAGE_REPLICATION_FACTOR, String.valueOf(DEFAULT_CONFIG_STORAGE_REPLICATION_FACTOR)))
                 || offsetStorageReplicationFactor != Integer.parseInt(vars.getOrDefault(KEY_OFFSET_STORAGE_REPLICATION_FACTOR, String.valueOf(DEFAULT_OFFSET_STORAGE_REPLICATION_FACTOR)))
-                || statusStorageReplicationFactor != Integer.parseInt(vars.getOrDefault(KEY_STATUS_STORAGE_REPLICATION_FACTOR, String.valueOf(DEFAULT_STATUS_STORAGE_REPLICATION_FACTOR)))
-                ) {
+                || statusStorageReplicationFactor != Integer.parseInt(vars.getOrDefault(KEY_STATUS_STORAGE_REPLICATION_FACTOR, String.valueOf(DEFAULT_STATUS_STORAGE_REPLICATION_FACTOR)))) {
             log.info("Diff: Kafka Connect options changed");
             different = true;
             rollingUpdate = true;

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/KafkaConnectS2ICluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/KafkaConnectS2ICluster.java
@@ -157,7 +157,7 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
                 || !keyConverter.equals(vars.getOrDefault(KEY_KEY_CONVERTER, DEFAULT_KEY_CONVERTER))
                 || keyConverterSchemasEnable != Boolean.parseBoolean(vars.getOrDefault(KEY_KEY_CONVERTER_SCHEMAS_EXAMPLE, String.valueOf(DEFAULT_KEY_CONVERTER_SCHEMAS_EXAMPLE)))
                 || !valueConverter.equals(vars.getOrDefault(KEY_VALUE_CONVERTER, DEFAULT_VALUE_CONVERTER))
-                || keyConverterSchemasEnable != Boolean.parseBoolean(vars.getOrDefault(KEY_VALUE_CONVERTER_SCHEMAS_EXAMPLE, String.valueOf(DEFAULT_VALUE_CONVERTER_SCHEMAS_EXAMPLE)))
+                || valueConverterSchemasEnable != Boolean.parseBoolean(vars.getOrDefault(KEY_VALUE_CONVERTER_SCHEMAS_EXAMPLE, String.valueOf(DEFAULT_VALUE_CONVERTER_SCHEMAS_EXAMPLE)))
                 || configStorageReplicationFactor != Integer.parseInt(vars.getOrDefault(KEY_CONFIG_STORAGE_REPLICATION_FACTOR, String.valueOf(DEFAULT_CONFIG_STORAGE_REPLICATION_FACTOR)))
                 || offsetStorageReplicationFactor != Integer.parseInt(vars.getOrDefault(KEY_OFFSET_STORAGE_REPLICATION_FACTOR, String.valueOf(DEFAULT_OFFSET_STORAGE_REPLICATION_FACTOR)))
                 || statusStorageReplicationFactor != Integer.parseInt(vars.getOrDefault(KEY_STATUS_STORAGE_REPLICATION_FACTOR, String.valueOf(DEFAULT_STATUS_STORAGE_REPLICATION_FACTOR)))) {

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/KafkaConnectS2ICluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/KafkaConnectS2ICluster.java
@@ -139,8 +139,7 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
         if (replicas > dep.getSpec().getReplicas()) {
             log.info("Diff: Expected replicas {}, actual replicas {}", replicas, dep.getSpec().getReplicas());
             scaleUp = true;
-        }
-        else if (replicas < dep.getSpec().getReplicas()) {
+        } else if (replicas < dep.getSpec().getReplicas()) {
             log.info("Diff: Expected replicas {}, actual replicas {}", replicas, dep.getSpec().getReplicas());
             scaleDown = true;
         }
@@ -161,8 +160,7 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
                 || keyConverterSchemasEnable != Boolean.parseBoolean(vars.getOrDefault(KEY_VALUE_CONVERTER_SCHEMAS_EXAMPLE, String.valueOf(DEFAULT_VALUE_CONVERTER_SCHEMAS_EXAMPLE)))
                 || configStorageReplicationFactor != Integer.parseInt(vars.getOrDefault(KEY_CONFIG_STORAGE_REPLICATION_FACTOR, String.valueOf(DEFAULT_CONFIG_STORAGE_REPLICATION_FACTOR)))
                 || offsetStorageReplicationFactor != Integer.parseInt(vars.getOrDefault(KEY_OFFSET_STORAGE_REPLICATION_FACTOR, String.valueOf(DEFAULT_OFFSET_STORAGE_REPLICATION_FACTOR)))
-                || statusStorageReplicationFactor != Integer.parseInt(vars.getOrDefault(KEY_STATUS_STORAGE_REPLICATION_FACTOR, String.valueOf(DEFAULT_STATUS_STORAGE_REPLICATION_FACTOR)))
-                ) {
+                || statusStorageReplicationFactor != Integer.parseInt(vars.getOrDefault(KEY_STATUS_STORAGE_REPLICATION_FACTOR, String.valueOf(DEFAULT_STATUS_STORAGE_REPLICATION_FACTOR)))) {
             log.info("Diff: Kafka Connect options changed");
             different = true;
             rollingUpdate = true;

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/ZookeeperCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/ZookeeperCluster.java
@@ -15,8 +15,6 @@ import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.fabric8.kubernetes.api.model.extensions.StatefulSet;
 import io.strimzi.controller.cluster.ClusterController;
-import io.strimzi.controller.cluster.operations.resource.ConfigMapOperations;
-import io.strimzi.controller.cluster.operations.resource.StatefulSetOperations;
 import io.vertx.core.json.JsonObject;
 
 import java.util.ArrayList;

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/ZookeeperCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/ZookeeperCluster.java
@@ -4,7 +4,15 @@
  */
 package io.strimzi.controller.cluster.resources;
 
-import io.fabric8.kubernetes.api.model.*;
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ContainerPort;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.EnvVarBuilder;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServicePort;
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.fabric8.kubernetes.api.model.extensions.StatefulSet;
 import io.strimzi.controller.cluster.ClusterController;
 import io.strimzi.controller.cluster.operations.resource.ConfigMapOperations;
@@ -29,19 +37,19 @@ public class ZookeeperCluster extends AbstractCluster {
     private static final int LEADER_ELECTION_PORT = 3888;
     private static final String LEADER_ELECTION_PORT_NAME = "leader-election";
 
-    private static String NAME_SUFFIX = "-zookeeper";
-    private static String HEADLESS_NAME_SUFFIX = NAME_SUFFIX + "-headless";
-    private static String METRICS_CONFIG_SUFFIX = NAME_SUFFIX + "-metrics-config";
+    private static final String NAME_SUFFIX = "-zookeeper";
+    private static final String HEADLESS_NAME_SUFFIX = NAME_SUFFIX + "-headless";
+    private static final String METRICS_CONFIG_SUFFIX = NAME_SUFFIX + "-metrics-config";
 
     // Zookeeper configuration
     // N/A
 
     // Configuration defaults
-    private static String DEFAULT_IMAGE = "strimzi/zookeeper:latest";
-    private static int DEFAULT_REPLICAS = 3;
-    private static int DEFAULT_HEALTHCHECK_DELAY = 15;
-    private static int DEFAULT_HEALTHCHECK_TIMEOUT = 5;
-    private static boolean DEFAULT_ZOOKEEPER_METRICS_ENABLED = false;
+    private static final String DEFAULT_IMAGE = "strimzi/zookeeper:latest";
+    private static final int DEFAULT_REPLICAS = 3;
+    private static final int DEFAULT_HEALTHCHECK_DELAY = 15;
+    private static final int DEFAULT_HEALTHCHECK_TIMEOUT = 5;
+    private static final boolean DEFAULT_ZOOKEEPER_METRICS_ENABLED = false;
 
     // Zookeeper configuration defaults
     // N/A
@@ -55,8 +63,8 @@ public class ZookeeperCluster extends AbstractCluster {
     public static final String KEY_STORAGE = "zookeeper-storage";
 
     // Zookeeper configuration keys
-    private static String KEY_ZOOKEEPER_NODE_COUNT = "ZOOKEEPER_NODE_COUNT";
-    private static String KEY_ZOOKEEPER_METRICS_ENABLED = "ZOOKEEPER_METRICS_ENABLED";
+    private static final String KEY_ZOOKEEPER_NODE_COUNT = "ZOOKEEPER_NODE_COUNT";
+    private static final String KEY_ZOOKEEPER_METRICS_ENABLED = "ZOOKEEPER_METRICS_ENABLED";
 
     public static String zookeeperClusterName(String cluster) {
         return cluster + ZookeeperCluster.NAME_SUFFIX;
@@ -184,8 +192,7 @@ public class ZookeeperCluster extends AbstractCluster {
             log.info("Diff: Expected replicas {}, actual replicas {}", replicas, ss.getSpec().getReplicas());
             scaleUp = true;
             rollingUpdate = true;
-        }
-        else if (replicas < ss.getSpec().getReplicas()) {
+        } else if (replicas < ss.getSpec().getReplicas()) {
             log.info("Diff: Expected replicas {}, actual replicas {}", replicas, ss.getSpec().getReplicas());
             scaleDown = true;
             rollingUpdate = true;
@@ -244,8 +251,8 @@ public class ZookeeperCluster extends AbstractCluster {
         Storage.StorageDiffResult storageDiffResult = storage.diff(ssStorage);
 
         // check for all the not allowed changes to the storage
-        boolean isStorageRejected = (storageDiffResult.isType() || storageDiffResult.isSize() ||
-                storageDiffResult.isStorageClass() || storageDiffResult.isSelector());
+        boolean isStorageRejected = storageDiffResult.isType() || storageDiffResult.isSize() ||
+                storageDiffResult.isStorageClass() || storageDiffResult.isSelector();
 
         // only delete-claim flag can be changed
         if (!isStorageRejected && (storage.type() == Storage.StorageType.PERSISTENT_CLAIM)) {
@@ -336,7 +343,7 @@ public class ZookeeperCluster extends AbstractCluster {
         List<ContainerPort> portList = new ArrayList<>();
         portList.add(createContainerPort(CLIENT_PORT_NAME, CLIENT_PORT, "TCP"));
         portList.add(createContainerPort(CLUSTERING_PORT_NAME, CLUSTERING_PORT, "TCP"));
-        portList.add(createContainerPort(LEADER_ELECTION_PORT_NAME, LEADER_ELECTION_PORT,"TCP"));
+        portList.add(createContainerPort(LEADER_ELECTION_PORT_NAME, LEADER_ELECTION_PORT, "TCP"));
         if (isMetricsEnabled) {
             portList.add(createContainerPort(metricsPortName, metricsPort, "TCP"));
         }

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/ResourceUtils.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/ResourceUtils.java
@@ -14,8 +14,6 @@ import io.strimzi.controller.cluster.resources.ZookeeperCluster;
 import java.util.HashMap;
 import java.util.Map;
 
-import static java.util.Collections.singletonMap;
-
 public class ResourceUtils {
 
     private ResourceUtils() {
@@ -27,13 +25,13 @@ public class ResourceUtils {
      * @param pairs (key, value) pairs. There must be an even number, obviously.
      * @return a map of labels
      */
-    public static Map<String,String> labels(String... pairs) {
+    public static Map<String, String> labels(String... pairs) {
         if (pairs.length % 2 != 0) {
             throw new IllegalArgumentException();
         }
         HashMap<String, String> map = new HashMap<>();
-        for (int i = 0; i < pairs.length; i+=2) {
-            map.put(pairs[i], pairs[i+1]);
+        for (int i = 0; i < pairs.length; i += 2) {
+            map.put(pairs[i], pairs[i + 1]);
         }
         return map;
     }
@@ -63,7 +61,7 @@ public class ResourceUtils {
         cmData.put(KafkaCluster.KEY_STORAGE, storage);
         cmData.put(KafkaCluster.KEY_METRICS_CONFIG, metricsCmJson);
         cmData.put(ZookeeperCluster.KEY_REPLICAS, Integer.toString(replicas));
-        cmData.put(ZookeeperCluster.KEY_IMAGE, image+"-zk");
+        cmData.put(ZookeeperCluster.KEY_IMAGE, image + "-zk");
         cmData.put(ZookeeperCluster.KEY_HEALTHCHECK_DELAY, Integer.toString(healthDelay));
         cmData.put(ZookeeperCluster.KEY_HEALTHCHECK_TIMEOUT, Integer.toString(healthTimeout));
         cmData.put(ZookeeperCluster.KEY_STORAGE, storage);

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperationsTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperationsTest.java
@@ -84,19 +84,19 @@ public class KafkaClusterOperationsTest {
         }
     }
 
-    @Parameterized.Parameters( name = "{0}" )
+    @Parameterized.Parameters(name = "{0}")
     public static Iterable<Params> data() {
         boolean[] shiftiness = {true, false};
         boolean[] metrics = {true, false};
         String[] storageConfigs = {
-                "{\"type\": \"ephemeral\"}",
-                "{\"type\": \"persistent-claim\", " +
-                        "\"size\": \"123\", " +
-                        "\"class\": \"foo\"," +
-                        "\"delete-claim\": true}",
-                "{\"type\": \"local\", " +
-                        "\"size\": \"123\", " +
-                        "\"class\": \"foo\"}"
+            "{\"type\": \"ephemeral\"}",
+            "{\"type\": \"persistent-claim\", " +
+                    "\"size\": \"123\", " +
+                    "\"class\": \"foo\"," +
+                    "\"delete-claim\": true}",
+            "{\"type\": \"local\", " +
+                    "\"size\": \"123\", " +
+                    "\"class\": \"foo\"}"
         };
         List<Params> result = new ArrayList();
         for (boolean shift: shiftiness) {
@@ -197,7 +197,7 @@ public class KafkaClusterOperationsTest {
             List<StatefulSet> capturedSs = ssCaptor.getAllValues();
             // We expect a statefulSet for kafka and zookeeper...
             context.assertEquals(set(KafkaCluster.kafkaClusterName(clusterCmName), ZookeeperCluster.zookeeperClusterName(clusterCmName)),
-                    capturedSs.stream().map(ss->ss.getMetadata().getName()).collect(Collectors.toSet()));
+                    capturedSs.stream().map(ss -> ss.getMetadata().getName()).collect(Collectors.toSet()));
 
             // Verify that we wait for readiness
             verify(mockEndpointOps, times(2)).waitUntilReady(any(), any(), anyLong(), anyLong());

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/resource/DeploymentConfigOperationsMockTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/resource/DeploymentConfigOperationsMockTest.java
@@ -16,7 +16,7 @@ import io.vertx.core.Vertx;
 
 import static org.mockito.Mockito.when;
 
-public class DeploymentConfigOperationsMockTest extends ResourceOperationsMockTest<OpenShiftClient,DeploymentConfig,DeploymentConfigList,DoneableDeploymentConfig,DeployableScalableResource<DeploymentConfig,DoneableDeploymentConfig>> {
+public class DeploymentConfigOperationsMockTest extends ResourceOperationsMockTest<OpenShiftClient, DeploymentConfig, DeploymentConfigList, DoneableDeploymentConfig,DeployableScalableResource<DeploymentConfig,DoneableDeploymentConfig>> {
 
     @Override
     protected Class<OpenShiftClient> clientType() {

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/resource/DeploymentConfigOperationsMockTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/resource/DeploymentConfigOperationsMockTest.java
@@ -16,7 +16,9 @@ import io.vertx.core.Vertx;
 
 import static org.mockito.Mockito.when;
 
-public class DeploymentConfigOperationsMockTest extends ResourceOperationsMockTest<OpenShiftClient, DeploymentConfig, DeploymentConfigList, DoneableDeploymentConfig,DeployableScalableResource<DeploymentConfig,DoneableDeploymentConfig>> {
+public class DeploymentConfigOperationsMockTest extends ResourceOperationsMockTest<OpenShiftClient, DeploymentConfig,
+        DeploymentConfigList, DoneableDeploymentConfig,
+        DeployableScalableResource<DeploymentConfig, DoneableDeploymentConfig>> {
 
     @Override
     protected Class<OpenShiftClient> clientType() {

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/resource/EndpointOperationsMockTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/resource/EndpointOperationsMockTest.java
@@ -5,13 +5,9 @@
 package io.strimzi.controller.cluster.operations.resource;
 
 import io.fabric8.kubernetes.api.model.DoneableEndpoints;
-import io.fabric8.kubernetes.api.model.DoneableService;
 import io.fabric8.kubernetes.api.model.Endpoints;
 import io.fabric8.kubernetes.api.model.EndpointsBuilder;
 import io.fabric8.kubernetes.api.model.EndpointsList;
-import io.fabric8.kubernetes.api.model.Service;
-import io.fabric8.kubernetes.api.model.ServiceBuilder;
-import io.fabric8.kubernetes.api.model.ServiceList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/resource/ResourceOperationsMockTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/resource/ResourceOperationsMockTest.java
@@ -21,15 +21,11 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.util.concurrent.TimeUnit;
-
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.matches;
 import static org.mockito.Mockito.atLeastOnce;

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/resources/KafkaClusterTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/resources/KafkaClusterTest.java
@@ -127,7 +127,7 @@ public class KafkaClusterTest {
     @Test
     public void testDiffMetrics() {
         KafkaCluster other = KafkaCluster.fromConfigMap(ResourceUtils.createKafkaClusterConfigMap(namespace, cluster,
-                replicas, image, healthDelay, healthTimeout,"{\"something\":\"different\"}"));
+                replicas, image, healthDelay, healthTimeout, "{\"something\":\"different\"}"));
         ClusterDiffResult diff = kc.diff(other.generateMetricsConfigMap(), other.generateStatefulSet(true));
         assertFalse(diff.isDifferent());
         assertFalse(diff.isScaleDown());
@@ -175,7 +175,7 @@ public class KafkaClusterTest {
     @Test
     public void testDiffHealthDelay() {
         KafkaCluster other = KafkaCluster.fromConfigMap(ResourceUtils.createKafkaClusterConfigMap(namespace, cluster,
-                replicas, image, healthDelay+1, healthTimeout, metricsCmJson));
+                replicas, image, healthDelay + 1, healthTimeout, metricsCmJson));
         ClusterDiffResult diff = kc.diff(other.generateMetricsConfigMap(), other.generateStatefulSet(true));
         assertTrue(diff.isDifferent());
         assertFalse(diff.isScaleDown());
@@ -187,7 +187,7 @@ public class KafkaClusterTest {
     @Test
     public void testDiffHealthTimeout() {
         KafkaCluster other = KafkaCluster.fromConfigMap(ResourceUtils.createKafkaClusterConfigMap(namespace, cluster,
-                replicas, image, healthDelay, healthTimeout+1, metricsCmJson));
+                replicas, image, healthDelay, healthTimeout + 1, metricsCmJson));
         ClusterDiffResult diff = kc.diff(other.generateMetricsConfigMap(), other.generateStatefulSet(true));
         assertTrue(diff.isDifferent());
         assertFalse(diff.isScaleDown());

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/resources/KafkaConnectClusterTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/resources/KafkaConnectClusterTest.java
@@ -148,7 +148,7 @@ public class KafkaConnectClusterTest {
     @Test
     public void testDiffScaleUp() {
         Deployment dep = kc.generateDeployment();
-        dep.getSpec().setReplicas(dep.getSpec().getReplicas()-1);
+        dep.getSpec().setReplicas(dep.getSpec().getReplicas() - 1);
         ClusterDiffResult diff = kc.diff(dep);
 
         assertFalse(diff.isDifferent());
@@ -161,7 +161,7 @@ public class KafkaConnectClusterTest {
     @Test
     public void testDiffScaleDown() {
         Deployment dep = kc.generateDeployment();
-        dep.getSpec().setReplicas(dep.getSpec().getReplicas()+1);
+        dep.getSpec().setReplicas(dep.getSpec().getReplicas() + 1);
         ClusterDiffResult diff = kc.diff(dep);
 
         assertFalse(diff.isDifferent());

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/resources/KafkaConnectS2IClusterTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/resources/KafkaConnectS2IClusterTest.java
@@ -162,7 +162,7 @@ public class KafkaConnectS2IClusterTest {
     @Test
     public void testDiffScaleUp() {
         DeploymentConfig dep = kc.generateDeploymentConfig();
-        dep.getSpec().setReplicas(dep.getSpec().getReplicas()-1);
+        dep.getSpec().setReplicas(dep.getSpec().getReplicas() - 1);
         ClusterDiffResult diff = kc.diff(dep, kc.generateSourceImageStream(), kc.generateTargetImageStream(), kc.generateBuildConfig());
 
         assertFalse(diff.isDifferent());
@@ -175,7 +175,7 @@ public class KafkaConnectS2IClusterTest {
     @Test
     public void testDiffScaleDown() {
         DeploymentConfig dep = kc.generateDeploymentConfig();
-        dep.getSpec().setReplicas(dep.getSpec().getReplicas()+1);
+        dep.getSpec().setReplicas(dep.getSpec().getReplicas() + 1);
         ClusterDiffResult diff = kc.diff(dep, kc.generateSourceImageStream(), kc.generateTargetImageStream(), kc.generateBuildConfig());
 
         assertFalse(diff.isDifferent());

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
                         <configuration>
                             <configLocation>.checkstyle/checkstyle.xml</configLocation>
                             <headerLocation>.checkstyle/java.header</headerLocation>
+                            <suppressionsLocation>.checkstyle/suppressions.xml</suppressionsLocation>
                             <includeTestSourceDirectory>true</includeTestSourceDirectory>
                             <encoding>UTF-8</encoding>
                             <consoleOutput>true</consoleOutput>

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/BackOff.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/BackOff.java
@@ -18,9 +18,9 @@ public class BackOff {
     }
 
     public BackOff(long scaleMs, int base, int maxAttempts) {
-        assert(scaleMs > 0);
-        assert(base > 0);
-        assert(maxAttempts > 0);
+        assert scaleMs > 0;
+        assert base > 0;
+        assert maxAttempts > 0;
         this.scaleMs = scaleMs;
         this.base = base;
         this.maxAttempts = maxAttempts;
@@ -47,7 +47,7 @@ public class BackOff {
         while (n-- > 1) {
             pow *= base;
         }
-        return scaleMs*pow;
+        return scaleMs * pow;
     }
 
     public long totalDelayMs() {

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/Config.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/Config.java
@@ -25,7 +25,7 @@ public class Config {
     }
 
     /** A java string */
-    private static Type<? extends String> STRING = new Type<String>() {
+    private static final Type<? extends String> STRING = new Type<String>() {
         @Override
         public String parse(String s) {
             return s;
@@ -33,7 +33,7 @@ public class Config {
     };
 
     /** A java Long */
-    private static Type<? extends Long> LONG = new Type<Long>() {
+    private static final Type<? extends Long> LONG = new Type<Long>() {
         @Override
         public Long parse(String s) {
             return Long.parseLong(s);
@@ -44,7 +44,7 @@ public class Config {
      * A time duration composed of a non-negative integer quantity and time unit taken from {@link TimeUnit}.
      * For example '5 seconds'.
      */
-    private static Type<? extends Long> DURATION = new Type<Long>() {
+    private static final Type<? extends Long> DURATION = new Type<Long>() {
 
         private final Pattern pattern = Pattern.compile("([0-9]+) *([a-z]+)", Pattern.CASE_INSENSITIVE);
 
@@ -65,7 +65,7 @@ public class Config {
     /**
      * A kubernetes selector.
      */
-    private static Type<? extends LabelPredicate> LABEL_PREDICATE = new Type<LabelPredicate>() {
+    private static final Type<? extends LabelPredicate> LABEL_PREDICATE = new Type<LabelPredicate>() {
         @Override
         public LabelPredicate parse(String s) {
             return LabelPredicate.fromString(s);
@@ -107,7 +107,7 @@ public class Config {
     private static final Set<Type> TYPES = new HashSet<>();
 
     /** A comma-separated list of key=value pairs for selecting ConfigMaps that describe topics. */
-    public static final Value<LabelPredicate> LABELS = new Value(TC_CM_LABELS, LABEL_PREDICATE,"strimzi.io/kind=topic");
+    public static final Value<LabelPredicate> LABELS = new Value(TC_CM_LABELS, LABEL_PREDICATE, "strimzi.io/kind=topic");
 
     /** A comma-separated list of kafka bootstrap servers. */
     public static final Value<String> KAFKA_BOOTSTRAP_SERVERS = new Value(TC_KAFKA_BOOTSTRAP_SERVERS, STRING, true);
@@ -196,11 +196,11 @@ public class Config {
     }
 
     public <T> T get(Value<T> value, T defaultValue) {
-        return (T)this.map.getOrDefault(value.key, defaultValue);
+        return (T) this.map.getOrDefault(value.key, defaultValue);
     }
 
     public <T> T get(Value<T> value) {
-        return (T)this.map.get(value.key);
+        return (T) this.map.get(value.key);
     }
 
     @Override

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/ConfigMapWatcher.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/ConfigMapWatcher.java
@@ -17,7 +17,7 @@ import java.util.Map;
 
 class ConfigMapWatcher implements Watcher<ConfigMap> {
 
-    private final static Logger logger = LoggerFactory.getLogger(ConfigMapWatcher.class);
+    private final static Logger LOGGER = LoggerFactory.getLogger(ConfigMapWatcher.class);
 
     private Controller controller;
     private final LabelPredicate cmPredicate;
@@ -32,21 +32,21 @@ class ConfigMapWatcher implements Watcher<ConfigMap> {
         Map<String, String> labels = metadata.getLabels();
         if (cmPredicate.test(configMap)) {
             String name = metadata.getName();
-            logger.info("ConfigMap watch received event {} on map {} with labels {}", action, name, labels);
+            LOGGER.info("ConfigMap watch received event {} on map {} with labels {}", action, name, labels);
             Handler<AsyncResult<Void>> resultHandler = ar -> {
                 if (ar.succeeded()) {
-                    logger.info("Success processing ConfigMap watch event {} on map {} with labels {}", action, name, labels);
+                    LOGGER.info("Success processing ConfigMap watch event {} on map {} with labels {}", action, name, labels);
                 } else {
                     String message;
                     if (ar.cause() instanceof InvalidConfigMapException) {
-                        message = "ConfigMap "+name+" has an invalid 'data' section: " + ar.cause().getMessage();
-                        logger.error("{}", message);
+                        message = "ConfigMap " + name + " has an invalid 'data' section: " + ar.cause().getMessage();
+                        LOGGER.error("{}", message);
 
                     } else {
-                        message = "Failure processing ConfigMap watch event " + action + " on map " + name + " with labels " + labels +": " + ar.cause().getMessage();
-                        logger.error("{}", message, ar.cause());
+                        message = "Failure processing ConfigMap watch event " + action + " on map " + name + " with labels " + labels + ": " + ar.cause().getMessage();
+                        LOGGER.error("{}", message, ar.cause());
                     }
-                    controller.enqueue(controller.new Event(configMap, message, Controller.EventType.WARNING, errorResult -> {}));
+                    controller.enqueue(controller.new Event(configMap, message, Controller.EventType.WARNING, errorResult -> { }));
                 }
             };
             switch (action) {
@@ -60,12 +60,12 @@ class ConfigMapWatcher implements Watcher<ConfigMap> {
                     controller.onConfigMapDeleted(configMap, resultHandler);
                     break;
                 case ERROR:
-                    logger.error("Watch received action=ERROR for ConfigMap " + name);
+                    LOGGER.error("Watch received action=ERROR for ConfigMap " + name);
             }
         }
     }
 
     public void onClose(KubernetesClientException e) {
-        logger.debug("Closing {}", this);
+        LOGGER.debug("Closing {}", this);
     }
 }

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/Controller.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/Controller.java
@@ -23,8 +23,8 @@ import static java.util.Collections.disjoint;
 
 public class Controller {
 
-    private final static Logger logger = LoggerFactory.getLogger(Controller.class);
-    private final static Logger eventLogger = LoggerFactory.getLogger("Event");
+    private final static Logger LOGGER = LoggerFactory.getLogger(Controller.class);
+    private final static Logger EVENT_LOGGER = LoggerFactory.getLogger("Event");
     private final Kafka kafka;
     private final K8s k8s;
     private final Vertx vertx;
@@ -83,17 +83,17 @@ public class Controller {
             io.fabric8.kubernetes.api.model.Event event = evtb.build();
             switch (eventType) {
                 case INFO:
-                    logger.info("{}", message);
+                    LOGGER.info("{}", message);
                     break;
                 case WARNING:
-                    logger.warn("{}", message);
+                    LOGGER.warn("{}", message);
                     break;
             }
             k8s.createEvent(event, handler);
         }
 
         public String toString() {
-            return "ErrorEvent(involvedObject="+involvedObject+", message="+message+")";
+            return "ErrorEvent(involvedObject=" + involvedObject + ", message=" + message + ")";
         }
     }
 
@@ -115,7 +115,7 @@ public class Controller {
 
         @Override
         public String toString() {
-            return "CreateConfigMap(topicName="+topic.getTopicName()+")";
+            return "CreateConfigMap(topicName=" + topic.getTopicName() + ")";
         }
     }
 
@@ -160,7 +160,7 @@ public class Controller {
 
         @Override
         public String toString() {
-            return "UpdateConfigMap(topicName="+topic.getTopicName()+")";
+            return "UpdateConfigMap(topicName=" + topic.getTopicName() + ")";
         }
     }
 
@@ -182,7 +182,7 @@ public class Controller {
         public void handle(Void v) throws ControllerException {
             kafka.createTopic(topic, ar -> {
                 if (ar.succeeded()) {
-                    logger.info("Created topic '{}' for ConfigMap '{}'", topic.getTopicName(), topic.getMapName());
+                    LOGGER.info("Created topic '{}' for ConfigMap '{}'", topic.getTopicName(), topic.getMapName());
                     handler.handle(ar);
                 } else {
                     handler.handle(ar);
@@ -197,7 +197,7 @@ public class Controller {
 
         @Override
         public String toString() {
-            return "CreateKafkaTopic(topicName="+ topic.getTopicName()+")";
+            return "CreateKafkaTopic(topicName=" + topic.getTopicName() + ")";
         }
     }
 
@@ -217,9 +217,9 @@ public class Controller {
 
         @Override
         public void handle(Void v) throws ControllerException {
-            kafka.updateTopicConfig(topic, ar-> {
+            kafka.updateTopicConfig(topic, ar -> {
                 if (ar.failed()) {
-                    enqueue(new Event(involvedObject, ar.cause().toString(), EventType.WARNING, eventResult -> {}));
+                    enqueue(new Event(involvedObject, ar.cause().toString(), EventType.WARNING, eventResult -> { }));
                 }
                 handler.handle(ar);
             });
@@ -228,7 +228,7 @@ public class Controller {
 
         @Override
         public String toString() {
-            return "UpdateKafkaConfig(topicName="+topic.getTopicName()+")";
+            return "UpdateKafkaConfig(topicName=" + topic.getTopicName() + ")";
         }
     }
 
@@ -248,9 +248,9 @@ public class Controller {
 
         @Override
         public void handle(Void v) throws ControllerException {
-            kafka.increasePartitions(topic, ar-> {
+            kafka.increasePartitions(topic, ar -> {
                 if (ar.failed()) {
-                    enqueue(new Event(involvedObject, ar.cause().toString(), EventType.WARNING, eventResult -> {}));
+                    enqueue(new Event(involvedObject, ar.cause().toString(), EventType.WARNING, eventResult -> { }));
                 }
                 handler.handle(ar);
             });
@@ -259,7 +259,7 @@ public class Controller {
 
         @Override
         public String toString() {
-            return "UpdateKafkaPartitions(topicName="+topic.getTopicName()+")";
+            return "UpdateKafkaPartitions(topicName=" + topic.getTopicName() + ")";
         }
     }
 
@@ -279,9 +279,9 @@ public class Controller {
 
         @Override
         public void handle(Void v) throws ControllerException {
-            kafka.changeReplicationFactor(topic, ar-> {
+            kafka.changeReplicationFactor(topic, ar -> {
                 if (ar.failed()) {
-                    enqueue(new Event(involvedObject, ar.cause().toString(), EventType.WARNING, eventResult -> {}));
+                    enqueue(new Event(involvedObject, ar.cause().toString(), EventType.WARNING, eventResult -> { }));
                 }
                 handler.handle(ar);
             });
@@ -290,7 +290,7 @@ public class Controller {
 
         @Override
         public String toString() {
-            return "ChangeReplicationFactor(topicName="+topic.getTopicName()+")";
+            return "ChangeReplicationFactor(topicName=" + topic.getTopicName() + ")";
         }
     }
 
@@ -307,13 +307,13 @@ public class Controller {
 
         @Override
         public void handle(Void v) throws ControllerException {
-            logger.info("Deleting topic '{}'", topicName);
+            LOGGER.info("Deleting topic '{}'", topicName);
             kafka.deleteTopic(topicName, handler);
         }
 
         @Override
         public String toString() {
-            return "DeleteKafkaTopic(topicName="+topicName+")";
+            return "DeleteKafkaTopic(topicName=" + topicName + ")";
         }
     }
 
@@ -346,9 +346,9 @@ public class Controller {
                 });
             });
         } catch (InvalidConfigMapException e) {
-            logger.error("Error reconciling ConfigMap {}: Invalid 'data' section: ", cm.getMetadata().getName(), e.getMessage());
+            LOGGER.error("Error reconciling ConfigMap {}: Invalid 'data' section: ", cm.getMetadata().getName(), e.getMessage());
         } catch (ControllerException e) {
-            logger.error("Error reconciling ConfigMap {}: ", cm.getMetadata().getName(), e);
+            LOGGER.error("Error reconciling ConfigMap {}: ", cm.getMetadata().getName(), e);
         }
     }
 
@@ -381,17 +381,17 @@ public class Controller {
 
         {
             TopicName topicName = k8sTopic != null ? k8sTopic.getTopicName() : kafkaTopic != null ? kafkaTopic.getTopicName() : privateTopic != null ? privateTopic.getTopicName() : null;
-            logger.info("Reconciling topic {}, k8sTopic:{}, kafkaTopic:{}, privateTopic:{}", topicName, k8sTopic==null?"null":"nonnull", kafkaTopic==null?"null":"nonnull", privateTopic==null?"null":"nonnull");
+            LOGGER.info("Reconciling topic {}, k8sTopic:{}, kafkaTopic:{}, privateTopic:{}", topicName, k8sTopic == null ? "null" : "nonnull", kafkaTopic == null ? "null" : "nonnull", privateTopic == null ? "null" : "nonnull");
         }
         if (privateTopic == null) {
             if (k8sTopic == null) {
                 if (kafkaTopic == null) {
                     // All three null: This happens reentrantly when a topic or configmap is deleted
-                    logger.debug("All three topics null during reconciliation.");
+                    LOGGER.debug("All three topics null during reconciliation.");
                     reconciliationResultHandler.handle(Future.succeededFuture());
                 } else {
                     // it's been created in Kafka => create in k8s and privateState
-                    logger.debug("topic created in kafka, will create cm in k8s and topicStore");
+                    LOGGER.debug("topic created in kafka, will create cm in k8s and topicStore");
                     enqueue(new CreateConfigMap(kafkaTopic, ar -> {
                         // In all cases, create in privateState
                         if (ar.succeeded()) {
@@ -403,7 +403,7 @@ public class Controller {
                 }
             } else if (kafkaTopic == null) {
                 // it's been created in k8s => create in Kafka and privateState
-                logger.debug("cm created in k8s, will create topic in kafka and topicStore");
+                LOGGER.debug("cm created in k8s, will create topic in kafka and topicStore");
                 enqueue(new CreateKafkaTopic(k8sTopic, involvedObject, ar -> {
                     // In all cases, create in privateState
                     if (ar.succeeded()) {
@@ -419,12 +419,12 @@ public class Controller {
             if (k8sTopic == null) {
                 if (kafkaTopic == null) {
                     // delete privateState
-                    logger.debug("cm deleted in k8s and topic deleted in kafka => delete from topicStore");
+                    LOGGER.debug("cm deleted in k8s and topic deleted in kafka => delete from topicStore");
                     enqueue(new DeleteFromTopicStore(privateTopic.getTopicName(), involvedObject, reconciliationResultHandler));
                     reconciliationResultHandler.handle(Future.succeededFuture());
                 } else {
                     // it was deleted in k8s so delete in kafka and privateState
-                    logger.debug("cm deleted in k8s => delete topic from kafka and from topicStore");
+                    LOGGER.debug("cm deleted in k8s => delete topic from kafka and from topicStore");
                     enqueue(new DeleteKafkaTopic(kafkaTopic.getTopicName(), ar -> {
                         if (ar.succeeded()) {
                             enqueue(new DeleteFromTopicStore(privateTopic.getTopicName(), involvedObject, reconciliationResultHandler));
@@ -436,7 +436,7 @@ public class Controller {
                 }
             } else if (kafkaTopic == null) {
                 // it was deleted in kafka so delete in k8s and privateState
-                logger.debug("topic deleted in kafkas => delete cm from k8s and from topicStore");
+                LOGGER.debug("topic deleted in kafkas => delete cm from k8s and from topicStore");
                 enqueue(new DeleteConfigMap(privateTopic.getOrAsMapName(), ar -> {
                     if (ar.succeeded()) {
                         enqueue(new DeleteFromTopicStore(privateTopic.getTopicName(), involvedObject, reconciliationResultHandler));
@@ -446,7 +446,7 @@ public class Controller {
                 }));
             } else {
                 // all three exist
-                logger.debug("3 way diff");
+                LOGGER.debug("3 way diff");
                 update3Way(involvedObject, k8sTopic, kafkaTopic, privateTopic, reconciliationResultHandler);
             }
         }
@@ -456,14 +456,14 @@ public class Controller {
         TopicDiff diff = TopicDiff.diff(kafkaTopic, k8sTopic);
         if (diff.isEmpty()) {
             // they're the same => do nothing, but stil create the private copy
-            logger.debug("cm created in k8s and topic created in kafka, but they're identical => just creating in topicStore");
-            logger.debug("k8s and kafka versions of topic '{}' are the same", kafkaTopic.getTopicName());
+            LOGGER.debug("cm created in k8s and topic created in kafka, but they're identical => just creating in topicStore");
+            LOGGER.debug("k8s and kafka versions of topic '{}' are the same", kafkaTopic.getTopicName());
             enqueue(new CreateInTopicStore(kafkaTopic, involvedObject, reconciliationResultHandler));
         } else if (!diff.changesReplicationFactor()
                 && !diff.changesNumPartitions()
                 && diff.changesConfig()
                 && disjoint(kafkaTopic.getConfig().keySet(), k8sTopic.getConfig().keySet())) {
-            logger.debug("cm created in k8s and topic created in kafka, they differ only in topic config, and those configs are disjoint: Updating k8s and kafka, and creating in topic store");
+            LOGGER.debug("cm created in k8s and topic created in kafka, they differ only in topic config, and those configs are disjoint: Updating k8s and kafka, and creating in topic store");
             Map mergedConfigs = new HashMap(kafkaTopic.getConfig());
             mergedConfigs.putAll(k8sTopic.getConfig());
             Topic mergedTopic = new Topic.Builder(kafkaTopic).withConfig(mergedConfigs).build();
@@ -482,7 +482,7 @@ public class Controller {
             }));
         } else {
             // Just use kafka version, but also create a warning event
-            logger.debug("cm created in k8s and topic created in kafka, and they are irreconcilably different => kafka version wins");
+            LOGGER.debug("cm created in k8s and topic created in kafka, and they are irreconcilably different => kafka version wins");
             enqueue(new Event(involvedObject, "ConfigMap is incompatible with the topic metadata. " +
                     "The topic metadata will be treated as canonical.", EventType.INFO, ar -> {
                 if (ar.succeeded()) {
@@ -504,49 +504,49 @@ public class Controller {
                             Handler<AsyncResult<Void>> reconciliationResultHandler) {
         if (!privateTopic.getMapName().equals(k8sTopic.getMapName())) {
             reconciliationResultHandler.handle(Future.failedFuture(new ControllerException(involvedObject,
-                    "Topic '"+ kafkaTopic.getTopicName() + "' is already managed via ConfigMap '" + privateTopic.getMapName() + "' it cannot also be managed via the ConfiMap '" + k8sTopic.getMapName() + "'")));
+                    "Topic '" + kafkaTopic.getTopicName() + "' is already managed via ConfigMap '" + privateTopic.getMapName() + "' it cannot also be managed via the ConfiMap '" + k8sTopic.getMapName() + "'")));
             return;
         }
         TopicDiff oursKafka = TopicDiff.diff(privateTopic, kafkaTopic);
-        logger.debug("topicStore->kafkaTopic: {}", oursKafka);
+        LOGGER.debug("topicStore->kafkaTopic: {}", oursKafka);
         TopicDiff oursK8s = TopicDiff.diff(privateTopic, k8sTopic);
-        logger.debug("topicStore->k8sTopic: {}", oursK8s);
+        LOGGER.debug("topicStore->k8sTopic: {}", oursK8s);
         String conflict = oursKafka.conflict(oursK8s);
         if (conflict != null) {
             final String message = "ConfigMap and Topic both changed in a conflicting way: " + conflict;
-            logger.error(message);
-            enqueue(new Event(involvedObject, message, EventType.INFO, eventResult -> {}));
+            LOGGER.error(message);
+            enqueue(new Event(involvedObject, message, EventType.INFO, eventResult -> { }));
             reconciliationResultHandler.handle(Future.failedFuture(new Exception(message)));
         } else {
             TopicDiff merged = oursKafka.merge(oursK8s);
-            logger.debug("Diffs do not conflict, merged diff: {}", merged);
+            LOGGER.debug("Diffs do not conflict, merged diff: {}", merged);
             if (merged.isEmpty()) {
-                logger.info("All three topics are identical");
+                LOGGER.info("All three topics are identical");
                 reconciliationResultHandler.handle(Future.succeededFuture());
             } else {
                 Topic result = merged.apply(privateTopic);
                 int partitionsDelta = merged.numPartitionsDelta();
                 if (partitionsDelta < 0) {
                     final String message = "Number of partitions cannot be decreased";
-                    logger.error(message);
+                    LOGGER.error(message);
                     enqueue(new Event(involvedObject, message, EventType.INFO, eventResult -> {
                     }));
                     reconciliationResultHandler.handle(Future.failedFuture(new Exception(message)));
                 } else {
                     if (merged.changesReplicationFactor()) {
-                        logger.error("Changes replication factor");
+                        LOGGER.error("Changes replication factor");
                         enqueue(new ChangeReplicationFactor(result, involvedObject, null));
                     }
                     // TODO What if we increase min.in.sync.replicas and the number of replicas,
                     // such that the old number of replicas < the new min isr? But likewise
                     // we could decrease, so order of tasks in the queue will need to change
                     // depending on what the diffs are.
-                    logger.debug("Updating cm, kafka topic and topicStore");
+                    LOGGER.debug("Updating cm, kafka topic and topicStore");
                     // TODO replace this with compose
                     enqueue(new UpdateConfigMap(result, ar -> {
                         Handler<Void> topicStoreHandler =
                                 ignored -> enqueue(new UpdateInTopicStore(
-                                        result, involvedObject, reconciliationResultHandler));
+                                    result, involvedObject, reconciliationResultHandler));
                         Handler<Void> partitionsHandler;
                         if (partitionsDelta > 0) {
                             partitionsHandler = ar4 -> enqueue(new IncreaseKafkaPartitions(result, involvedObject, ar2 -> topicStoreHandler.handle(null)));
@@ -565,7 +565,7 @@ public class Controller {
     }
 
     void enqueue(Handler<Void> event) {
-        logger.debug("Enqueuing event {}", event);
+        LOGGER.debug("Enqueuing event {}", event);
         vertx.runOnContext(event);
     }
 
@@ -619,7 +619,7 @@ public class Controller {
                                 if (topicResult.result().getNumPartitions() == kafkaTopic.getNumPartitions()) {
                                     retry();
                                 } else {
-                                    logger.info("Topic {} partitions changed to {}", topicName, kafkaTopic.getNumPartitions());
+                                    LOGGER.info("Topic {} partitions changed to {}", topicName, kafkaTopic.getNumPartitions());
                                     Controller.this.reconcileOnTopicChange(topicName, kafkaTopic, fut.completer());
                                 }
 
@@ -662,11 +662,11 @@ public class Controller {
                         Topic k8sTopic = TopicSerialization.fromConfigMap(cm);
                         reconcile(cm, k8sTopic, kafkaTopic, storeTopic, resultHandler);
                     } else {
-                        resultHandler.handle(kubeResult.<Void>map((Void)null));
+                        resultHandler.handle(kubeResult.<Void>map((Void) null));
                     }
                 });
             } else {
-                resultHandler.handle(storeResult.<Void>map((Void)null));
+                resultHandler.handle(storeResult.<Void>map((Void) null));
             }
         });
 /*
@@ -846,9 +846,9 @@ public class Controller {
 
         @Override
         public void handle(Void v) throws ControllerException {
-            topicStore.update(topic, ar-> {
+            topicStore.update(topic, ar -> {
                 if (ar.failed()) {
-                    enqueue(new Event(involvedObject, ar.cause().toString(), EventType.WARNING, eventResult -> {}));
+                    enqueue(new Event(involvedObject, ar.cause().toString(), EventType.WARNING, eventResult -> { }));
                 }
                 handler.handle(ar);
             });
@@ -856,7 +856,7 @@ public class Controller {
 
         @Override
         public String toString() {
-            return "UpdateInTopicStore(topicName="+topic.getTopicName()+")";
+            return "UpdateInTopicStore(topicName=" + topic.getTopicName() + ")";
         }
     }
 
@@ -874,14 +874,14 @@ public class Controller {
 
         @Override
         public void handle(Void v) throws ControllerException {
-            logger.debug("Executing {}", this);
-            topicStore.create(topic, ar-> {
-                logger.debug("Completing {}", this);
+            LOGGER.debug("Executing {}", this);
+            topicStore.create(topic, ar -> {
+                LOGGER.debug("Completing {}", this);
                 if (ar.failed()) {
-                    logger.debug("{} failed", this);
-                    enqueue(new Event(involvedObject, ar.cause().toString(), EventType.WARNING, eventResult -> {}));
+                    LOGGER.debug("{} failed", this);
+                    enqueue(new Event(involvedObject, ar.cause().toString(), EventType.WARNING, eventResult -> { }));
                 } else {
-                    logger.debug("{} succeeded", this);
+                    LOGGER.debug("{} succeeded", this);
                 }
                 handler.handle(ar);
             });
@@ -889,7 +889,7 @@ public class Controller {
 
         @Override
         public String toString() {
-            return "CreateInTopicStore(topicName="+topic.getTopicName()+")";
+            return "CreateInTopicStore(topicName=" + topic.getTopicName() + ")";
         }
     }
 
@@ -907,9 +907,9 @@ public class Controller {
 
         @Override
         public void handle(Void v) throws ControllerException {
-            topicStore.delete(topicName, ar-> {
+            topicStore.delete(topicName, ar -> {
                 if (ar.failed()) {
-                    enqueue(new Event(involvedObject, ar.cause().toString(), EventType.WARNING, eventResult -> {}));
+                    enqueue(new Event(involvedObject, ar.cause().toString(), EventType.WARNING, eventResult -> { }));
                 }
                 handler.handle(ar);
             });
@@ -917,7 +917,7 @@ public class Controller {
 
         @Override
         public String toString() {
-            return "DeleteFromTopicStore(topicName="+topicName+")";
+            return "DeleteFromTopicStore(topicName=" + topicName + ")";
         }
     }
 

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/Controller.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/Controller.java
@@ -545,8 +545,8 @@ public class Controller {
                     // TODO replace this with compose
                     enqueue(new UpdateConfigMap(result, ar -> {
                         Handler<Void> topicStoreHandler =
-                                ignored -> enqueue(new UpdateInTopicStore(
-                                    result, involvedObject, reconciliationResultHandler));
+                            ignored -> enqueue(new UpdateInTopicStore(
+                                result, involvedObject, reconciliationResultHandler));
                         Handler<Void> partitionsHandler;
                         if (partitionsDelta > 0) {
                             partitionsHandler = ar4 -> enqueue(new IncreaseKafkaPartitions(result, involvedObject, ar2 -> topicStoreHandler.handle(null)));

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/InFlight.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/InFlight.java
@@ -38,7 +38,7 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 class InFlight<T> {
 
-    private final static Logger logger = LoggerFactory.getLogger(InFlight.class);
+    private final static Logger LOGGER = LoggerFactory.getLogger(InFlight.class);
 
     private final Vertx vertx;
 
@@ -55,11 +55,11 @@ class InFlight<T> {
         public InflightHandler(T key, String fur, Handler<AsyncResult<Void>> h1) {
             this.fur = fur;
             this.h1 = h1;
-            this.h2 = x-> {
+            this.h2 = x -> {
                 // remove from map if fut is the current key
-                map.compute(key, (k2, v)-> {
+                map.compute(key, (k2, v) -> {
                     if (v == this) {
-                        logger.debug("Removing finished action {}", this);
+                        LOGGER.debug("Removing finished action {}", this);
                         return null;
                     } else {
                         return v;
@@ -103,18 +103,18 @@ class InFlight<T> {
      */
     public void enqueue(T key, Handler<AsyncResult<Void>> resultHandler, Handler<Future<Void>> action) {
         InflightHandler fut = new InflightHandler(key, action.toString(), resultHandler);
-        logger.debug("resultHandler:{}, action:{}, fut:{}", resultHandler, action, fut);
+        LOGGER.debug("resultHandler:{}, action:{}, fut:{}", resultHandler, action, fut);
         map.compute(key, (k, current) -> {
             if (current == null) {
-                logger.debug("Queueing {} for immediate execution", action);
-                vertx.runOnContext(ignored-> action.handle(fut.fut));
+                LOGGER.debug("Queueing {} for immediate execution", action);
+                vertx.runOnContext(ignored -> action.handle(fut.fut));
                 return fut;
             } else {
-                logger.debug("Queueing {} for deferred execution after {}", action, current);
+                LOGGER.debug("Queueing {} for deferred execution after {}", action, current);
                 current.setHandler(ar -> {
-                    logger.debug("Queueing {} after deferred execution", action);
+                    LOGGER.debug("Queueing {} after deferred execution", action);
                     vertx.runOnContext(ar2 ->
-                            action.handle(fut.fut) );
+                            action.handle(fut.fut));
                 });
                 return fut;
             }

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/K8sImpl.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/K8sImpl.java
@@ -18,7 +18,7 @@ import java.util.List;
 
 public class K8sImpl implements K8s {
 
-    private final static Logger logger = LoggerFactory.getLogger(Controller.class);
+    private final static Logger LOGGER = LoggerFactory.getLogger(Controller.class);
 
     private final LabelPredicate cmPredicate;
     private final String namespace;
@@ -72,7 +72,7 @@ public class K8sImpl implements K8s {
     }
 
     @Override
-    public void listMaps(Handler<AsyncResult<List<ConfigMap> >> handler) {
+    public void listMaps(Handler<AsyncResult<List<ConfigMap>>> handler) {
         vertx.executeBlocking(future -> {
             try {
                 future.complete(client.configMaps().inNamespace(namespace).withLabels(cmPredicate.labels()).list().getItems());
@@ -83,7 +83,7 @@ public class K8sImpl implements K8s {
     }
 
     @Override
-    public void getFromName(MapName mapName, Handler<AsyncResult<ConfigMap >> handler) {
+    public void getFromName(MapName mapName, Handler<AsyncResult<ConfigMap>> handler) {
         vertx.executeBlocking(future -> {
             try {
                 future.complete(client.configMaps().inNamespace(namespace).withName(mapName.toString()).get());
@@ -102,10 +102,10 @@ public class K8sImpl implements K8s {
         vertx.executeBlocking(future -> {
             try {
                 try {
-                    logger.debug("Creating event {}", event);
+                    LOGGER.debug("Creating event {}", event);
                     client.events().create(event);
                 } catch (KubernetesClientException e) {
-                    logger.error("Error creating event {}", event, e);
+                    LOGGER.error("Error creating event {}", event, e);
                 }
                 future.complete();
             } catch (Exception e) {

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/LabelPredicate.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/LabelPredicate.java
@@ -23,9 +23,9 @@ public class LabelPredicate implements Predicate<HasMetadata> {
         if (labels.length % 2 != 0) {
             throw new IllegalArgumentException();
         }
-        this.labels = new HashMap<>(labels.length/2);
-        for (int i = 0; i < labels.length; i+=2) {
-            this.labels.put(labels[i], labels[i+1]);
+        this.labels = new HashMap<>(labels.length / 2);
+        for (int i = 0; i < labels.length; i += 2) {
+            this.labels.put(labels[i], labels[i + 1]);
         }
         checkLabels(this.labels);
     }
@@ -77,7 +77,7 @@ public class LabelPredicate implements Predicate<HasMetadata> {
         Matcher keyMatcher = keyPattern.matcher(key);
         if (keyMatcher.matches()) {
             String prefix = keyMatcher.group(1);
-            if (prefix != null && !isSubdomain(prefix.substring(0, prefix.length()-1))) {
+            if (prefix != null && !isSubdomain(prefix.substring(0, prefix.length() - 1))) {
                 throw new IllegalArgumentException("The label prefix " + prefix + " is not a valid subdomain");
             }
             String name = keyMatcher.group(2);

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/Main.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/Main.java
@@ -19,7 +19,7 @@ import java.util.Map;
  */
 public class Main {
 
-    private final static Logger logger = LoggerFactory.getLogger(Main.class);
+    private final static Logger LOGGER = LoggerFactory.getLogger(Main.class);
 
     public static void main(String[] args) {
         Main main = new Main();
@@ -39,9 +39,9 @@ public class Main {
         Session session = new Session(kubeClient, config);
         vertx.deployVerticle(session, ar -> {
             if (ar.succeeded()) {
-                logger.info("Session deployed");
+                LOGGER.info("Session deployed");
             } else {
-                logger.error("Error deploying Session", ar.cause());
+                LOGGER.error("Error deploying Session", ar.cause());
             }
         });
     }

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/Session.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/Session.java
@@ -25,7 +25,7 @@ import java.util.stream.Collectors;
 
 public class Session extends AbstractVerticle {
 
-    private final static Logger logger = LoggerFactory.getLogger(Session.class);
+    private final static Logger LOGGER = LoggerFactory.getLogger(Session.class);
 
     private static final int HEALTH_SERVER_PORT = 8080;
 
@@ -50,7 +50,7 @@ public class Session extends AbstractVerticle {
         for (Config.Value v: config.keys()) {
             sb.append("\t").append(v.key).append(": ").append(config.get(v)).append(System.lineSeparator());
         }
-        logger.info("Using config:{}", sb.toString());
+        LOGGER.info("Using config:{}", sb.toString());
     }
 
     /**
@@ -61,107 +61,107 @@ public class Session extends AbstractVerticle {
         vertx.executeBlocking(blockingResult -> {
             long t0 = System.currentTimeMillis();
             long timeout = 120_000L;
-            logger.info("Stopping");
-            logger.debug("Stopping kube watch");
+            LOGGER.info("Stopping");
+            LOGGER.debug("Stopping kube watch");
             topicCmWatch.close();
-            logger.debug("Stopping zk watches");
+            LOGGER.debug("Stopping zk watches");
             topicsWatcher.stop();
 
             while (controller.isWorkInflight()) {
                 if (System.currentTimeMillis() - t0 > timeout) {
-                    logger.error("Timeout waiting for inflight work to finish");
+                    LOGGER.error("Timeout waiting for inflight work to finish");
                     break;
                 }
-                logger.debug("Waiting for inflight work to finish");
+                LOGGER.debug("Waiting for inflight work to finish");
                 try {
                     Thread.sleep(1_000);
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                 }
             }
-            logger.debug("Stopping kafka {}", kafka);
+            LOGGER.debug("Stopping kafka {}", kafka);
             kafka.stop();
             try {
-                logger.debug("Disconnecting from zookeeper {}", zk);
+                LOGGER.debug("Disconnecting from zookeeper {}", zk);
                 zk.disconnect();
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }
-            logger.debug("Closing AdminClient {}", adminClient);
+            LOGGER.debug("Closing AdminClient {}", adminClient);
             adminClient.close(timeout - (System.currentTimeMillis() - t0), TimeUnit.MILLISECONDS);
-            logger.info("Stopped");
+            LOGGER.info("Stopped");
             blockingResult.complete();
         }, stopFuture);
     }
 
     @Override
     public void start() {
-        logger.info("Starting");
+        LOGGER.info("Starting");
         Properties adminClientProps = new Properties();
         adminClientProps.setProperty(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, config.get(Config.KAFKA_BOOTSTRAP_SERVERS));
         this.adminClient = AdminClient.create(adminClientProps);
-        logger.debug("Using AdminClient {}", adminClient);
+        LOGGER.debug("Using AdminClient {}", adminClient);
         this.kafka = new ControllerAssignedKafkaImpl(adminClient, vertx, config);
-        logger.debug("Using Kafka {}", kafka);
+        LOGGER.debug("Using Kafka {}", kafka);
         LabelPredicate cmPredicate = config.get(Config.LABELS);
 
         String namespace = config.get(Config.NAMESPACE);
-        logger.debug("Using namespace {}", namespace);
+        LOGGER.debug("Using namespace {}", namespace);
         this.k8s = new K8sImpl(vertx, kubeClient, cmPredicate, namespace);
-        logger.debug("Using k8s {}", k8s);
+        LOGGER.debug("Using k8s {}", k8s);
 
         this.zk = Zk.create(vertx, config.get(Config.ZOOKEEPER_CONNECT), this.config.get(Config.ZOOKEEPER_SESSION_TIMEOUT_MS).intValue());
-        logger.debug("Using ZooKeeper {}", zk);
+        LOGGER.debug("Using ZooKeeper {}", zk);
 
         ZkTopicStore topicStore = new ZkTopicStore(zk);
-        logger.debug("Using TopicStore {}", topicStore);
+        LOGGER.debug("Using TopicStore {}", topicStore);
 
         this.controller = new Controller(vertx, kafka, k8s, topicStore, cmPredicate, namespace);
-        logger.debug("Using Controller {}", controller);
+        LOGGER.debug("Using Controller {}", controller);
 
         this.topicConfigsWatcher = new TopicConfigsWatcher(controller);
-        logger.debug("Using TopicConfigsWatcher {}", topicConfigsWatcher);
+        LOGGER.debug("Using TopicConfigsWatcher {}", topicConfigsWatcher);
         this.topicWatcher = new TopicWatcher(controller);
-        logger.debug("Using TopicWatcher {}", topicWatcher);
+        LOGGER.debug("Using TopicWatcher {}", topicWatcher);
         this.topicsWatcher = new TopicsWatcher(controller, topicConfigsWatcher, topicWatcher);
-        logger.debug("Using TopicsWatcher {}", topicsWatcher);
+        LOGGER.debug("Using TopicsWatcher {}", topicsWatcher);
         topicsWatcher.start(zk);
 
         Thread configMapThread = new Thread(() -> {
-            logger.debug("Watching configmaps matching {}", cmPredicate);
+            LOGGER.debug("Watching configmaps matching {}", cmPredicate);
             Session.this.topicCmWatch = kubeClient.configMaps().inNamespace(kubeClient.getNamespace()).watch(new ConfigMapWatcher(controller, cmPredicate));
-            logger.debug("Watching setup");
+            LOGGER.debug("Watching setup");
 
             // start the HTTP server for healthchecks
             this.startHealthServer();
 
         }, "configmap-watcher");
-        logger.debug("Starting {}", configMapThread);
+        LOGGER.debug("Starting {}", configMapThread);
         configMapThread.start();
 
         // Reconcile initially
         reconcileTopics("initial");
         // And periodically after that
         vertx.setPeriodic(this.config.get(Config.FULL_RECONCILIATION_INTERVAL_MS),
-                (timerId) -> {
-                    if (stopped) {
-                        vertx.cancelTimer(timerId);
-                        return;
-                    }
-                    reconcileTopics("periodic");
-                });
-        logger.info("Started");
+            timerId -> {
+                if (stopped) {
+                    vertx.cancelTimer(timerId);
+                    return;
+                }
+                reconcileTopics("periodic");
+            });
+        LOGGER.info("Started");
     }
 
     private void reconcileTopics(String reconciliationType) {
-        logger.info("Starting {} reconciliation", reconciliationType);
+        LOGGER.info("Starting {} reconciliation", reconciliationType);
         kafka.listTopics(arx -> {
             if (arx.succeeded()) {
                 Set<String> kafkaTopics = arx.result();
-                logger.debug("Reconciling kafka topics {}", kafkaTopics);
+                LOGGER.debug("Reconciling kafka topics {}", kafkaTopics);
                 // First reconcile the topics in kafka
                 for (String name : kafkaTopics) {
-                    logger.debug("{} reconciliation of topic {}", reconciliationType, name);
+                    LOGGER.debug("{} reconciliation of topic {}", reconciliationType, name);
                     TopicName topicName = new TopicName(name);
                     k8s.getFromName(topicName.asMapName(), ar -> {
                         ConfigMap cm = ar.result();
@@ -171,17 +171,17 @@ public class Session extends AbstractVerticle {
                     });
                 }
 
-                logger.debug("Reconciling configmaps");
+                LOGGER.debug("Reconciling configmaps");
                 // Then those in k8s which aren't in kafka
                 k8s.listMaps(ar -> {
                     List<ConfigMap> configMaps = ar.result();
                     Map<String, ConfigMap> configMapsMap = configMaps.stream().collect(Collectors.toMap(
-                            cm -> cm.getMetadata().getName(),
-                            cm -> cm));
+                        cm -> cm.getMetadata().getName(),
+                        cm -> cm));
                     configMapsMap.keySet().removeAll(kafkaTopics);
-                    logger.debug("Reconciling configmaps: {}", configMapsMap.keySet());
+                    LOGGER.debug("Reconciling configmaps: {}", configMapsMap.keySet());
                     for (ConfigMap cm : configMapsMap.values()) {
-                        logger.debug("{} reconciliation of configmap {}", reconciliationType, cm.getMetadata().getName());
+                        LOGGER.debug("{} reconciliation of configmap {}", reconciliationType, cm.getMetadata().getName());
                         // TODO need to check inflight
                         // TODO And need to prevent pileup of inflight periodic reconciliations
                         TopicName topicName = new TopicName(cm);
@@ -192,7 +192,7 @@ public class Session extends AbstractVerticle {
                     // TODO ^^
                 });
             } else {
-                logger.error("Error performing {} reconciliation", reconciliationType, arx.cause());
+                LOGGER.error("Error performing {} reconciliation", reconciliationType, arx.cause());
             }
         });
     }

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/Topic.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/Topic.java
@@ -22,19 +22,19 @@ public class Topic {
         }
 
         public Builder(String topicName, int numPartitions) {
-            this(new TopicName(topicName), numPartitions, (short)-1, null);
+            this(new TopicName(topicName), numPartitions, (short) -1, null);
         }
 
         public Builder(TopicName topicName, int numPartitions) {
-            this(topicName, numPartitions, (short)-1, null);
+            this(topicName, numPartitions, (short) -1, null);
         }
 
         public Builder(String topicName, int numPartitions, Map<String, String> config) {
-            this(new TopicName(topicName), numPartitions, (short)-1, config);
+            this(new TopicName(topicName), numPartitions, (short) -1, config);
         }
 
         public Builder(TopicName topicName, int numPartitions, Map<String, String> config) {
-            this(topicName, numPartitions, (short)-1, config);
+            this(topicName, numPartitions, (short) -1, config);
         }
 
         public Builder(String topicName, int numPartitions, short numReplicas, Map<String, String> config) {

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/TopicDiff.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/TopicDiff.java
@@ -77,7 +77,7 @@ public class TopicDiff {
         public static final String ADDRESS = "numReplicas";
         private short newNumReplicas;
 
-        public NumReplicasDifference (short newNumReplicas) {
+        public NumReplicasDifference(short newNumReplicas) {
             this.newNumReplicas = newNumReplicas;
         }
 
@@ -118,14 +118,14 @@ public class TopicDiff {
         private final String configValue;
 
         public AddedConfigEntry(String configKey, String configValue) {
-            assert(configKey != null && configValue != null);
+            assert configKey != null && configValue != null;
             this.configKey = configKey;
             this.configValue = configValue;
         }
 
         @Override
         public String address() {
-            return ADDRESS_PREFIX +configKey;
+            return ADDRESS_PREFIX + configKey;
         }
 
         @Override
@@ -168,7 +168,7 @@ public class TopicDiff {
 
         @Override
         public String address() {
-            return ADDRESS_PREFIX +configKey;
+            return ADDRESS_PREFIX + configKey;
         }
 
         @Override
@@ -284,7 +284,7 @@ public class TopicDiff {
     }
 
     public int numPartitionsDelta() {
-        NumPartitionsDifference newP = (NumPartitionsDifference)this.differences.get(NumPartitionsDifference.ADDRESS);
+        NumPartitionsDifference newP = (NumPartitionsDifference) this.differences.get(NumPartitionsDifference.ADDRESS);
         return newP == null ? 0 : newP.numPartitionsChange();
     }
 

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/TopicMetadataHandler.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/TopicMetadataHandler.java
@@ -73,7 +73,7 @@ public abstract class TopicMetadataHandler implements Handler<AsyncResult<TopicM
             vertx.runOnContext(timerId -> kafka.topicMetadata(topicName, this));
         } else {
             vertx.setTimer(TimeUnit.MILLISECONDS.convert(delay, TimeUnit.MILLISECONDS),
-                    timerId -> kafka.topicMetadata(topicName, this));
+                timerId -> kafka.topicMetadata(topicName, this));
         }
     }
 

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/TopicName.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/TopicName.java
@@ -19,7 +19,7 @@ class TopicName {
     private final String name;
 
     public TopicName(String name) {
-        assert(name != null && !name.isEmpty());
+        assert name != null && !name.isEmpty();
         // TODO Shame we can't validate a topic name without relying on an internal class
         Topic.validate(name);
         this.name = name;
@@ -64,16 +64,16 @@ class TopicName {
         } else {
             StringBuilder n = new StringBuilder();
             for (int i = 0; i < this.name.length(); i++) {
-                char next = i < this.name.length() - 1 ? this.name.charAt(i+1) : '\0';
+                char next = i < this.name.length() - 1 ? this.name.charAt(i + 1) : '\0';
                 char ch = this.name.charAt(i);
-                if (isInRange('a', ch,'z')
+                if (isInRange('a', ch, 'z')
                         || isInRange('0', ch, '9')) {
                     n.append(ch);
                 } else if (isInRange('A', ch, 'Z')) {
                     n.append(Character.toLowerCase(ch));
                 } else if (ch == '-' || ch == '.' || ch == '_') {
                     // avoid hyphen next to dot in the output
-                    for (int j = n.length()-1; j >= 0; j--) {
+                    for (int j = n.length() - 1; j >= 0; j--) {
                         if (isInRange('a', n.charAt(j), 'z')
                                 || isInRange('0', n.charAt(j), '9')) {
                             n.append(ch == '_' ? '-' : ch);
@@ -88,7 +88,7 @@ class TopicName {
 
             // it's still possible that n ends with a sequence of hyphens or dots
             int cut = 0;
-            for (int j = n.length()-1; j >= 0; j--) {
+            for (int j = n.length() - 1; j >= 0; j--) {
                 char ch = n.charAt(j);
                 if (ch == '.' || ch == '-') {
                     cut++;
@@ -96,7 +96,7 @@ class TopicName {
                     break;
                 }
             }
-            n.setLength(n.length()-cut);
+            n.setLength(n.length() - cut);
 
             final MessageDigest md;
             try {

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/TopicSerialization.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/TopicSerialization.java
@@ -61,7 +61,7 @@ public class TopicSerialization {
                 result = mapper.readValue(new StringReader(value) {
                     @Override
                     public String toString() {
-                        return "'config' key of 'data' section of ConfigMap '" +cm.getMetadata().getName() + "' in namespace '" + cm.getMetadata().getNamespace() + "'";
+                        return "'config' key of 'data' section of ConfigMap '" + cm.getMetadata().getName() + "' in namespace '" + cm.getMetadata().getNamespace() + "'";
                     }
                 }, Map.class);
             } catch (IOException e) {
@@ -83,14 +83,14 @@ public class TopicSerialization {
                 msg = "The value corresponding to the key must have a String value, not a value of type " + v.getClass();
             }
             if (!supportedConfigs.contains(key)) {
-                msg = "The allowed configs keys are "+ supportedConfigs;
+                msg = "The allowed configs keys are " + supportedConfigs;
             }
             if (msg != null) {
                 throw new InvalidConfigMapException(cm, "ConfigMap's 'data' section has invalid key '" +
-                        CM_KEY_CONFIG + "': The key '" + key +"' of the topic config is invalid: " + msg);
+                        CM_KEY_CONFIG + "': The key '" + key + "' of the topic config is invalid: " + msg);
             }
         }
-        return (Map)result;
+        return (Map) result;
     }
 
     private static Set<String> getSupportedTopicConfigs() {
@@ -193,7 +193,7 @@ public class TopicSerialization {
         try {
             mapData.put(CM_KEY_CONFIG, topicConfigToConfigMapString(topic.getConfig()));
         } catch (IOException e) {
-            throw new RuntimeException("Error converting topic config to a string, for topic '"+topic.getTopicName()+"'", e);
+            throw new RuntimeException("Error converting topic config to a string, for topic '" + topic.getTopicName() + "'", e);
         }
         MapName mapName = topic.getOrAsMapName();
         return new ConfigMapBuilder().withApiVersion("v1")
@@ -262,7 +262,7 @@ public class TopicSerialization {
         Topic.Builder builder = new Topic.Builder()
                 .withTopicName(meta.getDescription().name())
                 .withNumPartitions(meta.getDescription().partitions().size())
-                .withNumReplicas((short)meta.getDescription().partitions().get(0).replicas().size());
+                .withNumReplicas((short) meta.getDescription().partitions().get(0).replicas().size());
         for (ConfigEntry entry: meta.getConfig().entries()) {
             if (!entry.isDefault()) {
                 builder.withConfigEntry(entry.name(), entry.value());
@@ -311,11 +311,11 @@ public class TopicSerialization {
             throw new RuntimeException(e);
         }
         Topic.Builder builder = new Topic.Builder();
-        builder.withTopicName((String)root.get(JSON_KEY_TOPIC_NAME))
-                .withMapName((String)root.get(JSON_KEY_MAP_NAME))
-                .withNumPartitions((Integer)root.get(JSON_KEY_PARTITIONS))
-                .withNumReplicas(((Integer)root.get(JSON_KEY_REPLICAS)).shortValue());
-        Map<String, String> config = (Map)root.get(JSON_KEY_CONFIG);
+        builder.withTopicName((String) root.get(JSON_KEY_TOPIC_NAME))
+                .withMapName((String) root.get(JSON_KEY_MAP_NAME))
+                .withNumPartitions((Integer) root.get(JSON_KEY_PARTITIONS))
+                .withNumReplicas(((Integer) root.get(JSON_KEY_REPLICAS)).shortValue());
+        Map<String, String> config = (Map) root.get(JSON_KEY_CONFIG);
         for (Map.Entry<String, String> entry : config.entrySet()) {
             builder.withConfigEntry(entry.getKey(), entry.getValue());
         }

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/TopicsWatcher.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/TopicsWatcher.java
@@ -19,7 +19,7 @@ import java.util.Set;
  */
 class TopicsWatcher {
 
-    private final static Logger logger = LoggerFactory.getLogger(TopicsWatcher.class);
+    private final static Logger LOGGER = LoggerFactory.getLogger(TopicsWatcher.class);
 
     private static final String TOPICS_ZNODE = "/brokers/topics";
 
@@ -67,7 +67,7 @@ class TopicsWatcher {
                 throw new RuntimeException(childResult.cause());
             }
             List<String> result = childResult.result();
-            logger.debug("znode {} now has children {}, previous children {}", TOPICS_ZNODE, result, this.children);
+            LOGGER.debug("znode {} now has children {}, previous children {}", TOPICS_ZNODE, result, this.children);
             Set<String> deleted = new HashSet(this.children);
             deleted.removeAll(result);
             Set<String> created = new HashSet(result);
@@ -75,30 +75,30 @@ class TopicsWatcher {
             this.children = result;
 
             if (!deleted.isEmpty()) {
-                logger.info("Deleted topics: {}", deleted);
+                LOGGER.info("Deleted topics: {}", deleted);
                 for (String topicName : deleted) {
                     tcw.removeChild(topicName);
                     tw.removeChild(topicName);
                     controller.onTopicDeleted(new TopicName(topicName), ar -> {
                         if (ar.succeeded()) {
-                            logger.debug("Success responding to deletion of topic {}", topicName);
+                            LOGGER.debug("Success responding to deletion of topic {}", topicName);
                         } else {
-                            logger.warn("Error responding to deletion of topic {}", topicName, ar.cause());
+                            LOGGER.warn("Error responding to deletion of topic {}", topicName, ar.cause());
                         }
                     });
                 }
             }
 
             if (!created.isEmpty()) {
-                logger.info("Created topics: {}", created);
+                LOGGER.info("Created topics: {}", created);
                 for (String topicName : created) {
                     tcw.addChild(topicName);
                     tw.addChild(topicName);
                     controller.onTopicCreated(new TopicName(topicName), ar -> {
                         if (ar.succeeded()) {
-                            logger.debug("Success responding to creation of topic {}", topicName);
+                            LOGGER.debug("Success responding to creation of topic {}", topicName);
                         } else {
-                            logger.warn("Error responding to creation of topic {}", topicName, ar.cause());
+                            LOGGER.warn("Error responding to creation of topic {}", topicName, ar.cause());
                         }
                     });
                 }
@@ -109,7 +109,7 @@ class TopicsWatcher {
                 throw new RuntimeException(childResult.cause());
             }
             List<String> result = childResult.result();
-            logger.debug("Setting initial children {}", result);
+            LOGGER.debug("Setting initial children {}", result);
             this.children = result;
             this.state = 1;
         });

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/ZkTopicStore.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/ZkTopicStore.java
@@ -23,7 +23,7 @@ import java.util.List;
  */
 public class ZkTopicStore implements TopicStore {
 
-    private final static Logger logger = LoggerFactory.getLogger(ZkTopicStore.class);
+    private final static Logger LOGGER = LoggerFactory.getLogger(ZkTopicStore.class);
     public static final String TOPICS_PATH = "/strimzi/topics";
 
     private final Zk zk;
@@ -41,7 +41,7 @@ public class ZkTopicStore implements TopicStore {
         zk.create(path, null, acl, CreateMode.PERSISTENT, result -> {
             if (result.failed()) {
                 if (!(result.cause() instanceof KeeperException.NodeExistsException)) {
-                    logger.error("Error creating {}", path, result.cause());
+                    LOGGER.error("Error creating {}", path, result.cause());
                     throw new RuntimeException(result.cause());
                 }
             }
@@ -56,7 +56,7 @@ public class ZkTopicStore implements TopicStore {
     @Override
     public void read(TopicName topicName, Handler<AsyncResult<Topic>> handler) {
         String topicPath = getTopicPath(topicName);
-        logger.debug("read znode {}", topicPath);
+        LOGGER.debug("read znode {}", topicPath);
         zk.getData(topicPath, result -> {
             final AsyncResult<Topic> fut;
             if (result.succeeded()) {
@@ -65,7 +65,7 @@ public class ZkTopicStore implements TopicStore {
                 if (result.cause() instanceof KeeperException.NoNodeException) {
                     fut = Future.succeededFuture(null);
                 } else {
-                    fut = result.map((Topic)null);
+                    fut = result.map((Topic) null);
                 }
             }
             handler.handle(fut);
@@ -76,7 +76,7 @@ public class ZkTopicStore implements TopicStore {
     public void create(Topic topic, Handler<AsyncResult<Void>> handler) {
         byte[] data = TopicSerialization.toJson(topic);
         String topicPath = getTopicPath(topic.getTopicName());
-        logger.debug("create znode {}", topicPath);
+        LOGGER.debug("create znode {}", topicPath);
         zk.create(topicPath, data, acl, CreateMode.PERSISTENT, result -> {
             if (result.failed() && result.cause() instanceof KeeperException.NodeExistsException) {
                 handler.handle(Future.failedFuture(new EntityExistsException()));
@@ -91,7 +91,7 @@ public class ZkTopicStore implements TopicStore {
         byte[] data = TopicSerialization.toJson(topic);
         // TODO pass a non-zero version
         String topicPath = getTopicPath(topic.getTopicName());
-        logger.debug("update znode {}", topicPath);
+        LOGGER.debug("update znode {}", topicPath);
         zk.setData(topicPath, data, -1, handler);
     }
 
@@ -99,7 +99,7 @@ public class ZkTopicStore implements TopicStore {
     public void delete(TopicName topicName, Handler<AsyncResult<Void>> handler) {
         // TODO pass a non-zero version
         String topicPath = getTopicPath(topicName);
-        logger.debug("delete znode {}", topicPath);
+        LOGGER.debug("delete znode {}", topicPath);
         zk.delete(topicPath, -1, result -> {
             if (result.failed() && result.cause() instanceof KeeperException.NoNodeException) {
                 handler.handle(Future.failedFuture(new NoSuchEntityExistsException()));

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/ZkWatcher.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/ZkWatcher.java
@@ -23,7 +23,7 @@ public abstract class ZkWatcher {
     private volatile ZkWatcherState state = ZkWatcherState.NOT_STARTED;
     private volatile Zk zk;
 
-    private final ConcurrentHashMap<String,Boolean> children = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Boolean> children = new ConcurrentHashMap<>();
     private final String rootZNode;
 
     /**

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/zk/AclBuilder.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/zk/AclBuilder.java
@@ -117,7 +117,7 @@ public class AclBuilder {
             a = new ACL();
             digests.put(username, a);
         }
-        a.setId(new Id("digest", username+":"+password));
+        a.setId(new Id("digest", username + ":" + password));
         a.setPerms(Permission.encode(permissions));
         return this;
     }
@@ -151,7 +151,7 @@ public class AclBuilder {
      */
     public AclBuilder addIp(String address, int bits, Permission... permissions) {
         Map<String, ACL> ips = getIps();
-        String cidr = address+"/"+bits;
+        String cidr = address + "/" + bits;
         ACL a = ips.get(cidr);
         if (a == null) {
             a = new ACL();

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/zk/ZkImpl.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/zk/ZkImpl.java
@@ -30,7 +30,7 @@ import java.util.concurrent.ExecutionException;
  */
 public class ZkImpl implements Zk {
 
-    private final static Logger logger = LoggerFactory.getLogger(ZkImpl.class);
+    private final static Logger LOGGER = LoggerFactory.getLogger(ZkImpl.class);
     public static final String PREFIX_DATA = "data:";
     public static final String PREFIX_CHILDREN = "children:";
     public static final String PREFIX_EXISTS = "exists:";
@@ -59,7 +59,7 @@ public class ZkImpl implements Zk {
                 // See https://wiki.apache.org/hadoop/ZooKeeper/FAQ
                 // for state transitions
                 Watcher.Event.KeeperState state = watchedEvent.getState();
-                logger.debug("In state {}", state);
+                LOGGER.debug("In state {}", state);
                 final Future<Zk> future;
                 final Handler<AsyncResult<Zk>> handler;
                 switch (state) {
@@ -75,7 +75,7 @@ public class ZkImpl implements Zk {
                         }
                         /* fall through */
                     case SyncConnected:
-                        logger.debug("Connected, session id {}", zk().getSessionId());
+                        LOGGER.debug("Connected, session id {}", zk().getSessionId());
                         f.complete(null);
                         break;
                     case Expired:
@@ -140,7 +140,7 @@ public class ZkImpl implements Zk {
     @Override
     public Zk create(String path, byte[] data, List<ACL> acls, CreateMode createMode, Handler<AsyncResult<Void>> handler) {
         ZooKeeper zookeeper;
-        synchronized(this) {
+        synchronized (this) {
             zookeeper = zk;
         }
         if (zookeeper == null) {
@@ -148,7 +148,7 @@ public class ZkImpl implements Zk {
             return this;
         }
         zookeeper.create(path, data == null ? new byte[0] : data, acls, createMode,
-        (rc, path2, ctx, name) -> invokeOnContext(handler, path, rc, null), null);
+            (rc, path2, ctx, name) -> invokeOnContext(handler, path, rc, null), null);
         return this;
     }
 
@@ -156,7 +156,7 @@ public class ZkImpl implements Zk {
     @Override
     public Zk setData(String path, byte[] data, int version, Handler<AsyncResult<Void>> handler) {
         ZooKeeper zookeeper;
-        synchronized(this) {
+        synchronized (this) {
             zookeeper = zk;
         }
         if (zookeeper == null) {
@@ -164,7 +164,7 @@ public class ZkImpl implements Zk {
             return this;
         }
         zookeeper.setData(path, data, version,
-                (int rc, String path2, Object ctx, Stat stat) -> invokeOnContext(handler, path, rc, null),
+            (int rc, String path2, Object ctx, Stat stat) -> invokeOnContext(handler, path, rc, null),
                 null);
         return this;
     }
@@ -177,7 +177,7 @@ public class ZkImpl implements Zk {
     @Override
     public Zk getData(String path, Handler<AsyncResult<byte[]>> handler) {
         ZooKeeper zookeeper;
-        synchronized(this) {
+        synchronized (this) {
             zookeeper = zk;
         }
         if (zookeeper == null) {
@@ -185,7 +185,7 @@ public class ZkImpl implements Zk {
             return this;
         }
         final AsyncCallback.DataCallback callback = (rc, path2, ctx, data, stat) -> {
-            Watcher.Event.EventType eventType = (Watcher.Event.EventType)ctx;
+            Watcher.Event.EventType eventType = (Watcher.Event.EventType) ctx;
             if (eventType == null // first time
                     || eventType == Watcher.Event.EventType.NodeDataChanged) {
                 Future<byte[]> future = mapResult(path2, rc, data);
@@ -221,15 +221,15 @@ public class ZkImpl implements Zk {
     }
 
     private Handler<AsyncResult<byte[]>> getDataWatchHandler(String path) {
-        return (Handler<AsyncResult<byte[]>>)watches.get(PREFIX_DATA + path);
+        return (Handler<AsyncResult<byte[]>>) watches.get(PREFIX_DATA + path);
     }
 
     private Handler<AsyncResult<List<String>>> getChildrenWatchHandler(String path) {
-        return (Handler<AsyncResult<List<String>>>)watches.get(PREFIX_CHILDREN + path);
+        return (Handler<AsyncResult<List<String>>>) watches.get(PREFIX_CHILDREN + path);
     }
 
     private Handler<AsyncResult<Stat>> getExistsWatchHandler(String path) {
-        return (Handler<AsyncResult<Stat>>)watches.get(PREFIX_EXISTS + path);
+        return (Handler<AsyncResult<Stat>>) watches.get(PREFIX_EXISTS + path);
     }
 
     @Override
@@ -247,7 +247,7 @@ public class ZkImpl implements Zk {
     @Override
     public Zk delete(String path, int version, Handler<AsyncResult<Void>> handler) {
         ZooKeeper zookeeper;
-        synchronized(this) {
+        synchronized (this) {
             zookeeper = zk;
         }
         if (zookeeper == null) {
@@ -262,7 +262,7 @@ public class ZkImpl implements Zk {
     @Override
     public Zk exists(String path, Handler<AsyncResult<Stat>> handler) {
         ZooKeeper zookeeper;
-        synchronized(this) {
+        synchronized (this) {
             zookeeper = zk;
         }
         if (zookeeper == null) {
@@ -322,7 +322,7 @@ public class ZkImpl implements Zk {
     @Override
     public Zk children(String path, Handler<AsyncResult<List<String>>> handler) {
         ZooKeeper zookeeper;
-        synchronized(this) {
+        synchronized (this) {
             zookeeper = zk;
         }
         if (zookeeper == null) {
@@ -330,9 +330,9 @@ public class ZkImpl implements Zk {
             return this;
         }
         final AsyncCallback.Children2Callback callback = (rc, path2, ctx, children, stat) -> {
-            Watcher.Event.EventType eventType = (Watcher.Event.EventType)ctx;
+            Watcher.Event.EventType eventType = (Watcher.Event.EventType) ctx;
             KeeperException.Code code = KeeperException.Code.get(rc);
-            logger.debug("{}: {} {}", path2, eventType, code);
+            LOGGER.debug("{}: {} {}", path2, eventType, code);
             if (eventType == null // first time
                     || eventType == Watcher.Event.EventType.NodeChildrenChanged
                     || code != KeeperException.Code.OK) {

--- a/topic-controller/src/test/java/io/strimzi/controller/topic/ConfigTest.java
+++ b/topic-controller/src/test/java/io/strimzi/controller/topic/ConfigTest.java
@@ -15,12 +15,12 @@ import static org.junit.Assert.fail;
 
 public class ConfigTest {
 
-    private static final Map<String, String> mandatory = new HashMap<>();
+    private static final Map<String, String> MANDATORY = new HashMap<>();
 
     static {
-        mandatory.put(Config.ZOOKEEPER_CONNECT.key, "localhost:2181");
-        mandatory.put(Config.KAFKA_BOOTSTRAP_SERVERS.key, "localhost:9092");
-        mandatory.put(Config.NAMESPACE.key, "default");
+        MANDATORY.put(Config.ZOOKEEPER_CONNECT.key, "localhost:2181");
+        MANDATORY.put(Config.KAFKA_BOOTSTRAP_SERVERS.key, "localhost:9092");
+        MANDATORY.put(Config.NAMESPACE.key, "default");
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -35,14 +35,14 @@ public class ConfigTest {
 
     @Test
     public void defaults() {
-        Map<String, String> map = new HashMap<>(mandatory);
+        Map<String, String> map = new HashMap<>(MANDATORY);
         Config c = new Config(map);
         assertEquals(20_000, c.get(Config.ZOOKEEPER_SESSION_TIMEOUT_MS).intValue());
     }
 
     @Test
     public void override() {
-        Map<String, String> map = new HashMap<>(mandatory);
+        Map<String, String> map = new HashMap<>(MANDATORY);
         map.put(Config.ZOOKEEPER_SESSION_TIMEOUT_MS.key, "13 seconds");
 
         Config c = new Config(map);
@@ -51,7 +51,7 @@ public class ConfigTest {
 
     @Test
     public void intervals() {
-        Map<String, String> map = new HashMap<>(mandatory);
+        Map<String, String> map = new HashMap<>(MANDATORY);
 
         map.put(Config.ZOOKEEPER_SESSION_TIMEOUT_MS.key, "13 seconds");
         new Config(map);

--- a/topic-controller/src/test/java/io/strimzi/controller/topic/ControllerAssignedKafkaImplTest.java
+++ b/topic-controller/src/test/java/io/strimzi/controller/topic/ControllerAssignedKafkaImplTest.java
@@ -19,7 +19,6 @@ import java.util.Map;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
-import static java.util.Collections.singletonMap;
 
 @RunWith(VertxUnitRunner.class)
 public class ControllerAssignedKafkaImplTest {
@@ -56,7 +55,7 @@ public class ControllerAssignedKafkaImplTest {
         }
 
         static List<String> verifyInProgress(String... partitions) {
-            List<String> result = new ArrayList(2*partitions.length);
+            List<String> result = new ArrayList(2 * partitions.length);
             for (String partition: partitions) {
                 result.add("--verify-in-progress");
                 result.add(partition);
@@ -65,7 +64,7 @@ public class ControllerAssignedKafkaImplTest {
         }
 
         static List<String> verifySuccess(String... partitions) {
-            List<String> result = new ArrayList(2*partitions.length);
+            List<String> result = new ArrayList(2 * partitions.length);
             for (String partition: partitions) {
                 result.add("--verify-success");
                 result.add(partition);

--- a/topic-controller/src/test/java/io/strimzi/controller/topic/ControllerIntegrationTest.java
+++ b/topic-controller/src/test/java/io/strimzi/controller/topic/ControllerIntegrationTest.java
@@ -56,21 +56,21 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 @RoleBinding(
-        name="strimzi-role-binding",
-        role="strimzi-role",
-        users="developer"
+        name = "strimzi-role-binding",
+        role = "strimzi-role",
+        users = "developer"
 )
 @Role(
-        name="strimzi-role",
+        name = "strimzi-role",
         permissions = {
-            @Permission(resource="cm", verbs={"get", "create", "watch", "list", "delete", "update"}),
-            @Permission(resource="events", verbs={"get", "create"})
+            @Permission(resource = "cm", verbs = {"get", "create", "watch", "list", "delete", "update"}),
+            @Permission(resource = "events", verbs = {"get", "create"})
         }
 )
 @RunWith(VertxUnitRunner.class)
 public class ControllerIntegrationTest {
 
-    private static final Logger logger = LoggerFactory.getLogger(ControllerIntegrationTest.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ControllerIntegrationTest.class);
 
     @ClassRule
     public static KubeClusterResource testCluster = new KubeClusterResource();
@@ -106,7 +106,7 @@ public class ControllerIntegrationTest {
 
     @Before
     public void setup(TestContext context) throws Exception {
-        logger.info("Setting up test");
+        LOGGER.info("Setting up test");
         Runtime.getRuntime().addShutdownHook(kafkaHook);
         kafkaCluster = new KafkaCluster();
         kafkaCluster.addBrokers(1);
@@ -117,10 +117,10 @@ public class ControllerIntegrationTest {
 
         kubeClient = new DefaultKubernetesClient();
         namespace = testCluster.defaultNamespace();
-        logger.info("Using namespace {}", namespace);
+        LOGGER.info("Using namespace {}", namespace);
         Map<String, String> m = new HashMap();
         m.put(Config.KAFKA_BOOTSTRAP_SERVERS.key, kafkaCluster.brokerList());
-        m.put(Config.ZOOKEEPER_CONNECT.key, "localhost:"+ zkPort(kafkaCluster));
+        m.put(Config.ZOOKEEPER_CONNECT.key, "localhost:" + zkPort(kafkaCluster));
         m.put(Config.NAMESPACE.key, testCluster.defaultNamespace());
         Session session = new Session(kubeClient, new Config(m));
 
@@ -153,7 +153,7 @@ public class ControllerIntegrationTest {
                 map(evt -> evt.getMetadata().getUid()).
                 collect(Collectors.toSet());
 
-        logger.info("Finished setting up test");
+        LOGGER.info("Finished setting up test");
     }
 
     private static int zkPort(KafkaCluster cluster) {
@@ -170,7 +170,7 @@ public class ControllerIntegrationTest {
 
     @After
     public void teardown(TestContext context) {
-        logger.info("Tearing down test");
+        LOGGER.info("Tearing down test");
 
         kubeClient.configMaps().inNamespace(namespace).delete();
 
@@ -186,7 +186,7 @@ public class ControllerIntegrationTest {
                 topicWatcher = null;
                 topicsWatcher = null;
                 if (ar.failed()) {
-                    logger.error("Error undeploying session", ar.cause());
+                    LOGGER.error("Error undeploying session", ar.cause());
                     context.fail("Error undeploying session");
                 }
                 async.complete();
@@ -197,7 +197,7 @@ public class ControllerIntegrationTest {
             kafkaCluster.shutdown();
         }
         Runtime.getRuntime().removeShutdownHook(kafkaHook);
-        logger.info("Finished tearing down test");
+        LOGGER.info("Finished tearing down test");
     }
 
 
@@ -207,7 +207,7 @@ public class ControllerIntegrationTest {
         kubeClient.configMaps().inNamespace(namespace).create(cm);
 
         // Wait for the topic to be created
-        waitFor(context, ()-> {
+        waitFor(context, () -> {
             try {
                 adminClient.describeTopics(singletonList(topicName)).values().get(topicName).get();
                 return true;
@@ -231,7 +231,7 @@ public class ControllerIntegrationTest {
     }
 
     private String createTopic(TestContext context, String topicName) throws InterruptedException, ExecutionException {
-        logger.info("Creating topic {}", topicName);
+        LOGGER.info("Creating topic {}", topicName);
         // Create a topic
         String configMapName = new TopicName(topicName).asMapName().toString();
         CreateTopicsResult crt = adminClient.createTopics(singletonList(new NewTopic(topicName, 1, (short) 1)));
@@ -240,11 +240,11 @@ public class ControllerIntegrationTest {
         // Wait for the configmap to be created
         waitFor(context, () -> {
             ConfigMap cm = kubeClient.configMaps().inNamespace(namespace).withName(configMapName).get();
-            logger.info("Polled configmap {} waiting for creation", configMapName);
+            LOGGER.info("Polled configmap {} waiting for creation", configMapName);
             return cm != null;
         }, timeout, "Expected the configmap to have been created by now");
 
-        logger.info("configmap {} has been created", configMapName);
+        LOGGER.info("configmap {} has been created", configMapName);
         return configMapName;
     }
 
@@ -266,7 +266,7 @@ public class ControllerIntegrationTest {
             changedValue = "snappy";
         }
         m.put(key, new ConfigEntry(key, changedValue));
-        logger.info("Changing topic config {} to {}", key, changedValue);
+        LOGGER.info("Changing topic config {} to {}", key, changedValue);
 
         // Update the topic config
         AlterConfigsResult cgf = adminClient.alterConfigs(singletonMap(configResource,
@@ -276,9 +276,9 @@ public class ControllerIntegrationTest {
         // Wait for the configmap to be modified
         waitFor(context, () -> {
             ConfigMap cm = kubeClient.configMaps().inNamespace(namespace).withName(configMapName).get();
-            logger.info("Polled configmap {}, waiting for config change", configMapName);
+            LOGGER.info("Polled configmap {}, waiting for config change", configMapName);
             String gotValue = TopicSerialization.fromConfigMap(cm).getConfig().get(key);
-            logger.info("Got value {}", gotValue);
+            LOGGER.info("Got value {}", gotValue);
             return changedValue.equals(gotValue);
         }, timeout, "Expected the configmap to have been deleted by now");
     }
@@ -296,10 +296,10 @@ public class ControllerIntegrationTest {
         // Wait for the configmap to be modified
         waitFor(context, () -> {
             ConfigMap cm = kubeClient.configMaps().inNamespace(namespace).withName(configMapName).get();
-            logger.info("Polled configmap {}, waiting for partitions change", configMapName);
+            LOGGER.info("Polled configmap {}, waiting for partitions change", configMapName);
             int gotValue = TopicSerialization.fromConfigMap(cm).getNumPartitions();
-            logger.info("Got value {}", gotValue);
-            return (changedValue == gotValue);
+            LOGGER.info("Got value {}", gotValue);
+            return changedValue == gotValue;
         }, timeout, "Expected the configmap to have been deleted by now");
     }
 
@@ -323,16 +323,16 @@ public class ControllerIntegrationTest {
     }
 
     private void deleteTopic(TestContext context, String topicName, String configMapName) throws InterruptedException, ExecutionException {
-        logger.info("Deleting topic {} (ConfigMap {})", topicName, configMapName);
+        LOGGER.info("Deleting topic {} (ConfigMap {})", topicName, configMapName);
         // Now we can delete the topic
         DeleteTopicsResult dlt = adminClient.deleteTopics(singletonList(topicName));
         dlt.all().get();
-        logger.info("Deleted topic {}", topicName);
+        LOGGER.info("Deleted topic {}", topicName);
 
         // Wait for the configmap to be deleted
         waitFor(context, () -> {
             ConfigMap cm = kubeClient.configMaps().inNamespace(namespace).withName(configMapName).get();
-            logger.info("Polled configmap {}, got {}, waiting for deletion", configMapName, cm);
+            LOGGER.info("Polled configmap {}, got {}, waiting for deletion", configMapName, cm);
             return cm == null;
         }, timeout, "Expected the configmap to have been deleted by now");
     }
@@ -352,7 +352,7 @@ public class ControllerIntegrationTest {
         Async async = context.async();
         long t0 = System.currentTimeMillis();
         Future<Void> fut = Future.future();
-        vertx.setPeriodic(3_000L, timerId-> {
+        vertx.setPeriodic(3_000L, timerId -> {
             // Wait for a configmap to be created
             boolean isFinished;
             try {
@@ -388,7 +388,7 @@ public class ControllerIntegrationTest {
                     && "ConfigMap".equals(evt.getInvolvedObject().getKind())
                     && cm.getMetadata().getName().equals(evt.getInvolvedObject().getName())).
                     collect(Collectors.toList());
-            logger.debug("Waiting for events: {}", filtered.stream().map(evt->evt.getMessage()).collect(Collectors.toList()));
+            LOGGER.debug("Waiting for events: {}", filtered.stream().map(evt -> evt.getMessage()).collect(Collectors.toList()));
             if (!filtered.isEmpty()) {
                 assertEquals(1, filtered.size());
                 Event event = filtered.get(0);
@@ -482,7 +482,7 @@ public class ControllerIntegrationTest {
         kubeClient.configMaps().inNamespace(namespace).withName(cm.getMetadata().getName()).delete();
 
         // Wait for the topic to be deleted
-        waitFor(context, ()-> {
+        waitFor(context, () -> {
             try {
                 adminClient.describeTopics(singletonList(topicName)).values().get(topicName).get();
                 return false;
@@ -510,11 +510,11 @@ public class ControllerIntegrationTest {
         kubeClient.configMaps().inNamespace(namespace).withName(cm.getMetadata().getName()).edit().addToData(TopicSerialization.CM_KEY_CONFIG, "{\"retention.ms\":\"12341234\"}").done();
 
         // Wait for that to be reflected in the topic
-        waitFor(context, ()-> {
+        waitFor(context, () -> {
             ConfigResource configResource = topicConfigResource(topicName);
             org.apache.kafka.clients.admin.Config config = getTopicConfig(configResource);
             String retention = config.get("retention.ms").value();
-            logger.debug("retention of {}, waiting for 12341234", retention);
+            LOGGER.debug("retention of {}, waiting for 12341234", retention);
             return "12341234".equals(retention);
         },  timeout, "Expected the topic to be updated");
     }
@@ -544,7 +544,7 @@ public class ControllerIntegrationTest {
 
         // now change the cm
         String changedName = topicName.toUpperCase(Locale.ENGLISH);
-        logger.info("Changing CM data.name from {} to {}", topicName, changedName);
+        LOGGER.info("Changing CM data.name from {} to {}", topicName, changedName);
         kubeClient.configMaps().inNamespace(namespace).withName(cm.getMetadata().getName()).edit().addToData(TopicSerialization.CM_KEY_NAME, changedName).done();
 
         // We expect this to cause a warning event
@@ -559,7 +559,7 @@ public class ControllerIntegrationTest {
         String topicName = "two-cms-one-topic";
         Topic topic = new Topic.Builder(topicName, 1, (short) 1, emptyMap()).build();
         ConfigMap cm = TopicSerialization.toConfigMap(topic, cmPredicate);
-        ConfigMap cm2 = new ConfigMapBuilder(cm).editMetadata().withName(topicName+"-1").endMetadata().build();
+        ConfigMap cm2 = new ConfigMapBuilder(cm).editMetadata().withName(topicName + "-1").endMetadata().build();
         // create one
         createCm(context, cm2);
         // create another

--- a/topic-controller/src/test/java/io/strimzi/controller/topic/ControllerIntegrationTest.java
+++ b/topic-controller/src/test/java/io/strimzi/controller/topic/ControllerIntegrationTest.java
@@ -82,10 +82,7 @@ public class ControllerIntegrationTest {
 
     private final Vertx vertx = Vertx.vertx();
     private KafkaCluster kafkaCluster;
-    private volatile Controller controller;
-    private volatile ControllerAssignedKafkaImpl kafka;
     private volatile AdminClient adminClient;
-    private volatile K8sImpl k8s;
     private DefaultKubernetesClient kubeClient;
     private volatile TopicsWatcher topicsWatcher;
     private Thread kafkaHook = new Thread() {
@@ -99,7 +96,6 @@ public class ControllerIntegrationTest {
     private volatile TopicConfigsWatcher topicsConfigWatcher;
     private volatile TopicWatcher topicWatcher;
 
-    private Session session;
     private volatile String deploymentId;
     private Set<String> preExistingEvents;
 
@@ -129,9 +125,6 @@ public class ControllerIntegrationTest {
             if (ar.succeeded()) {
                 deploymentId = ar.result();
                 adminClient = session.adminClient;
-                kafka = session.kafka;
-                k8s = session.k8s;
-                controller = session.controller;
                 topicsConfigWatcher = session.topicConfigsWatcher;
                 topicWatcher = session.topicWatcher;
                 topicsWatcher = session.topicsWatcher;
@@ -179,9 +172,6 @@ public class ControllerIntegrationTest {
             vertx.undeploy(deploymentId, ar -> {
                 deploymentId = null;
                 adminClient = null;
-                kafka = null;
-                k8s = null;
-                controller = null;
                 topicsConfigWatcher = null;
                 topicWatcher = null;
                 topicsWatcher = null;

--- a/topic-controller/src/test/java/io/strimzi/controller/topic/ControllerTest.java
+++ b/topic-controller/src/test/java/io/strimzi/controller/topic/ControllerTest.java
@@ -39,9 +39,7 @@ import static java.util.Arrays.asList;
 @RunWith(VertxUnitRunner.class)
 public class ControllerTest {
 
-    private final LabelPredicate cmPredicate = new LabelPredicate(
-            "kind", "topic",
-            "app", "strimzi");
+    private final LabelPredicate cmPredicate = LabelPredicate.fromString("kind=topic,app=strimzi");
 
     private final TopicName topicName = new TopicName("my-topic");
     private final MapName mapName = topicName.asMapName();
@@ -128,10 +126,9 @@ public class ControllerTest {
     /** Test what happens when a non-topic config map gets created in kubernetes */
     @Test
     public void testOnConfigMapAdded_invalidCm(TestContext context) {
-        Map<String, String> data = new HashMap<>();
-        data.put(TopicSerialization.CM_KEY_REPLICAS, "1");
-        data.put(TopicSerialization.CM_KEY_PARTITIONS, "1");
-        data.put(TopicSerialization.CM_KEY_CONFIG, "{null:null}");
+        Map<String, String> data = map(TopicSerialization.CM_KEY_REPLICAS, "1",
+                TopicSerialization.CM_KEY_PARTITIONS, "1",
+                TopicSerialization.CM_KEY_CONFIG, "{null:null}");
         ConfigMap cm = new ConfigMapBuilder().withNewMetadata().withName("invalid").withLabels(cmPredicate.labels()).endMetadata().
                 withData(data).build();
 

--- a/topic-controller/src/test/java/io/strimzi/controller/topic/ControllerTest.java
+++ b/topic-controller/src/test/java/io/strimzi/controller/topic/ControllerTest.java
@@ -72,9 +72,9 @@ public class ControllerTest {
         if (pairs.length % 2 != 0) {
             throw new IllegalArgumentException();
         }
-        Map<String, String> result = new HashMap<>(pairs.length/2);
-        for (int i = 0; i < pairs.length; i+=2) {
-            result.put(pairs[i], pairs[i+1]);
+        Map<String, String> result = new HashMap<>(pairs.length / 2);
+        for (int i = 0; i < pairs.length; i += 2) {
+            result.put(pairs[i], pairs[i + 1]);
         }
         return result;
     }
@@ -95,14 +95,14 @@ public class ControllerTest {
     private TopicMetadata getTopicMetadata(Topic kubeTopic) {
         List<Node> nodes = new ArrayList<>();
         for (int nodeId = 0; nodeId < kubeTopic.getNumReplicas(); nodeId++) {
-            nodes.add(new Node(nodeId, "localhost", 9092+nodeId));
+            nodes.add(new Node(nodeId, "localhost", 9092 + nodeId));
         }
         List<TopicPartitionInfo> partitions = new ArrayList<>();
         for (int partitionId = 0; partitionId < kubeTopic.getNumPartitions(); partitionId++) {
             partitions.add(new TopicPartitionInfo(partitionId, nodes.get(0), nodes, nodes));
         }
         List<ConfigEntry> configs = new ArrayList<>();
-        for (Map.Entry<String,String> entry: kubeTopic.getConfig().entrySet()) {
+        for (Map.Entry<String, String> entry: kubeTopic.getConfig().entrySet()) {
             configs.add(new ConfigEntry(entry.getKey(), entry.getValue()));
         }
 
@@ -305,7 +305,7 @@ public class ControllerTest {
     }
 
     private <T> void assertSucceeded(TestContext context, AsyncResult<T> ar) {
-        context.assertTrue(ar.succeeded(), ar.cause() != null ? ar.cause().toString(): "");
+        context.assertTrue(ar.succeeded(), ar.cause() != null ? ar.cause().toString() : "");
     }
 
     private <T> void assertFailed(TestContext context, AsyncResult<T> ar) {
@@ -340,34 +340,34 @@ public class ControllerTest {
      */
     @Test
     public void testOnTopicChanged(TestContext context) {
-        Topic kubeTopic = new Topic.Builder(topicName.toString(), 10, (short)2, map("cleanup.policy", "bar")).build();
-        Topic kafkaTopic = new Topic.Builder(topicName.toString(), 10, (short)2, map("cleanup.policy", "baz")).build();
+        Topic kubeTopic = new Topic.Builder(topicName.toString(), 10, (short) 2, map("cleanup.policy", "bar")).build();
+        Topic kafkaTopic = new Topic.Builder(topicName.toString(), 10, (short) 2, map("cleanup.policy", "baz")).build();
         Topic privateTopic = kubeTopic;
         ConfigMap cm = TopicSerialization.toConfigMap(kubeTopic, cmPredicate);
 
         mockKafka.setCreateTopicResponse(topicName.toString(), null)
-                .createTopic(kafkaTopic, ar -> {});
+                .createTopic(kafkaTopic, ar -> { });
         mockKafka.setTopicMetadataResponse(topicName, getTopicMetadata(kafkaTopic), null);
         //mockKafka.setUpdateTopicResponse(topicName -> Future.succeededFuture());
 
         mockTopicStore.setCreateTopicResponse(topicName, null)
-                .create(privateTopic, ar -> {});
+                .create(privateTopic, ar -> { });
         mockTopicStore.setUpdateTopicResponse(topicName, null);
 
         mockK8s.setCreateResponse(mapName, null)
-                .createConfigMap(cm, ar->{});
+                .createConfigMap(cm, ar -> { });
         mockK8s.setModifyResponse(mapName, null);
 
         Async async = context.async(3);
-        controller.onTopicConfigChanged(topicName, ar-> {
+        controller.onTopicConfigChanged(topicName, ar -> {
             assertSucceeded(context, ar);
             context.assertEquals("baz", mockKafka.getTopicState(topicName).getConfig().get("cleanup.policy"));
-            mockTopicStore.read(topicName, ar2-> {
+            mockTopicStore.read(topicName, ar2 -> {
                 assertSucceeded(context, ar2);
                 context.assertEquals("baz", ar2.result().getConfig().get("cleanup.policy"));
                 async.countDown();
             });
-            mockK8s.getFromName(mapName, ar2-> {
+            mockK8s.getFromName(mapName, ar2 -> {
                 assertSucceeded(context, ar2);
                 context.assertEquals("baz", TopicSerialization.fromConfigMap(ar2.result()).getConfig().get("cleanup.policy"));
                 async.countDown();
@@ -385,7 +385,7 @@ public class ControllerTest {
     @Test
     public void testReconcile_withCm_noKafka_noPrivate(TestContext context) {
 
-        Topic kubeTopic = new Topic.Builder(topicName.toString(), 10, (short)2, map("cleanup.policy", "bar")).build();
+        Topic kubeTopic = new Topic.Builder(topicName.toString(), 10, (short) 2, map("cleanup.policy", "bar")).build();
         Topic kafkaTopic = null;
         Topic privateTopic = null;
 
@@ -417,7 +417,7 @@ public class ControllerTest {
     @Test
     public void testReconcile_withCm_noKafka_withPrivate(TestContext context) {
 
-        Topic kubeTopic = new Topic.Builder(topicName.toString(), 10, (short)2, map("cleanup.policy", "bar")).build();
+        Topic kubeTopic = new Topic.Builder(topicName.toString(), 10, (short) 2, map("cleanup.policy", "bar")).build();
         Topic kafkaTopic = null;
         Topic privateTopic = kubeTopic;
 
@@ -426,7 +426,7 @@ public class ControllerTest {
                 .createConfigMap(TopicSerialization.toConfigMap(kubeTopic, cmPredicate), ar -> async0.countDown());
         mockK8s.setDeleteResponse(mapName, null);
         mockTopicStore.setCreateTopicResponse(topicName, null)
-                .create(privateTopic, ar-> async0.countDown());
+                .create(privateTopic, ar -> async0.countDown());
         mockTopicStore.setDeleteTopicResponse(topicName, null);
 
         Async async = context.async();
@@ -448,7 +448,7 @@ public class ControllerTest {
     public void testReconcile_noCm_withKafka_noPrivate(TestContext context) {
 
         Topic kubeTopic = null;
-        Topic kafkaTopic = new Topic.Builder(topicName.toString(), 10, (short)2, map("cleanup.policy", "bar")).build();
+        Topic kafkaTopic = new Topic.Builder(topicName.toString(), 10, (short) 2, map("cleanup.policy", "bar")).build();
         Topic privateTopic = null;
 
         Async async0 = context.async();
@@ -486,7 +486,7 @@ public class ControllerTest {
     @Test
     public void testReconcile_noCm_withKafka_withPrivate(TestContext context) {
         Topic kubeTopic = null;
-        Topic kafkaTopic = new Topic.Builder(topicName.toString(), 10, (short)2, map("cleanup.policy", "bar")).build();
+        Topic kafkaTopic = new Topic.Builder(topicName.toString(), 10, (short) 2, map("cleanup.policy", "bar")).build();
         Topic privateTopic = kafkaTopic;
 
         Async async0 = context.async(2);
@@ -514,7 +514,7 @@ public class ControllerTest {
      */
     @Test
     public void testReconcile_withCm_withKafka_noPrivate_matching(TestContext context) {
-        Topic kubeTopic = new Topic.Builder(topicName.toString(), 10, (short)2, map("cleanup.policy", "bar")).build();
+        Topic kubeTopic = new Topic.Builder(topicName.toString(), 10, (short) 2, map("cleanup.policy", "bar")).build();
         Topic kafkaTopic = kubeTopic;
         Topic privateTopic = null;
 
@@ -549,10 +549,10 @@ public class ControllerTest {
      */
     @Test
     public void testReconcile_withCm_withKafka_noPrivate_configsReconcilable(TestContext context) {
-        Topic kubeTopic = new Topic.Builder(topicName.toString(), 10, (short)2, map("cleanup.policy", "bar")).build();
-        Topic kafkaTopic = new Topic.Builder(topicName.toString(), 10, (short)2, map("unclean.leader.election.enable", "true")).build();
+        Topic kubeTopic = new Topic.Builder(topicName.toString(), 10, (short) 2, map("cleanup.policy", "bar")).build();
+        Topic kafkaTopic = new Topic.Builder(topicName.toString(), 10, (short) 2, map("unclean.leader.election.enable", "true")).build();
         Topic privateTopic = null;
-        Topic mergedTopic = new Topic.Builder(topicName.toString(), 10, (short)2, map("unclean.leader.election.enable", "true", "cleanup.policy", "bar")).build();
+        Topic mergedTopic = new Topic.Builder(topicName.toString(), 10, (short) 2, map("unclean.leader.election.enable", "true", "cleanup.policy", "bar")).build();
 
         Async async0 = context.async(2);
         mockKafka.setCreateTopicResponse(topicName -> Future.succeededFuture());
@@ -592,8 +592,8 @@ public class ControllerTest {
      */
     @Test
     public void testReconcile_withCm_withKafka_noPrivate_irreconcilable(TestContext context) {
-        Topic kubeTopic = new Topic.Builder(topicName.toString(), 10, (short)2, map("cleanup.policy", "bar")).build();
-        Topic kafkaTopic = new Topic.Builder(topicName.toString(), 12, (short)2, map("cleanup.policy", "baz")).build();
+        Topic kubeTopic = new Topic.Builder(topicName.toString(), 10, (short) 2, map("cleanup.policy", "bar")).build();
+        Topic kafkaTopic = new Topic.Builder(topicName.toString(), 12, (short) 2, map("cleanup.policy", "baz")).build();
         Topic privateTopic = null;
 
         Async async0 = context.async(2);
@@ -636,10 +636,10 @@ public class ControllerTest {
      */
     @Test
     public void testReconcile_withCm_withKafka_withPrivate_3WayMerge(TestContext context) {
-        Topic kubeTopic = new Topic.Builder(topicName, mapName, 10, (short)2, map("cleanup.policy", "bar")).build();
-        Topic kafkaTopic = new Topic.Builder(topicName, mapName, 12, (short)2, map("cleanup.policy", "baz")).build();
-        Topic privateTopic = new Topic.Builder(topicName, mapName, 10, (short)2, map("cleanup.policy", "baz")).build();
-        Topic resultTopic = new Topic.Builder(topicName, mapName, 12, (short)2, map("cleanup.policy", "bar")).build();
+        Topic kubeTopic = new Topic.Builder(topicName, mapName, 10, (short) 2, map("cleanup.policy", "bar")).build();
+        Topic kafkaTopic = new Topic.Builder(topicName, mapName, 12, (short) 2, map("cleanup.policy", "baz")).build();
+        Topic privateTopic = new Topic.Builder(topicName, mapName, 10, (short) 2, map("cleanup.policy", "baz")).build();
+        Topic resultTopic = new Topic.Builder(topicName, mapName, 12, (short) 2, map("cleanup.policy", "bar")).build();
 
         Async async0 = context.async(3);
         mockKafka.setCreateTopicResponse(topicName -> Future.succeededFuture());
@@ -683,17 +683,17 @@ public class ControllerTest {
     // + error cases
 
     private void configMapRemoved(TestContext context, Exception deleteTopicException, Exception storeException) {
-        Topic kubeTopic = new Topic.Builder(topicName.toString(), 10, (short)2, map("cleanup.policy", "bar")).build();
+        Topic kubeTopic = new Topic.Builder(topicName.toString(), 10, (short) 2, map("cleanup.policy", "bar")).build();
         Topic kafkaTopic = kubeTopic;
         Topic privateTopic = kubeTopic;
 
         mockKafka.setCreateTopicResponse(topicName.toString(), null)
-                .createTopic(kafkaTopic, ar -> {});
+                .createTopic(kafkaTopic, ar -> { });
         mockKafka.setTopicMetadataResponse(topicName, getTopicMetadata(kubeTopic), null);
         mockKafka.setDeleteTopicResponse(topicName, deleteTopicException);
 
         mockTopicStore.setCreateTopicResponse(topicName, null)
-                .create(privateTopic, ar -> {});
+                .create(privateTopic, ar -> { });
         mockTopicStore.setDeleteTopicResponse(topicName, storeException);
 
         ConfigMap cm = TopicSerialization.toConfigMap(kubeTopic, cmPredicate);
@@ -721,32 +721,32 @@ public class ControllerTest {
 
     @Test
     public void testOnConfigMapChanged(TestContext context) {
-        Topic kubeTopic = new Topic.Builder(topicName, mapName, 10, (short)2, map("cleanup.policy", "baz")).build();
-        Topic kafkaTopic = new Topic.Builder(topicName, mapName, 10, (short)2, map("cleanup.policy", "bar")).build();
+        Topic kubeTopic = new Topic.Builder(topicName, mapName, 10, (short) 2, map("cleanup.policy", "baz")).build();
+        Topic kafkaTopic = new Topic.Builder(topicName, mapName, 10, (short) 2, map("cleanup.policy", "bar")).build();
         Topic privateTopic = kafkaTopic;
         ConfigMap cm = TopicSerialization.toConfigMap(kubeTopic, cmPredicate);
 
         mockKafka.setCreateTopicResponse(topicName.toString(), null)
-                .createTopic(kafkaTopic, ar -> {});
+                .createTopic(kafkaTopic, ar -> { });
         mockKafka.setTopicMetadataResponse(topicName, getTopicMetadata(kafkaTopic), null);
         mockKafka.setUpdateTopicResponse(topicName -> Future.succeededFuture());
 
         mockTopicStore.setCreateTopicResponse(topicName, null)
-                .create(privateTopic, ar -> {});
+                .create(privateTopic, ar -> { });
         mockTopicStore.setUpdateTopicResponse(topicName, null);
 
         mockK8s.setModifyResponse(mapName, null);
 
         Async async = context.async(3);
-        controller.onConfigMapModified(cm, ar-> {
+        controller.onConfigMapModified(cm, ar -> {
             assertSucceeded(context, ar);
             context.assertEquals("baz", mockKafka.getTopicState(topicName).getConfig().get("cleanup.policy"));
-            mockTopicStore.read(topicName, ar2-> {
+            mockTopicStore.read(topicName, ar2 -> {
                 assertSucceeded(context, ar2);
                 context.assertEquals("baz", ar2.result().getConfig().get("cleanup.policy"));
                 async.countDown();
             });
-            mockK8s.getFromName(mapName, ar2-> {
+            mockK8s.getFromName(mapName, ar2 -> {
                 assertSucceeded(context, ar2);
                 context.assertEquals("baz", TopicSerialization.fromConfigMap(ar2.result()).getConfig().get("cleanup.policy"));
                 async.countDown();
@@ -777,16 +777,16 @@ public class ControllerTest {
     }
 
     private void topicDeleted(TestContext context, Exception storeException, Exception k8sException) {
-        Topic kubeTopic = new Topic.Builder(topicName.toString(), 10, (short)2, map("cleanup.policy", "bar")).withMapName(mapName).build();
+        Topic kubeTopic = new Topic.Builder(topicName.toString(), 10, (short) 2, map("cleanup.policy", "bar")).withMapName(mapName).build();
         Topic kafkaTopic = kubeTopic;
         Topic privateTopic = kubeTopic;
 
         mockK8s.setCreateResponse(mapName, null)
-                .createConfigMap(TopicSerialization.toConfigMap(kubeTopic, cmPredicate), ar -> {});
+                .createConfigMap(TopicSerialization.toConfigMap(kubeTopic, cmPredicate), ar -> { });
         mockK8s.setDeleteResponse(mapName, k8sException);
 
         mockTopicStore.setCreateTopicResponse(topicName, null)
-                .create(privateTopic, ar -> {});
+                .create(privateTopic, ar -> { });
         mockTopicStore.setDeleteTopicResponse(topicName, storeException);
 
         Async async = context.async();

--- a/topic-controller/src/test/java/io/strimzi/controller/topic/EmbeddedZooKeeper.java
+++ b/topic-controller/src/test/java/io/strimzi/controller/topic/EmbeddedZooKeeper.java
@@ -69,7 +69,7 @@ public class EmbeddedZooKeeper {
 
     public String getZkConnectString() {
         InetSocketAddress addr = factory.getLocalAddress();
-        return addr.getAddress().getHostAddress()+":"+addr.getPort();
+        return addr.getAddress().getHostAddress() + ":" + addr.getPort();
     }
 
 }

--- a/topic-controller/src/test/java/io/strimzi/controller/topic/InFlightTest.java
+++ b/topic-controller/src/test/java/io/strimzi/controller/topic/InFlightTest.java
@@ -16,7 +16,7 @@ import org.slf4j.LoggerFactory;
 @RunWith(VertxUnitRunner.class)
 public class InFlightTest {
 
-    private static final Logger logger = LoggerFactory.getLogger(InFlightTest.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(InFlightTest.class);
 
     private final Vertx vertx = Vertx.vertx();
 
@@ -25,7 +25,7 @@ public class InFlightTest {
         Async async = context.async();
         InFlight<String> inflight = new InFlight(vertx);
 
-        inflight.enqueue("test", ignored->async.complete(), fut->fut.complete());
+        inflight.enqueue("test", ignored -> async.complete(), fut -> fut.complete());
     }
 
     @Test
@@ -35,35 +35,35 @@ public class InFlightTest {
         Async secondCompleted = context.async();
         InFlight<String> inflight = new InFlight(vertx);
         inflight.enqueue("test", v -> {
-            logger.debug("completing firstCompleted");
+            LOGGER.debug("completing firstCompleted");
             firstCompleted.complete();
         }, fut -> {
-            logger.debug("1st task waiting for both to enqueue");
-            bothEnqueued.await();
-            logger.debug("1st task completing");
-            fut.complete();
-        });
+                LOGGER.debug("1st task waiting for both to enqueue");
+                bothEnqueued.await();
+                LOGGER.debug("1st task completing");
+                fut.complete();
+            });
 
-        inflight.enqueue("test", v->{
-            logger.debug("completing secondCompleted");
+        inflight.enqueue("test", v -> {
+            LOGGER.debug("completing secondCompleted");
             secondCompleted.complete();
         }, fut -> {
-            logger.debug("2nd task waiting for both to enqueue");
-            bothEnqueued.await();
-            logger.debug("2nd task completing");
-            fut.complete();
-        });
-        logger.debug("completing bothEnqueued");
+                LOGGER.debug("2nd task waiting for both to enqueue");
+                bothEnqueued.await();
+                LOGGER.debug("2nd task completing");
+                fut.complete();
+            });
+        LOGGER.debug("completing bothEnqueued");
         bothEnqueued.complete();
         secondCompleted.await();
-        logger.debug("Waiting for inflight to empty");
+        LOGGER.debug("Waiting for inflight to empty");
         Async empty = context.async();
         vertx.setPeriodic(100, timerId -> {
             int size = inflight.size();
-            logger.debug("inflight size {}", size);
+            LOGGER.debug("inflight size {}", size);
             if (size == 0) {
                 vertx.cancelTimer(timerId);
-                logger.debug("completing empty");
+                LOGGER.debug("completing empty");
                 empty.complete();
             }
         });
@@ -78,37 +78,37 @@ public class InFlightTest {
         Async secondCompleted = context.async();
         InFlight<String> inflight = new InFlight(vertx);
         inflight.enqueue("test", v -> {
-            logger.debug("completing firstCompleted");
+            LOGGER.debug("completing firstCompleted");
             firstCompleted.complete();
             context.assertTrue(v.failed());
             context.assertEquals("Oops!", v.cause().getMessage());
         }, fut -> {
-            logger.debug("1st task waiting for both to enqueue");
-            bothEnqueued.await();
-            logger.debug("1st task failing");
-            fut.fail("Oops!");
-        });
+                LOGGER.debug("1st task waiting for both to enqueue");
+                bothEnqueued.await();
+                LOGGER.debug("1st task failing");
+                fut.fail("Oops!");
+            });
 
         inflight.enqueue("test", v -> {
-            logger.debug("completing secondCompleted");
+            LOGGER.debug("completing secondCompleted");
             secondCompleted.complete();
         }, fut -> {
-            logger.debug("2nd task waiting for both to enqueue");
-            bothEnqueued.await();
-            logger.debug("2nd task completing");
-            fut.complete();
-        });
-        logger.debug("completing bothEnqueued");
+                LOGGER.debug("2nd task waiting for both to enqueue");
+                bothEnqueued.await();
+                LOGGER.debug("2nd task completing");
+                fut.complete();
+            });
+        LOGGER.debug("completing bothEnqueued");
         bothEnqueued.complete();
         secondCompleted.await();
-        logger.debug("Waiting for inflight to empty");
+        LOGGER.debug("Waiting for inflight to empty");
         Async empty = context.async();
         vertx.setPeriodic(100, timerId -> {
             int size = inflight.size();
-            logger.debug("inflight size {}", size);
+            LOGGER.debug("inflight size {}", size);
             if (size == 0) {
                 vertx.cancelTimer(timerId);
-                logger.debug("completing empty");
+                LOGGER.debug("completing empty");
                 empty.complete();
             }
         });

--- a/topic-controller/src/test/java/io/strimzi/controller/topic/LabelPredicateTest.java
+++ b/topic-controller/src/test/java/io/strimzi/controller/topic/LabelPredicateTest.java
@@ -23,14 +23,14 @@ public class LabelPredicateTest {
         try {
             new LabelPredicate("foo");
             fail();
-        } catch(IllegalArgumentException e) {
+        } catch (IllegalArgumentException e) {
 
         }
 
         try {
             new LabelPredicate("foo", "1", "bar");
             fail();
-        } catch(IllegalArgumentException e) {
+        } catch (IllegalArgumentException e) {
 
         }
     }

--- a/topic-controller/src/test/java/io/strimzi/controller/topic/MockController.java
+++ b/topic-controller/src/test/java/io/strimzi/controller/topic/MockController.java
@@ -74,12 +74,12 @@ class MockController extends Controller {
         }
     }
 
-    public AsyncResult<Void> topicCreatedResult = Future.failedFuture("Unexpected mock interaction. Configure " + getClass().getSimpleName()+".topicCreatedResult");
-    public AsyncResult<Void> topicDeletedResult = Future.failedFuture("Unexpected mock interaction. Configure " + getClass().getSimpleName()+".topicDeletedResult");
-    public AsyncResult<Void> topicModifiedResult = Future.failedFuture("Unexpected mock interaction. Configure " + getClass().getSimpleName()+".topicModifiedResult");
-    public AsyncResult<Void> cmAddedResult = Future.failedFuture("Unexpected mock interaction. Configure " + getClass().getSimpleName()+".cmAddedResult");
-    public AsyncResult<Void> cmDeletedResult = Future.failedFuture("Unexpected mock interaction. Configure " + getClass().getSimpleName()+".cmDeletedResult");
-    public AsyncResult<Void> cmModifiedResult = Future.failedFuture("Unexpected mock interaction. Configure " + getClass().getSimpleName()+".cmModifiedResult");
+    public AsyncResult<Void> topicCreatedResult = Future.failedFuture("Unexpected mock interaction. Configure " + getClass().getSimpleName() + ".topicCreatedResult");
+    public AsyncResult<Void> topicDeletedResult = Future.failedFuture("Unexpected mock interaction. Configure " + getClass().getSimpleName() + ".topicDeletedResult");
+    public AsyncResult<Void> topicModifiedResult = Future.failedFuture("Unexpected mock interaction. Configure " + getClass().getSimpleName() + ".topicModifiedResult");
+    public AsyncResult<Void> cmAddedResult = Future.failedFuture("Unexpected mock interaction. Configure " + getClass().getSimpleName() + ".cmAddedResult");
+    public AsyncResult<Void> cmDeletedResult = Future.failedFuture("Unexpected mock interaction. Configure " + getClass().getSimpleName() + ".cmDeletedResult");
+    public AsyncResult<Void> cmModifiedResult = Future.failedFuture("Unexpected mock interaction. Configure " + getClass().getSimpleName() + ".cmModifiedResult");
     private List<MockControllerEvent> mockControllerEvents = new ArrayList<>();
 
     public List<MockControllerEvent> getMockControllerEvents() {

--- a/topic-controller/src/test/java/io/strimzi/controller/topic/MockKafka.java
+++ b/topic-controller/src/test/java/io/strimzi/controller/topic/MockKafka.java
@@ -17,7 +17,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 
-import static io.vertx.core.Future.*;
+import static io.vertx.core.Future.failedFuture;
+import static io.vertx.core.Future.succeededFuture;
 
 public class MockKafka implements Kafka {
 
@@ -25,13 +26,13 @@ public class MockKafka implements Kafka {
 
     private AsyncResult<Set<String>> topicsListResponse = Future.succeededFuture(Collections.emptySet());
     private Function<TopicName, AsyncResult<TopicMetadata>> topicMetadataRespose =
-            t -> failedFuture("Unexpected. Your test probably need to configure the MockKafka with a topicMetadataResponse.");
+        t -> failedFuture("Unexpected. Your test probably need to configure the MockKafka with a topicMetadataResponse.");
     private Function<String, AsyncResult<Void>> createTopicResponse =
-            t -> failedFuture("Unexpected. Your test probably need to configure the MockKafka with a createTopicResponse.");
+        t -> failedFuture("Unexpected. Your test probably need to configure the MockKafka with a createTopicResponse.");
     private Function<TopicName, AsyncResult<Void>> deleteTopicResponse =
-            t -> failedFuture("Unexpected. Your test probably need to configure the MockKafka with a deleteTopicResponse.");
+        t -> failedFuture("Unexpected. Your test probably need to configure the MockKafka with a deleteTopicResponse.");
     private Function<TopicName, AsyncResult<Void>> updateTopicResponse =
-            t -> failedFuture("Unexpected. Your test probably need to configure the MockKafka with a updateTopicResponse.");
+        t -> failedFuture("Unexpected. Your test probably need to configure the MockKafka with a updateTopicResponse.");
 
     public MockKafka setTopicsListResponse(AsyncResult<Set<String>> topicsListResponse) {
         this.topicsListResponse = topicsListResponse;

--- a/topic-controller/src/test/java/io/strimzi/controller/topic/MockZk.java
+++ b/topic-controller/src/test/java/io/strimzi/controller/topic/MockZk.java
@@ -18,10 +18,10 @@ import java.util.Map;
 
 class MockZk implements Zk {
 
-    public AsyncResult<Void> createResult = Future.failedFuture("Unexpected mock interaction. Configure " + getClass().getSimpleName()+".connectResult");
-    public AsyncResult<Void> setDataResult = Future.failedFuture("Unexpected mock interaction. Configure " + getClass().getSimpleName()+".setDataResult");
-    public AsyncResult<List<String>> childrenResult = Future.failedFuture("Unexpected mock interaction. Configure " + getClass().getSimpleName()+".childrenResult");
-    public AsyncResult<byte[]> dataResult = Future.failedFuture("Unexpected mock interaction. Configure " + getClass().getSimpleName()+".dataResult");
+    public AsyncResult<Void> createResult = Future.failedFuture("Unexpected mock interaction. Configure " + getClass().getSimpleName() + ".connectResult");
+    public AsyncResult<Void> setDataResult = Future.failedFuture("Unexpected mock interaction. Configure " + getClass().getSimpleName() + ".setDataResult");
+    public AsyncResult<List<String>> childrenResult = Future.failedFuture("Unexpected mock interaction. Configure " + getClass().getSimpleName() + ".childrenResult");
+    public AsyncResult<byte[]> dataResult = Future.failedFuture("Unexpected mock interaction. Configure " + getClass().getSimpleName() + ".dataResult");
     private Handler<AsyncResult<List<String>>> childrenHandler;
     private Map<String, Handler<AsyncResult<byte[]>>> dataHandlers = new HashMap<>();
 

--- a/topic-controller/src/test/java/io/strimzi/controller/topic/TopicBuilderTest.java
+++ b/topic-controller/src/test/java/io/strimzi/controller/topic/TopicBuilderTest.java
@@ -49,7 +49,7 @@ public class TopicBuilderTest {
         topic = builder.build();
         assertEquals(new TopicName("my_topic"), topic.getTopicName());
         assertEquals(1, topic.getNumPartitions());
-        assertEquals(-1, topic.getNumReplicas());;
+        assertEquals(-1, topic.getNumReplicas());
         assertEquals(singletonMap("foo", "bar"), topic.getConfig());
     }
 
@@ -75,7 +75,7 @@ public class TopicBuilderTest {
         topic = builder.build();
         assertEquals(new TopicName("my_topic"), topic.getTopicName());
         assertEquals(1, topic.getNumPartitions());
-        assertEquals(-1, topic.getNumReplicas());;
+        assertEquals(-1, topic.getNumReplicas());
         assertEquals(singletonMap("foo", "bar"), topic.getConfig());
     }
 

--- a/topic-controller/src/test/java/io/strimzi/controller/topic/TopicDiffTest.java
+++ b/topic-controller/src/test/java/io/strimzi/controller/topic/TopicDiffTest.java
@@ -24,7 +24,7 @@ public class TopicDiffTest {
         config.put("b", "2");
         config.put("c", "3");
     }
-    Topic topicA = new Topic.Builder("test" , 2, config).build();
+    Topic topicA = new Topic.Builder("test", 2, config).build();
 
     {
         config.clear();
@@ -32,7 +32,7 @@ public class TopicDiffTest {
         config.put("c", "3");
         config.put("d", "4");
     }
-    Topic topicB = new Topic.Builder("test" , 3, config).build();
+    Topic topicB = new Topic.Builder("test", 3, config).build();
 
     @Test
     public void testDiff() {
@@ -42,7 +42,7 @@ public class TopicDiffTest {
         TopicDiff diffBA = TopicDiff.diff(topicB, topicA);
         assertEquals(topicA, diffBA.apply(topicB));
 
-        Topic topicWrongName = new Topic.Builder("another_name" , 3, config).build();
+        Topic topicWrongName = new Topic.Builder("another_name", 3, config).build();
         try {
             TopicDiff.diff(topicA, topicWrongName);
             fail("Should throw");
@@ -130,7 +130,7 @@ public class TopicDiffTest {
 
     @Test
     public void testChangesNumPartitions() {
-        Topic topicC = new Topic.Builder(topicB.getTopicName() , topicB.getNumPartitions(), topicB.getConfig()).build();
+        Topic topicC = new Topic.Builder(topicB.getTopicName(), topicB.getNumPartitions(), topicB.getConfig()).build();
         assertTrue(TopicDiff.diff(topicB, topicA).changesNumPartitions());
         assertEquals(-1, TopicDiff.diff(topicB, topicA).numPartitionsDelta());
         assertTrue(TopicDiff.diff(topicA, topicB).changesNumPartitions());
@@ -148,7 +148,7 @@ public class TopicDiffTest {
 
     @Test
     public void testChangesConfig() {
-        Topic topicC = new Topic.Builder(topicB.getTopicName() , topicB.getNumPartitions(), topicB.getConfig()).build();
+        Topic topicC = new Topic.Builder(topicB.getTopicName(), topicB.getNumPartitions(), topicB.getConfig()).build();
         assertTrue(TopicDiff.diff(topicB, topicA).changesConfig());
         assertTrue(TopicDiff.diff(topicA, topicB).changesConfig());
         assertFalse(TopicDiff.diff(topicB, topicC).changesConfig());
@@ -156,9 +156,9 @@ public class TopicDiffTest {
 
     @Test
     public void testChangesReplicationFactor() {
-        Topic topicC = new Topic.Builder(topicB.getTopicName() , topicB.getNumPartitions(), (short) 2, topicB.getConfig()).build();
-        Topic topicD = new Topic.Builder(topicB.getTopicName() , topicC.getNumPartitions()+1, (short) 2, topicB.getConfig()).build();
-        Topic topicE = new Topic.Builder(topicB.getTopicName() , topicB.getNumPartitions(), (short) 3, topicB.getConfig()).build();
+        Topic topicC = new Topic.Builder(topicB.getTopicName(), topicB.getNumPartitions(), (short) 2, topicB.getConfig()).build();
+        Topic topicD = new Topic.Builder(topicB.getTopicName(), topicC.getNumPartitions() + 1, (short) 2, topicB.getConfig()).build();
+        Topic topicE = new Topic.Builder(topicB.getTopicName(), topicB.getNumPartitions(), (short) 3, topicB.getConfig()).build();
         assertFalse(TopicDiff.diff(topicC, topicD).changesReplicationFactor());
         assertTrue(TopicDiff.diff(topicD, topicE).changesReplicationFactor());
         assertTrue(TopicDiff.diff(topicC, topicE).changesReplicationFactor());

--- a/topic-controller/src/test/java/io/strimzi/controller/topic/TopicSerializationTest.java
+++ b/topic-controller/src/test/java/io/strimzi/controller/topic/TopicSerializationTest.java
@@ -54,7 +54,7 @@ public class TopicSerializationTest {
         assertEquals(wroteTopic.getTopicName().toString(), cm.getData().get(TopicSerialization.CM_KEY_NAME));
         assertEquals("2", cm.getData().get(TopicSerialization.CM_KEY_PARTITIONS));
         assertEquals("1", cm.getData().get(TopicSerialization.CM_KEY_REPLICAS));
-        assertEquals("{\"cleanup.policy\":\"bar\"}" , cm.getData().get(TopicSerialization.CM_KEY_CONFIG));
+        assertEquals("{\"cleanup.policy\":\"bar\"}", cm.getData().get(TopicSerialization.CM_KEY_CONFIG));
 
         Topic readTopic = TopicSerialization.fromConfigMap(cm);
         assertEquals(wroteTopic, readTopic);
@@ -89,7 +89,7 @@ public class TopicSerializationTest {
                 .withTopicName("test-topic")
                 .withConfigEntry("foo", "bar")
                 .withNumPartitions(3)
-                .withNumReplicas((short)2)
+                .withNumReplicas((short) 2)
                 .withMapName("gee")
                 .build();
         NewTopic newTopic = TopicSerialization.toNewTopic(topic, null);
@@ -101,7 +101,7 @@ public class TopicSerializationTest {
         // and only provides a package-access method to convert to topic details
         Method m = NewTopic.class.getDeclaredMethod("convertToTopicDetails");
         m.setAccessible(true);
-        CreateTopicsRequest.TopicDetails details = (CreateTopicsRequest.TopicDetails)m.invoke(newTopic);
+        CreateTopicsRequest.TopicDetails details = (CreateTopicsRequest.TopicDetails) m.invoke(newTopic);
         assertEquals(singletonMap("foo", "bar"), details.configs);
     }
 
@@ -111,7 +111,7 @@ public class TopicSerializationTest {
                 .withTopicName("test-topic")
                 .withConfigEntry("foo", "bar")
                 .withNumPartitions(3)
-                .withNumReplicas((short)2)
+                .withNumReplicas((short) 2)
                 .withMapName("gee")
                 .build();
         Map<ConfigResource, Config> config = TopicSerialization.toTopicConfig(topic);

--- a/topic-controller/src/test/java/io/strimzi/controller/topic/ZkTopicStoreTest.java
+++ b/topic-controller/src/test/java/io/strimzi/controller/topic/ZkTopicStoreTest.java
@@ -51,7 +51,7 @@ public class ZkTopicStoreTest {
     @Test
     public void testCrud(TestContext context) throws ExecutionException, InterruptedException {
         Topic topic = new Topic.Builder("my_topic", 2,
-                (short)3, Collections.singletonMap("foo", "bar")).build();
+                (short) 3, Collections.singletonMap("foo", "bar")).build();
 
 
 
@@ -80,7 +80,7 @@ public class ZkTopicStoreTest {
         assertEquals(topic.getConfig(), readTopic.getConfig());
 
         // try to create it again: assert an error
-        store.create(topic, ar-> {
+        store.create(topic, ar -> {
             if (ar.succeeded()) {
                 context.fail("Should throw");
             } else {
@@ -95,7 +95,7 @@ public class ZkTopicStoreTest {
         Topic updated = new Topic.Builder(topic)
                 .withNumPartitions(3)
                 .withConfigEntry("fruit", "apple").build();
-        store.update(updated, ar->async2.complete());
+        store.update(updated, ar -> async2.complete());
         async2.await();
 
         // re-read it and assert equal
@@ -116,12 +116,12 @@ public class ZkTopicStoreTest {
 
         // delete it
         Async async4 = context.async();
-        store.delete(updated.getTopicName(), ar-> async4.complete());
+        store.delete(updated.getTopicName(), ar -> async4.complete());
         async4.await();
 
         // assert we can't read it again
         Async async5 = context.async();
-        store.read(new TopicName("my_topic"), ar-> {
+        store.read(new TopicName("my_topic"), ar -> {
             async5.complete();
             if (ar.succeeded()) {
                 context.assertNull(ar.result());
@@ -133,13 +133,13 @@ public class ZkTopicStoreTest {
 
         // delete it again: assert an error
         Async async6 = context.async();
-        store.delete(updated.getTopicName(), ar-> {
+        store.delete(updated.getTopicName(), ar -> {
             async6.complete();
             if (ar.succeeded()) {
                 context.fail("Should throw");
             } else {
                 if (!(ar.cause() instanceof TopicStore.NoSuchEntityExistsException)) {
-                    context.fail("Unexpected exception "+ar.cause());
+                    context.fail("Unexpected exception " + ar.cause());
                 }
             }
         });

--- a/topic-controller/src/test/java/io/strimzi/controller/topic/zk/ZkImplTest.java
+++ b/topic-controller/src/test/java/io/strimzi/controller/topic/zk/ZkImplTest.java
@@ -53,7 +53,7 @@ public class ZkImplTest {
         ZkImpl zkImpl = new ZkImpl(vertx, zkServer.getZkConnectString(), 60_000, false);
         zkServer.restart();
         Async async = context.async();
-        zkImpl.create("/foo", null, AclBuilder.PUBLIC, CreateMode.PERSISTENT, ar-> {
+        zkImpl.create("/foo", null, AclBuilder.PUBLIC, CreateMode.PERSISTENT, ar -> {
             context.assertTrue(ar.succeeded());
             async.complete();
         });
@@ -65,7 +65,7 @@ public class ZkImplTest {
         // TODO We also need to reset the watches on reconnection.
         Thread.sleep(2000);
         Async async2 = context.async();
-        zkImpl.create("/bar", null, AclBuilder.PUBLIC, CreateMode.PERSISTENT, ar-> {
+        zkImpl.create("/bar", null, AclBuilder.PUBLIC, CreateMode.PERSISTENT, ar -> {
             //ar.cause().printStackTrace();
             context.assertTrue(ar.succeeded(), ar.toString());
             async2.complete();
@@ -74,7 +74,7 @@ public class ZkImplTest {
 
     private ZkImpl connect(TestContext context) {
         Zk zk = new ZkImpl(vertx, zkServer.getZkConnectString(), 60_000, false);
-        return (ZkImpl)zk;
+        return (ZkImpl) zk;
     }
 
     @Test
@@ -82,7 +82,7 @@ public class ZkImplTest {
         ZkImpl zk = connect(context);
         // Create a node
         Async fooFuture = context.async();
-        zk.create("/foo", null, AclBuilder.PUBLIC, CreateMode.PERSISTENT, ar-> {
+        zk.create("/foo", null, AclBuilder.PUBLIC, CreateMode.PERSISTENT, ar -> {
             fooFuture.complete();
         });
         fooFuture.await();
@@ -99,7 +99,7 @@ public class ZkImplTest {
         });
         zk.children("/foo", lsResult -> {
             context.assertEquals(emptyList(), lsResult.result());
-            zk.create("/foo/bar", null, AclBuilder.PUBLIC, CreateMode.PERSISTENT, ig -> {});
+            zk.create("/foo/bar", null, AclBuilder.PUBLIC, CreateMode.PERSISTENT, ig -> { });
         });
         barFuture.await();
     }
@@ -110,7 +110,7 @@ public class ZkImplTest {
         // Create a node
         Async fooFuture = context.async();
         byte[] data1 = new byte[]{1};
-        zk.create("/foo", data1, AclBuilder.PUBLIC, CreateMode.PERSISTENT, ar-> {
+        zk.create("/foo", data1, AclBuilder.PUBLIC, CreateMode.PERSISTENT, ar -> {
             fooFuture.complete();
         });
         fooFuture.await();
@@ -134,14 +134,14 @@ public class ZkImplTest {
         // Create a node
         Async created = context.async(2);
         Async deleted = context.async(2);
-        zk.watchExists("/foo", existsResult-> {
+        zk.watchExists("/foo", existsResult -> {
             if (existsResult.result() != null) {
                 created.countDown();
             } else {
                 deleted.countDown();
             }
         }).exists("/foo", null);
-        zk.create("/foo", null, AclBuilder.PUBLIC, CreateMode.PERSISTENT, ar-> {
+        zk.create("/foo", null, AclBuilder.PUBLIC, CreateMode.PERSISTENT, ar -> {
             created.countDown();
         });
         created.await();
@@ -153,7 +153,7 @@ public class ZkImplTest {
 
         zk.unwatchExists("/foo");
         Async created2 = context.async();
-        zk.create("/foo", null, AclBuilder.PUBLIC, CreateMode.PERSISTENT, ar-> {
+        zk.create("/foo", null, AclBuilder.PUBLIC, CreateMode.PERSISTENT, ar -> {
             created2.complete();
         });
     }

--- a/topic-controller/src/test/java/io/strimzi/test/Exec.java
+++ b/topic-controller/src/test/java/io/strimzi/test/Exec.java
@@ -17,7 +17,7 @@ import java.util.regex.Pattern;
 import static java.lang.String.join;
 
 class Exec {
-    private static final Logger logger = LoggerFactory.getLogger(Exec.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(Exec.class);
 
     /**
      * Executes the given command in a subprocess.
@@ -55,7 +55,7 @@ class Exec {
 
     private static String execOutput(File out, List<String> cmd) throws KubeClusterException {
         try {
-            logger.info("{}", join(" ", cmd));
+            LOGGER.info("{}", join(" ", cmd));
             ProcessBuilder pb = new ProcessBuilder(cmd);
             if (out == null) {
                 pb.redirectOutput(ProcessBuilder.Redirect.INHERIT);
@@ -66,7 +66,7 @@ class Exec {
             Process p = pb.start();
             int sc = p.waitFor();
             if (sc != 0) {
-                throw new KubeClusterException(sc, "`"+ join(" ", cmd) + "` got status code " + sc);
+                throw new KubeClusterException(sc, "`" + join(" ", cmd) + "` got status code " + sc);
             }
             return out == null ? null : new String(Files.readAllBytes(out.toPath()));
         } catch (IOException e) {

--- a/topic-controller/src/test/java/io/strimzi/test/KubeClusterResource.java
+++ b/topic-controller/src/test/java/io/strimzi/test/KubeClusterResource.java
@@ -33,7 +33,7 @@ import java.util.Arrays;
  */
 public class KubeClusterResource extends ExternalResource {
 
-    private static final Logger logger = LoggerFactory.getLogger(KubeClusterResource.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(KubeClusterResource.class);
     private final boolean shouldStartCluster = System.getenv("CI") == null;
     private final KubeCluster cluster;
     private final KubeClient client;
@@ -46,22 +46,22 @@ public class KubeClusterResource extends ExternalResource {
         KubeCluster cluster = null;
         for (KubeCluster kc : new KubeCluster[]{new OpenShift(), Minikube.minikube(), Minikube.minishift()}) {
             if (kc.isAvailable()) {
-                logger.debug("Cluster {} is installed", kc);
+                LOGGER.debug("Cluster {} is installed", kc);
                 if (shouldStartCluster) {
-                    logger.debug("Using cluster {}", kc);
+                    LOGGER.debug("Using cluster {}", kc);
                     cluster = kc;
                     break;
                 } else {
                     if (kc.isClusterUp()) {
-                        logger.debug("Cluster {} is running", kc);
+                        LOGGER.debug("Cluster {} is running", kc);
                         cluster = kc;
                         break;
                     } else {
-                        logger.debug("Cluster {} is not running", kc);
+                        LOGGER.debug("Cluster {} is not running", kc);
                     }
                 }
             } else {
-                logger.debug("Cluster {} is not installed", kc );
+                LOGGER.debug("Cluster {} is not installed", kc);
             }
         }
         this.cluster = cluster;
@@ -91,7 +91,7 @@ public class KubeClusterResource extends ExternalResource {
             if (cluster.isClusterUp()) {
                 throw new RuntimeException("Cluster " + cluster + " is already up");
             }
-            logger.info("Starting cluster {}", cluster);
+            LOGGER.info("Starting cluster {}", cluster);
             // It can happen that if the VM exits abnormally the cluster remains up, and further tests don't work because
             // it appears there are two brokers with id 1, so use a shutdown hook to kill the cluster.
             startedCluster = true;
@@ -133,7 +133,7 @@ public class KubeClusterResource extends ExternalResource {
         if (startedCluster) {
             startedCluster = false;
             try {
-                logger.info("Executing oc cluster down");
+                LOGGER.info("Executing oc cluster down");
                 cluster.clusterDown();
             } catch (Exception e) {
                 e.printStackTrace();

--- a/topic-controller/src/test/java/io/strimzi/test/Kubectl.java
+++ b/topic-controller/src/test/java/io/strimzi/test/Kubectl.java
@@ -8,7 +8,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static io.strimzi.test.Exec.*;
+import static io.strimzi.test.Exec.isExecutableOnPath;
+import static io.strimzi.test.Exec.exec;
 
 /**
  * A {@link KubeClient} wrapping {@code kubectl}.
@@ -31,7 +32,7 @@ public class Kubectl implements KubeClient {
                 cmd.add("--resource=" + resource);
             }
             for (int i = 0; i < p.verbs().length; i++) {
-                cmd.add("--verb="+p.verbs()[i]);
+                cmd.add("--verb=" + p.verbs()[i]);
             }
         }
         exec(cmd);
@@ -40,9 +41,9 @@ public class Kubectl implements KubeClient {
     @Override
     public void createRoleBinding(String bindingName, String roleName, String... users) {
         List<String> cmd = new ArrayList<>();
-        cmd.addAll(Arrays.asList(KUBECTL, "create", "rolebinding", bindingName, "--role="+roleName));
+        cmd.addAll(Arrays.asList(KUBECTL, "create", "rolebinding", bindingName, "--role=" + roleName));
         for (int i = 0; i < users.length; i++) {
-            cmd.add("--user="+users[i]);
+            cmd.add("--user=" + users[i]);
         }
         exec(cmd);
     }

--- a/topic-controller/src/test/java/io/strimzi/test/Oc.java
+++ b/topic-controller/src/test/java/io/strimzi/test/Oc.java
@@ -8,7 +8,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static io.strimzi.test.Exec.*;
+import static io.strimzi.test.Exec.isExecutableOnPath;
+import static io.strimzi.test.Exec.exec;
 
 /**
  * A {@link KubeClient} implementation wrapping {@code oc}.
@@ -32,7 +33,7 @@ public class Oc implements KubeClient {
                 cmd.add("--resource=" + resource);
             }
             for (int i = 0; i < p.verbs().length; i++) {
-                cmd.add("--verb="+p.verbs()[i]);
+                cmd.add("--verb=" + p.verbs()[i]);
             }
         }
         exec(cmd);
@@ -43,9 +44,9 @@ public class Oc implements KubeClient {
     public void createRoleBinding(String bindingName, String roleName, String... user) {
         exec(OC, "login", "-u", "system:admin");
         List<String> cmd = new ArrayList<>();
-        cmd.addAll(Arrays.asList(OC, "create", "rolebinding", bindingName, "--role="+roleName));
+        cmd.addAll(Arrays.asList(OC, "create", "rolebinding", bindingName, "--role=" + roleName));
         for (int i = 0; i < user.length; i++) {
-            cmd.add("--user="+user[i]);
+            cmd.add("--user=" + user[i]);
         }
         exec(cmd);
         exec(OC, "login", "-u", "developer");

--- a/topic-controller/src/test/java/io/strimzi/test/OpenShift.java
+++ b/topic-controller/src/test/java/io/strimzi/test/OpenShift.java
@@ -4,7 +4,8 @@
  */
 package io.strimzi.test;
 
-import static io.strimzi.test.Exec.*;
+import static io.strimzi.test.Exec.isExecutableOnPath;
+import static io.strimzi.test.Exec.exec;
 
 public class OpenShift implements KubeCluster {
 


### PR DESCRIPTION
These are checkstyle fixes necessary for the topic controller. The vast majority are:

* Whitespace around operators, type casts
* Indentation
* Constants not in upper case

Fixing these was really easy by pointing the intellij plugin at the `checkstyle.xml`.

There are two or three more interesting cases where checkstyle complained about method complexity of various kinds. In the last commit I silenced a couple of these cases by factoring out other methods, but I'm not really convinced that actually helps when reading the code. The alternative would have been us suppress those errors for those methods.

A final thing perhpas worthy on metion: The topic controller has uses of `assert`, which might be worth calling out, since by default at runtime those assertions aren't evaluated. Should we convert them to `if+throw`?