### PR TITLE
Multi namespace

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -83,7 +83,7 @@ you can push the images to OpenShift's Docker repo like this:
    specify the Docker repo, otherwise OpenShift will still try to pull 
    the image from docker.io:
    
-        oc new-app strimzi -p IMAGE_REPO_NAME=172.30.1.1:5000/myproject
+        oc new-app strimzi-ephemeral -p IMAGE_REPO_NAME=172.30.1.1:5000/myproject
 
 
 ## Release

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterController.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterController.java
@@ -173,7 +173,7 @@ public class ClusterController extends AbstractVerticle {
                     log.info("ConfigMap watcher running for labels {}", labels);
                     handler.handle(Future.succeededFuture((Watch) res.result()));
                 } else {
-                    log.info("ConfigMap watcher failed to start");
+                    log.info("ConfigMap watcher failed to start", res.cause());
                     handler.handle(Future.failedFuture("ConfigMap watcher failed to start"));
                 }
             }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterController.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterController.java
@@ -170,7 +170,7 @@ public class ClusterController extends AbstractVerticle {
                 future.complete(watch);
             }, res -> {
                 if (res.succeeded())    {
-                    log.info("ConfigMap watcher up and running for labels {}", labels);
+                    log.info("ConfigMap watcher running for labels {}", labels);
                     handler.handle(Future.succeededFuture((Watch) res.result()));
                 } else {
                     log.info("ConfigMap watcher failed to start");
@@ -185,10 +185,10 @@ public class ClusterController extends AbstractVerticle {
 
         createConfigMapWatch(res -> {
             if (res.succeeded())    {
-                log.info("ConfigMap watch recreated");
+                log.info("ConfigMap watch recreated in namespace {}", namespace);
                 configMapWatch = res.result();
             } else {
-                log.error("Failed to recreate ConfigMap watch");
+                log.error("Failed to recreate ConfigMap watch in namespace {}", namespace);
             }
         });
     }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterController.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterController.java
@@ -5,15 +5,11 @@
 package io.strimzi.controller.cluster;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
-import io.fabric8.kubernetes.api.model.ConfigMapList;
-import io.fabric8.kubernetes.api.model.DoneableConfigMap;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
-import io.fabric8.kubernetes.client.dsl.FilterWatchListMultiDeletable;
-import io.fabric8.kubernetes.client.dsl.MixedOperation;
-import io.fabric8.kubernetes.client.dsl.Resource;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.strimzi.controller.cluster.operations.cluster.AbstractClusterOperations;
 import io.strimzi.controller.cluster.operations.cluster.KafkaClusterOperations;
@@ -29,12 +25,8 @@ import io.vertx.core.Handler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
-
-import static java.util.Collections.singleton;
 
 public class ClusterController extends AbstractVerticle {
 
@@ -61,15 +53,6 @@ public class ClusterController extends AbstractVerticle {
     private final KafkaConnectClusterOperations kafkaConnectClusterOperations;
     private final KafkaConnectS2IClusterOperations kafkaConnectS2IClusterOperations;
 
-    /**
-     * @param namespace The namespace to watch, or null for all namespaces in the Kubernetes/OpenShift cluster.
-     * @param labels The labels that watched-for ConfigMaps must have.
-     * @param reconciliationInterval The interval between periodic reconciliations.
-     * @param client The kubernetes client.
-     * @param kafkaClusterOperations Operations for Kafka clusters.
-     * @param kafkaConnectClusterOperations Operations for Connect clusters.
-     * @param kafkaConnectS2IClusterOperations Operations for Connect S2I clusters.
-     */
     public ClusterController(String namespace,
                              Map<String, String> labels,
                              long reconciliationInterval,
@@ -130,14 +113,7 @@ public class ClusterController extends AbstractVerticle {
     private void createConfigMapWatch(Handler<AsyncResult<Watch>> handler) {
         getVertx().executeBlocking(
             future -> {
-                MixedOperation<ConfigMap, ConfigMapList, DoneableConfigMap, Resource<ConfigMap, DoneableConfigMap>> cmOperation = client.configMaps();
-                FilterWatchListMultiDeletable<ConfigMap, ConfigMapList, Boolean, Watch, Watcher<ConfigMap>> cmWatchList;
-                if (namespace != null) {
-                    cmWatchList = cmOperation.inNamespace(namespace);
-                } else {
-                    cmWatchList = cmOperation.inAnyNamespace();
-                }
-                Watch watch = cmWatchList.withLabels(labels).watch(new Watcher<ConfigMap>() {
+                Watch watch = client.configMaps().inNamespace(namespace).withLabels(labels).watch(new Watcher<ConfigMap>() {
                     @Override
                     public void eventReceived(Action action, ConfigMap cm) {
                         Map<String, String> labels = cm.getMetadata().getLabels();
@@ -158,7 +134,6 @@ public class ClusterController extends AbstractVerticle {
                             return;
                         }
                         String name = cm.getMetadata().getName();
-                        String namespace = cm.getMetadata().getNamespace();
                         switch (action) {
                             case ADDED:
                                 log.info("New ConfigMap {}", name);
@@ -194,8 +169,7 @@ public class ClusterController extends AbstractVerticle {
                     }
                 });
                 future.complete(watch);
-            },
-            res -> {
+            }, res -> {
                 if (res.succeeded())    {
                     log.info("ConfigMap watcher up and running for labels {}", labels);
                     handler.handle(Future.succeededFuture((Watch) res.result()));
@@ -224,17 +198,9 @@ public class ClusterController extends AbstractVerticle {
       Periodical reconciliation (in case we lost some event)
      */
     private void reconcile() {
-        Set<String> namespaces;
-        if (namespace == null) {
-            namespaces = new HashSet(client.namespaces().list().getItems());
-        } else {
-            namespaces = singleton(namespace);
-        }
-        for (String namespace : namespaces) {
-            kafkaClusterOperations.reconcile(namespace, labels);
-            kafkaConnectClusterOperations.reconcile(namespace, labels);
-            kafkaConnectS2IClusterOperations.reconcile(namespace, labels);
-        }
+        kafkaClusterOperations.reconcile(namespace, labels);
+        kafkaConnectClusterOperations.reconcile(namespace, labels);
+        kafkaConnectS2IClusterOperations.reconcile(namespace, labels);
     }
 
     /**

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterController.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterController.java
@@ -59,7 +59,7 @@ public class ClusterController extends AbstractVerticle {
                              KafkaClusterOperations kafkaClusterOperations,
                              KafkaConnectClusterOperations kafkaConnectClusterOperations,
                              KafkaConnectS2IClusterOperations kafkaConnectS2IClusterOperations) {
-        log.info("Creating ClusterController");
+        log.info("Creating ClusterController for namespace {}", namespace);
         this.namespace = namespace;
         this.labels = labels;
         this.reconciliationInterval = reconciliationInterval;
@@ -94,13 +94,13 @@ public class ClusterController extends AbstractVerticle {
                 start.complete();
             } else {
                 log.error("ClusterController startup failed for namespace {}", namespace, res.cause());
-                start.fail("ClusterController startup failed for namesapce " + namespace);
+                start.fail("ClusterController startup failed for namespace " + namespace);
             }
         });
     }
 
     @Override
-    public void stop(Future<Void> stop) throws Exception {
+    public void stop(Future<Void> stop) {
 
         vertx.cancelTimer(reconcileTimer);
         configMapWatch.close();

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterController.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterController.java
@@ -53,14 +53,16 @@ public class ClusterController extends AbstractVerticle {
     private final KafkaConnectClusterOperations kafkaConnectClusterOperations;
     private final KafkaConnectS2IClusterOperations kafkaConnectS2IClusterOperations;
 
-    public ClusterController(ClusterControllerConfig config,
+    public ClusterController(String namespace,
+                             Map<String, String> labels,
+                             long reconciliationInterval,
                              KafkaClusterOperations kafkaClusterOperations,
                              KafkaConnectClusterOperations kafkaConnectClusterOperations,
                              KafkaConnectS2IClusterOperations kafkaConnectS2IClusterOperations) {
         log.info("Creating ClusterController");
-        this.namespace = config.getNamespace();
-        this.labels = config.getLabels();
-        this.reconciliationInterval = config.getReconciliationInterval();
+        this.namespace = namespace;
+        this.labels = labels;
+        this.reconciliationInterval = reconciliationInterval;
         this.client = new DefaultKubernetesClient();
         this.kafkaClusterOperations = kafkaClusterOperations;
         this.kafkaConnectClusterOperations = kafkaConnectClusterOperations;

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterController.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterController.java
@@ -56,6 +56,7 @@ public class ClusterController extends AbstractVerticle {
     public ClusterController(String namespace,
                              Map<String, String> labels,
                              long reconciliationInterval,
+                             KubernetesClient client,
                              KafkaClusterOperations kafkaClusterOperations,
                              KafkaConnectClusterOperations kafkaConnectClusterOperations,
                              KafkaConnectS2IClusterOperations kafkaConnectS2IClusterOperations) {
@@ -63,7 +64,7 @@ public class ClusterController extends AbstractVerticle {
         this.namespace = namespace;
         this.labels = labels;
         this.reconciliationInterval = reconciliationInterval;
-        this.client = new DefaultKubernetesClient();
+        this.client = client;
         this.kafkaClusterOperations = kafkaClusterOperations;
         this.kafkaConnectClusterOperations = kafkaConnectClusterOperations;
         this.kafkaConnectS2IClusterOperations = kafkaConnectS2IClusterOperations;

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterControllerConfig.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterControllerConfig.java
@@ -4,14 +4,10 @@
  */
 package io.strimzi.controller.cluster;
 
-import io.fabric8.kubernetes.client.KubernetesClient;
-
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableSet;

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterControllerConfig.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterControllerConfig.java
@@ -39,7 +39,7 @@ public class ClusterControllerConfig {
      * @param reconciliationInterval    specify every how many milliseconds the reconciliation runs
      */
     public ClusterControllerConfig(Set<String> namespaces, Map<String, String> labels, long reconciliationInterval) {
-        this.namespaces = unmodifiableSet(new HashSet<>(namespaces));
+        this.namespaces = namespaces == null ? null : unmodifiableSet(new HashSet<>(namespaces));
         this.labels = labels;
         this.reconciliationInterval = reconciliationInterval;
     }
@@ -60,12 +60,12 @@ public class ClusterControllerConfig {
      * @param map   map from which loading configuration parameters
      * @return  Cluster Controller configuration instance
      */
-    public static ClusterControllerConfig fromMap(Map<String, String> map, KubernetesClient client) {
+    public static ClusterControllerConfig fromMap(Map<String, String> map) {
 
         String namespacesList = map.get(ClusterControllerConfig.STRIMZI_NAMESPACE);
         Set<String> namespaces;
         if (namespacesList == null) {
-            namespaces = client.namespaces().list().getItems().stream().map(ns -> ns.getMetadata().getName()).collect(Collectors.toSet());
+            namespaces = null;
         } else {
             namespaces = new HashSet(asList(namespacesList.trim().split("\\s*,+\\s*")));
         }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterControllerConfig.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterControllerConfig.java
@@ -39,7 +39,7 @@ public class ClusterControllerConfig {
      * @param reconciliationInterval    specify every how many milliseconds the reconciliation runs
      */
     public ClusterControllerConfig(Set<String> namespaces, Map<String, String> labels, long reconciliationInterval) {
-        this.namespaces = namespaces == null ? null : unmodifiableSet(new HashSet<>(namespaces));
+        this.namespaces = unmodifiableSet(new HashSet<>(namespaces));
         this.labels = labels;
         this.reconciliationInterval = reconciliationInterval;
     }
@@ -60,12 +60,12 @@ public class ClusterControllerConfig {
      * @param map   map from which loading configuration parameters
      * @return  Cluster Controller configuration instance
      */
-    public static ClusterControllerConfig fromMap(Map<String, String> map) {
+    public static ClusterControllerConfig fromMap(Map<String, String> map, KubernetesClient client) {
 
         String namespacesList = map.get(ClusterControllerConfig.STRIMZI_NAMESPACE);
         Set<String> namespaces;
         if (namespacesList == null) {
-            namespaces = null;
+            namespaces = client.namespaces().list().getItems().stream().map(ns -> ns.getMetadata().getName()).collect(Collectors.toSet());
         } else {
             namespaces = new HashSet(asList(namespacesList.trim().split("\\s*,+\\s*")));
         }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterControllerConfig.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterControllerConfig.java
@@ -60,18 +60,18 @@ public class ClusterControllerConfig {
      * @param map   map from which loading configuration parameters
      * @return  Cluster Controller configuration instance
      */
-    public static ClusterControllerConfig fromMap(Map<String, String> map, KubernetesClient client) {
+    public static ClusterControllerConfig fromMap(Map<String, String> map) {
 
         String namespacesList = map.get(ClusterControllerConfig.STRIMZI_NAMESPACE);
         Set<String> namespaces;
-        if (namespacesList == null) {
-            namespaces = client.namespaces().list().getItems().stream().map(ns -> ns.getMetadata().getName()).collect(Collectors.toSet());
+        if (namespacesList == null || namespacesList.isEmpty()) {
+            throw new IllegalArgumentException(ClusterControllerConfig.STRIMZI_NAMESPACE + " cannot be null");
         } else {
             namespaces = new HashSet(asList(namespacesList.trim().split("\\s*,+\\s*")));
         }
         String stringLabels = map.get(ClusterControllerConfig.STRIMZI_CONFIGMAP_LABELS);
-        if (stringLabels == null) {
-            throw new IllegalArgumentException("Labels to watch cannot be null");
+        if (stringLabels == null || stringLabels.isEmpty()) {
+            throw new IllegalArgumentException(ClusterControllerConfig.STRIMZI_CONFIGMAP_LABELS + " cannot be null");
         }
         Long reconciliationInterval = DEFAULT_FULL_RECONCILIATION_INTERVAL;
 

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/Main.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/Main.java
@@ -57,22 +57,24 @@ public class Main {
                     serviceOperations, imagesStreamOperations, buildConfigOperations);
 
             ClusterControllerConfig config = ClusterControllerConfig.fromMap(System.getenv(), client);
-            ClusterController controller = new ClusterController(config.getNamespaces(),
-                    config.getLabels(),
-                    config.getReconciliationInterval(),
-                    client,
-                    kafkaClusterOperations,
-                    kafkaConnectClusterOperations,
-                    kafkaConnectS2IClusterOperations);
-            vertx.deployVerticle(controller,
-                res -> {
-                    if (res.succeeded()) {
-                        log.info("Cluster Controller verticle started");
-                    } else {
-                        log.error("Cluster Controller verticle failed to start", res.cause());
-                        System.exit(1);
-                    }
-                });
+            for (String namespace : config.getNamespaces()) {
+                ClusterController controller = new ClusterController(namespace,
+                        config.getLabels(),
+                        config.getReconciliationInterval(),
+                        client,
+                        kafkaClusterOperations,
+                        kafkaConnectClusterOperations,
+                        kafkaConnectS2IClusterOperations);
+                vertx.deployVerticle(controller,
+                    res -> {
+                        if (res.succeeded()) {
+                            log.info("Cluster Controller verticle started");
+                        } else {
+                            log.error("Cluster Controller verticle failed to start", res.cause());
+                            System.exit(1);
+                        }
+                    });
+            }
         } catch (IllegalArgumentException e) {
             log.error("Unable to parse arguments", e);
             System.exit(1);

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/Main.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/Main.java
@@ -5,6 +5,7 @@
 package io.strimzi.controller.cluster;
 
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.openshift.client.OpenShiftClient;
 import io.strimzi.controller.cluster.operations.cluster.KafkaClusterOperations;
 import io.strimzi.controller.cluster.operations.cluster.KafkaConnectClusterOperations;
@@ -55,22 +56,25 @@ public class Main {
                     configMapOperations, deploymentConfigOperations,
                     serviceOperations, imagesStreamOperations, buildConfigOperations);
 
-            ClusterControllerConfig config = ClusterControllerConfig.fromMap(System.getenv());
-            vertx.deployVerticle(new ClusterController(config.getNamespace(),
-                    config.getLabels(),
-                    config.getReconciliationInterval(),
-                    kafkaClusterOperations,
-                    kafkaConnectClusterOperations,
-                    kafkaConnectS2IClusterOperations),
+            ClusterControllerConfig config = ClusterControllerConfig.fromMap(System.getenv(), client);
+            for (String namespace : config.getNamespaces()) {
+                ClusterController controller = new ClusterController(namespace,
+                        config.getLabels(),
+                        config.getReconciliationInterval(),
+                        client,
+                        kafkaClusterOperations,
+                        kafkaConnectClusterOperations,
+                        kafkaConnectS2IClusterOperations);
+                vertx.deployVerticle(controller,
                     res -> {
-                if (res.succeeded())    {
-                    log.info("Cluster Controller verticle started");
-                }
-                else {
-                    log.error("Cluster Controller verticle failed to start", res.cause());
-                    System.exit(1);
-                }
-            });
+                        if (res.succeeded()) {
+                            log.info("Cluster Controller verticle started");
+                        } else {
+                            log.error("Cluster Controller verticle failed to start", res.cause());
+                            System.exit(1);
+                        }
+                    });
+            }
         } catch (IllegalArgumentException e) {
             log.error("Unable to parse arguments", e);
             System.exit(1);

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/Main.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/Main.java
@@ -83,9 +83,9 @@ public class Main {
             vertx.deployVerticle(controller,
                 res -> {
                     if (res.succeeded()) {
-                        log.info("Cluster Controller verticle started");
+                        log.info("Cluster Controller verticle started in namespace {}", namespace);
                     } else {
-                        log.error("Cluster Controller verticle failed to start", res.cause());
+                        log.error("Cluster Controller verticle in namespace {} failed to start", namespace, res.cause());
                         System.exit(1);
                     }
                     fut.completer().handle(res);

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/Main.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/Main.java
@@ -57,24 +57,22 @@ public class Main {
                     serviceOperations, imagesStreamOperations, buildConfigOperations);
 
             ClusterControllerConfig config = ClusterControllerConfig.fromMap(System.getenv(), client);
-            for (String namespace : config.getNamespaces()) {
-                ClusterController controller = new ClusterController(namespace,
-                        config.getLabels(),
-                        config.getReconciliationInterval(),
-                        client,
-                        kafkaClusterOperations,
-                        kafkaConnectClusterOperations,
-                        kafkaConnectS2IClusterOperations);
-                vertx.deployVerticle(controller,
-                    res -> {
-                        if (res.succeeded()) {
-                            log.info("Cluster Controller verticle started");
-                        } else {
-                            log.error("Cluster Controller verticle failed to start", res.cause());
-                            System.exit(1);
-                        }
-                    });
-            }
+            ClusterController controller = new ClusterController(config.getNamespaces(),
+                    config.getLabels(),
+                    config.getReconciliationInterval(),
+                    client,
+                    kafkaClusterOperations,
+                    kafkaConnectClusterOperations,
+                    kafkaConnectS2IClusterOperations);
+            vertx.deployVerticle(controller,
+                res -> {
+                    if (res.succeeded()) {
+                        log.info("Cluster Controller verticle started");
+                    } else {
+                        log.error("Cluster Controller verticle failed to start", res.cause());
+                        System.exit(1);
+                    }
+                });
         } catch (IllegalArgumentException e) {
             log.error("Unable to parse arguments", e);
             System.exit(1);

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/Main.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/Main.java
@@ -56,16 +56,21 @@ public class Main {
                     serviceOperations, imagesStreamOperations, buildConfigOperations);
 
             ClusterControllerConfig config = ClusterControllerConfig.fromMap(System.getenv());
-            vertx.deployVerticle(new ClusterController(config, kafkaClusterOperations,
-                kafkaConnectClusterOperations, kafkaConnectS2IClusterOperations),
-                res -> {
-                    if (res.succeeded())    {
-                        log.info("Cluster Controller verticle started");
-                    } else {
-                        log.error("Cluster Controller verticle failed to start", res.cause());
-                        System.exit(1);
-                    }
-                });
+            vertx.deployVerticle(new ClusterController(config.getNamespace(),
+                    config.getLabels(),
+                    config.getReconciliationInterval(),
+                    kafkaClusterOperations,
+                    kafkaConnectClusterOperations,
+                    kafkaConnectS2IClusterOperations),
+                    res -> {
+                if (res.succeeded())    {
+                    log.info("Cluster Controller verticle started");
+                }
+                else {
+                    log.error("Cluster Controller verticle failed to start", res.cause());
+                    System.exit(1);
+                }
+            });
         } catch (IllegalArgumentException e) {
             log.error("Unable to parse arguments", e);
             System.exit(1);

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/Main.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/Main.java
@@ -56,15 +56,24 @@ public class Main {
                     configMapOperations, deploymentConfigOperations,
                     serviceOperations, imagesStreamOperations, buildConfigOperations);
 
-            ClusterControllerConfig config = ClusterControllerConfig.fromMap(System.getenv());
-            if (config.getNamespaces() == null) {
-                deployController(vertx, client, kafkaClusterOperations, kafkaConnectClusterOperations,
-                        kafkaConnectS2IClusterOperations, config, null);
-            } else {
-                for (String namespace : config.getNamespaces()) {
-                    deployController(vertx, client, kafkaClusterOperations, kafkaConnectClusterOperations,
-                            kafkaConnectS2IClusterOperations, config, namespace);
-                }
+            ClusterControllerConfig config = ClusterControllerConfig.fromMap(System.getenv(), client);
+            for (String namespace : config.getNamespaces()) {
+                ClusterController controller = new ClusterController(namespace,
+                        config.getLabels(),
+                        config.getReconciliationInterval(),
+                        client,
+                        kafkaClusterOperations,
+                        kafkaConnectClusterOperations,
+                        kafkaConnectS2IClusterOperations);
+                vertx.deployVerticle(controller,
+                    res -> {
+                        if (res.succeeded()) {
+                            log.info("Cluster Controller verticle started");
+                        } else {
+                            log.error("Cluster Controller verticle failed to start", res.cause());
+                            System.exit(1);
+                        }
+                    });
             }
         } catch (IllegalArgumentException e) {
             log.error("Unable to parse arguments", e);
@@ -73,40 +82,5 @@ public class Main {
             log.error("Error starting cluster controller:", e);
             System.exit(1);
         }
-    }
-
-    /**
-     * Deploy a {@link ClusterController} in Vertx
-     * @param vertx The vertx instance
-     * @param client The kubernetes client
-     * @param kafkaClusterOperations Operations for Kafka clusters.
-     * @param kafkaConnectClusterOperations Operations for Connect clusters.
-     * @param kafkaConnectS2IClusterOperations Operations for Connect S2I clusters.
-     * @param config The controller config
-     * @param namespace The namespace to watch, or null to watch all namespaces in the Kubenetes/OpenShift cluster.
-     */
-    private static void deployController(Vertx vertx, DefaultKubernetesClient client,
-                                         KafkaClusterOperations kafkaClusterOperations,
-                                         KafkaConnectClusterOperations kafkaConnectClusterOperations,
-                                         KafkaConnectS2IClusterOperations kafkaConnectS2IClusterOperations,
-                                         ClusterControllerConfig config,
-                                         String namespace) {
-        ClusterController controller = new ClusterController(namespace,
-                config.getLabels(),
-                config.getReconciliationInterval(),
-                client,
-                kafkaClusterOperations,
-                kafkaConnectClusterOperations,
-                kafkaConnectS2IClusterOperations);
-        vertx.deployVerticle(controller,
-                res -> {
-                    String description = namespace == null ? "all namespaces" : "namespace" + namespace;
-                    if (res.succeeded()) {
-                        log.info("ClusterController started for {}", description);
-                    } else {
-                        log.error("ClusterController for {} failed to start", description, res.cause());
-                        System.exit(1);
-                    }
-                });
     }
 }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/Main.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/Main.java
@@ -5,7 +5,6 @@
 package io.strimzi.controller.cluster;
 
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
-import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.openshift.client.OpenShiftClient;
 import io.strimzi.controller.cluster.operations.cluster.KafkaClusterOperations;
 import io.strimzi.controller.cluster.operations.cluster.KafkaConnectClusterOperations;

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/Main.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/Main.java
@@ -56,7 +56,7 @@ public class Main {
                     configMapOperations, deploymentConfigOperations,
                     serviceOperations, imagesStreamOperations, buildConfigOperations);
 
-            ClusterControllerConfig config = ClusterControllerConfig.fromMap(System.getenv(), client);
+            ClusterControllerConfig config = ClusterControllerConfig.fromMap(System.getenv());
             for (String namespace : config.getNamespaces()) {
                 ClusterController controller = new ClusterController(namespace,
                         config.getLabels(),

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/resource/AbstractOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/resource/AbstractOperations.java
@@ -64,7 +64,7 @@ public abstract class AbstractOperations<C, T extends HasMetadata, L extends Kub
                 if (operation().inNamespace(namespace).withName(name).get() == null) {
                     try {
                         log.info("Creating {} {} in namespace {}", resourceKind, name, namespace);
-                        operation().createOrReplace(resource);
+                        operation().inNamespace(namespace).createOrReplace(resource);
                         log.info("{} {} in namespace {} has been created", resourceKind, name, namespace);
                         future.complete();
                     } catch (Exception e) {

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/ClusterControllerTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/ClusterControllerTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.controller.cluster;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.Watch;
+import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.util.Arrays.asList;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(VertxUnitRunner.class)
+public class ClusterControllerTest {
+
+    public static final String STRIMZI_IO_KIND_CLUSTER = "strimzi.io/kind=cluster";
+    private Vertx vertx;
+
+    @Before
+    public void createClient(TestContext context) {
+        vertx = Vertx.vertx();
+    }
+
+    @After
+    public void closeClient() {
+        vertx.close();
+    }
+
+    @Test
+    public void startStopSingleNamespace(TestContext context) {
+        startStop(context, "namespace");
+    }
+
+    @Test
+    public void startStopMultiNamespace(TestContext context) {
+        startStop(context, "namespace1, namespace2");
+    }
+
+    /**
+     * Does the CC start and then stop a verticle per namespace?
+     * @param context
+     * @param namespaces
+     */
+    private void startStop(TestContext context, String namespaces) {
+        AtomicInteger numWatchers = new AtomicInteger(0);
+        KubernetesClient client = mock(KubernetesClient.class);
+        MixedOperation mockCms = mock(MixedOperation.class);
+        when(client.configMaps()).thenReturn(mockCms);
+        List<String> namespaceList = asList(namespaces.split(" *,+ *"));
+        for (String namespace: namespaceList) {
+
+            MixedOperation mockNamespacedCms = mock(MixedOperation.class);
+            when(mockNamespacedCms.watch(any())).thenAnswer(invo -> {
+                numWatchers.incrementAndGet();
+                Watch mockWatch = mock(Watch.class);
+                doAnswer(invo2 -> {
+                    ((Watcher) invo.getArgument(0)).onClose(null);
+                    return null;
+                }).when(mockWatch).close();
+                return mockWatch;
+            });
+
+            when(mockNamespacedCms.withLabels(any())).thenReturn(mockNamespacedCms);
+            when(mockCms.inNamespace(namespace)).thenReturn(mockNamespacedCms);
+        }
+        Async async = context.async();
+
+        Map<String, String> env = new HashMap<>();
+        env.put(ClusterControllerConfig.STRIMZI_NAMESPACE, namespaces);
+        env.put(ClusterControllerConfig.STRIMZI_CONFIGMAP_LABELS, STRIMZI_IO_KIND_CLUSTER);
+        env.put(ClusterControllerConfig.STRIMZI_FULL_RECONCILIATION_INTERVAL, "120000");
+        Main.run(vertx, client, env).setHandler(ar -> {
+            context.assertNull(ar.cause(), "Expected all verticles to start OK");
+            async.complete();
+        });
+        async.await();
+
+        context.assertEquals(namespaceList.size(), vertx.deploymentIDs().size(), "A verticle per namespace");
+
+        List<Async> asyncs = new ArrayList<>();
+        for (String deploymentId: vertx.deploymentIDs()) {
+            Async async2 = context.async();
+            asyncs.add(async2);
+            vertx.undeploy(deploymentId, ar -> {
+                context.assertNull(ar.cause(), "Didn't expect error when undeploying verticle " + deploymentId);
+                async2.complete();
+            });
+        }
+
+        for (Async async2: asyncs) {
+            async2.await();
+        }
+
+        if (numWatchers.get() > namespaceList.size()) {
+            context.fail("Looks like there were more watchers than namespaces");
+        }
+    }
+
+}

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/resource/ResourceOperationsMockTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/resource/ResourceOperationsMockTest.java
@@ -154,7 +154,7 @@ public abstract class ResourceOperationsMockTest<C extends KubernetesClient, T e
         op.create(resource).setHandler(ar -> {
             assertTrue(ar.succeeded());
             verify(mockResource).get();
-            verify(mockCms).createOrReplace(eq(resource));
+            verify(mockNameable).createOrReplace(eq(resource));
             async.complete();
         });
     }
@@ -172,7 +172,7 @@ public abstract class ResourceOperationsMockTest<C extends KubernetesClient, T e
 
         MixedOperation mockCms = mock(MixedOperation.class);
         when(mockCms.inNamespace(matches(resource.getMetadata().getNamespace()))).thenReturn(mockNameable);
-        when(mockCms.createOrReplace(any())).thenThrow(ex);
+        when(mockNameable.createOrReplace(any())).thenThrow(ex);
 
         C mockClient = mock(clientType());
         mocker(mockClient, mockCms);

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,6 @@
                             <encoding>UTF-8</encoding>
                             <consoleOutput>true</consoleOutput>
                             <failsOnError>true</failsOnError>
-                            <linkXRef>false</linkXRef>
                         </configuration>
                         <goals>
                             <goal>check</goal>


### PR DESCRIPTION
The simplest thing to do is to deploy multiple cluster-controller verticles. I guess we can do better in the all-namespaces case, where we could make do with a single watcher. I'll try to do that next...