### PR TITLE
Make the tests run faster.

### DIFF
--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperations.java
@@ -137,21 +137,21 @@ public class KafkaClusterOperations extends AbstractClusterOperations<KafkaClust
 
             CompositeFuture
                 .join(createResult)
-                .compose(res -> statefulSetOperations.waitUntilReady(namespace, zk.getName(), 1, 60, TimeUnit.SECONDS))
+                .compose(res -> statefulSetOperations.waitUntilReady(namespace, zk.getName(), 1_000, 60_000))
                 .compose(res -> {
                     List<Future> waitPodResult = new ArrayList<>(zk.getReplicas());
 
                     for (int i = 0; i < zk.getReplicas(); i++) {
                         String podName = zk.getName() + "-" + i;
-                        waitPodResult.add(podOperations.waitUntilReady(namespace, podName, 1, 60, TimeUnit.SECONDS));
+                        waitPodResult.add(podOperations.waitUntilReady(namespace, podName, 1_000, 60_000));
                     }
 
                     return CompositeFuture.join(waitPodResult);
                 })
                 .compose(res -> {
                     List<Future> waitEndpointResult = new ArrayList<>(2);
-                    waitEndpointResult.add(endpointOperations.waitUntilReady(namespace, zk.getName(), 1, 60, TimeUnit.SECONDS));
-                    waitEndpointResult.add(endpointOperations.waitUntilReady(namespace, zk.getHeadlessName(), 1, 60, TimeUnit.SECONDS));
+                    waitEndpointResult.add(endpointOperations.waitUntilReady(namespace, zk.getName(), 1_000, 60_000));
+                    waitEndpointResult.add(endpointOperations.waitUntilReady(namespace, zk.getHeadlessName(), 1_000, 60_000));
                     return CompositeFuture.join(waitEndpointResult);
                 })
                 .compose(res -> {

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperations.java
@@ -137,21 +137,21 @@ public class KafkaClusterOperations extends AbstractClusterOperations<KafkaClust
 
             CompositeFuture
                 .join(createResult)
-                .compose(res -> statefulSetOperations.waitUntilReady(namespace, zk.getName(), 60, TimeUnit.SECONDS))
+                .compose(res -> statefulSetOperations.waitUntilReady(namespace, zk.getName(), 1, 60, TimeUnit.SECONDS))
                 .compose(res -> {
                     List<Future> waitPodResult = new ArrayList<>(zk.getReplicas());
 
                     for (int i = 0; i < zk.getReplicas(); i++) {
                         String podName = zk.getName() + "-" + i;
-                        waitPodResult.add(podOperations.waitUntilReady(namespace, podName, 60, TimeUnit.SECONDS));
+                        waitPodResult.add(podOperations.waitUntilReady(namespace, podName, 1, 60, TimeUnit.SECONDS));
                     }
 
                     return CompositeFuture.join(waitPodResult);
                 })
                 .compose(res -> {
                     List<Future> waitEndpointResult = new ArrayList<>(2);
-                    waitEndpointResult.add(endpointOperations.waitUntilReady(namespace, zk.getName(), 60, TimeUnit.SECONDS));
-                    waitEndpointResult.add(endpointOperations.waitUntilReady(namespace, zk.getHeadlessName(), 60, TimeUnit.SECONDS));
+                    waitEndpointResult.add(endpointOperations.waitUntilReady(namespace, zk.getName(), 1, 60, TimeUnit.SECONDS));
+                    waitEndpointResult.add(endpointOperations.waitUntilReady(namespace, zk.getHeadlessName(), 1, 60, TimeUnit.SECONDS));
                     return CompositeFuture.join(waitEndpointResult);
                 })
                 .compose(res -> {

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/resource/AbstractOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/resource/AbstractOperations.java
@@ -170,19 +170,17 @@ public abstract class AbstractOperations<C, T extends HasMetadata, L extends Kub
     /**
      * Waits until resource is in the Ready state
      *
-     * @param namespace The namespace
-     * @param name The resource name
-     * @param timeout Timeout in {@code timeUnit}
-     * @param timeUnit Time unit
+     * @param namespace The namespace.
+     * @param name The resource name.
+     * @param pollInteralMs The poll interval in milliseconds.
+     * @param timeoutMs The timeout, in milliseconds.
      */
-    public Future<Void> waitUntilReady(String namespace, String name, long pollInteral, long timeout, TimeUnit timeUnit) {
+    public Future<Void> waitUntilReady(String namespace, String name, long pollInteralMs, long timeoutMs) {
         Future<Void> fut = Future.future();
         log.info("Waiting for {} resource {} in namespace {} to get ready", resourceKind, name, namespace);
         long startTime = System.currentTimeMillis();
-        long timer = timeUnit.toMillis(pollInteral);
-        long timeoutInMs = timeUnit.toMillis(timeout);
 
-        vertx.setPeriodic(timer, timerId -> {
+        vertx.setPeriodic(pollInteralMs, timerId -> {
             vertx.createSharedWorkerExecutor("kubernetes-ops-pool").executeBlocking(
                     future -> {
                         try {
@@ -204,9 +202,9 @@ public abstract class AbstractOperations<C, T extends HasMetadata, L extends Kub
                             log.info("{} {} in namespace {} is ready", resourceKind, name, namespace);
                             fut.complete();
                         } else {
-                            if (System.currentTimeMillis() - startTime > timeoutInMs)   {
+                            if (System.currentTimeMillis() - startTime > timeoutMs)   {
                                 vertx.cancelTimer(timerId);
-                                log.error("Exceeded timeout of {} ms while waiting for {} {} in namespace {} to be ready", timeoutInMs, resourceKind, name, namespace);
+                                log.error("Exceeded timeoutMs of {} ms while waiting for {} {} in namespace {} to be ready", timeoutMs, resourceKind, name, namespace);
                                 fut.fail(new TimeoutException());
                             }
                         }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/resource/AbstractOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/resource/AbstractOperations.java
@@ -175,11 +175,11 @@ public abstract class AbstractOperations<C, T extends HasMetadata, L extends Kub
      * @param timeout Timeout in {@code timeUnit}
      * @param timeUnit Time unit
      */
-    public Future<Void> waitUntilReady(String namespace, String name, long timeout, TimeUnit timeUnit) {
+    public Future<Void> waitUntilReady(String namespace, String name, long pollInteral, long timeout, TimeUnit timeUnit) {
         Future<Void> fut = Future.future();
         log.info("Waiting for {} resource {} in namespace {} to get ready", resourceKind, name, namespace);
         long startTime = System.currentTimeMillis();
-        long timer = 1000L;
+        long timer = timeUnit.toMillis(pollInteral);
         long timeoutInMs = timeUnit.toMillis(timeout);
 
         vertx.setPeriodic(timer, timerId -> {

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperationsTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperationsTest.java
@@ -150,10 +150,10 @@ public class KafkaClusterOperationsTest {
         when(mockServiceOps.create(serviceCaptor.capture())).thenReturn(Future.succeededFuture());
         ArgumentCaptor<StatefulSet> ssCaptor = ArgumentCaptor.forClass(StatefulSet.class);
         when(mockSsOps.create(ssCaptor.capture())).thenReturn(Future.succeededFuture());
-        when(mockSsOps.waitUntilReady(any(), any(), anyLong(), anyLong(), any())).thenReturn(Future.succeededFuture());
+        when(mockSsOps.waitUntilReady(any(), any(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
 
-        when(mockPodOps.waitUntilReady(any(), any(), anyLong(), anyLong(), any())).thenReturn(Future.succeededFuture());
-        when(mockEndpointOps.waitUntilReady(any(), any(), anyLong(), anyLong(), any())).thenReturn(Future.succeededFuture());
+        when(mockPodOps.waitUntilReady(any(), any(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
+        when(mockEndpointOps.waitUntilReady(any(), any(), anyLong(), anyLong())).thenReturn(Future.succeededFuture());
 
         KafkaCluster kafkaCluster = KafkaCluster.fromConfigMap(clusterCm);
         ZookeeperCluster zookeeperCluster = ZookeeperCluster.fromConfigMap(clusterCm);
@@ -200,9 +200,9 @@ public class KafkaClusterOperationsTest {
                     capturedSs.stream().map(ss->ss.getMetadata().getName()).collect(Collectors.toSet()));
 
             // Verify that we wait for readiness
-            verify(mockEndpointOps, times(2)).waitUntilReady(any(), any(), anyLong(), anyLong(), any());
-            verify(mockSsOps).waitUntilReady(any(), any(), anyLong(), anyLong(), any());
-            verify(mockPodOps, times(zookeeperCluster.getReplicas())).waitUntilReady(any(), any(), anyLong(), anyLong(), any());
+            verify(mockEndpointOps, times(2)).waitUntilReady(any(), any(), anyLong(), anyLong());
+            verify(mockSsOps).waitUntilReady(any(), any(), anyLong(), anyLong());
+            verify(mockPodOps, times(zookeeperCluster.getReplicas())).waitUntilReady(any(), any(), anyLong(), anyLong());
 
             // PvcOperations only used for deletion
             verifyNoMoreInteractions(mockPvcOps);

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperationsTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperationsTest.java
@@ -150,10 +150,10 @@ public class KafkaClusterOperationsTest {
         when(mockServiceOps.create(serviceCaptor.capture())).thenReturn(Future.succeededFuture());
         ArgumentCaptor<StatefulSet> ssCaptor = ArgumentCaptor.forClass(StatefulSet.class);
         when(mockSsOps.create(ssCaptor.capture())).thenReturn(Future.succeededFuture());
-        when(mockSsOps.waitUntilReady(any(), any(), anyLong(), any())).thenReturn(Future.succeededFuture());
+        when(mockSsOps.waitUntilReady(any(), any(), anyLong(), anyLong(), any())).thenReturn(Future.succeededFuture());
 
-        when(mockPodOps.waitUntilReady(any(), any(), anyLong(), any())).thenReturn(Future.succeededFuture());
-        when(mockEndpointOps.waitUntilReady(any(), any(), anyLong(), any())).thenReturn(Future.succeededFuture());
+        when(mockPodOps.waitUntilReady(any(), any(), anyLong(), anyLong(), any())).thenReturn(Future.succeededFuture());
+        when(mockEndpointOps.waitUntilReady(any(), any(), anyLong(), anyLong(), any())).thenReturn(Future.succeededFuture());
 
         KafkaCluster kafkaCluster = KafkaCluster.fromConfigMap(clusterCm);
         ZookeeperCluster zookeeperCluster = ZookeeperCluster.fromConfigMap(clusterCm);
@@ -200,9 +200,9 @@ public class KafkaClusterOperationsTest {
                     capturedSs.stream().map(ss->ss.getMetadata().getName()).collect(Collectors.toSet()));
 
             // Verify that we wait for readiness
-            verify(mockEndpointOps, times(2)).waitUntilReady(any(), any(), anyLong(), any());
-            verify(mockSsOps).waitUntilReady(any(), any(), anyLong(), any());
-            verify(mockPodOps, times(zookeeperCluster.getReplicas())).waitUntilReady(any(), any(), anyLong(), any());
+            verify(mockEndpointOps, times(2)).waitUntilReady(any(), any(), anyLong(), anyLong(), any());
+            verify(mockSsOps).waitUntilReady(any(), any(), anyLong(), anyLong(), any());
+            verify(mockPodOps, times(zookeeperCluster.getReplicas())).waitUntilReady(any(), any(), anyLong(), anyLong(), any());
 
             // PvcOperations only used for deletion
             verifyNoMoreInteractions(mockPvcOps);

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/resource/ResourceOperationsMockTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/resource/ResourceOperationsMockTest.java
@@ -317,7 +317,7 @@ public abstract class ResourceOperationsMockTest<C extends KubernetesClient, T e
         AbstractOperations<C, T, L, D, R> op = createResourceOperations(vertx, mockClient);
 
         Async async = context.async();
-        Future<Void> fut = op.waitUntilReady(NAMESPACE, RESOURCE_NAME, 2, TimeUnit.SECONDS);
+        Future<Void> fut = op.waitUntilReady(NAMESPACE, RESOURCE_NAME, 20, 100, TimeUnit.MILLISECONDS);
         fut.setHandler(ar -> {
             assertTrue(ar.failed());
             assertThat(ar.cause(), instanceOf(TimeoutException.class));
@@ -347,7 +347,7 @@ public abstract class ResourceOperationsMockTest<C extends KubernetesClient, T e
         AbstractOperations<C, T, L, D, R> op = createResourceOperations(vertx, mockClient);
 
         Async async = context.async();
-        op.waitUntilReady(NAMESPACE, RESOURCE_NAME, 2, TimeUnit.SECONDS).setHandler(ar -> {
+        op.waitUntilReady(NAMESPACE, RESOURCE_NAME, 20, 100, TimeUnit.MILLISECONDS).setHandler(ar -> {
             assertTrue(ar.failed());
             assertThat(ar.cause(), instanceOf(TimeoutException.class));
             verify(mockResource, never()).isReady();
@@ -374,7 +374,7 @@ public abstract class ResourceOperationsMockTest<C extends KubernetesClient, T e
         AbstractOperations<C, T, L, D, R> op = createResourceOperations(vertx, mockClient);
 
         Async async = context.async();
-        op.waitUntilReady(NAMESPACE, RESOURCE_NAME, 2, TimeUnit.SECONDS).setHandler(ar -> {
+        op.waitUntilReady(NAMESPACE, RESOURCE_NAME, 20, 100, TimeUnit.MILLISECONDS).setHandler(ar -> {
             assertTrue(ar.succeeded());
             verify(mockResource).get();
 
@@ -409,7 +409,7 @@ public abstract class ResourceOperationsMockTest<C extends KubernetesClient, T e
         AbstractOperations<C, T, L, D, R> op = createResourceOperations(vertx, mockClient);
 
         Async async = context.async();
-        op.waitUntilReady(NAMESPACE, RESOURCE_NAME, 2, TimeUnit.SECONDS).setHandler(ar -> {
+        op.waitUntilReady(NAMESPACE, RESOURCE_NAME, 20, 100, TimeUnit.MILLISECONDS).setHandler(ar -> {
             assertTrue(ar.failed());
             assertThat(ar.cause(), instanceOf(TimeoutException.class));
             verify(mockResource, atLeastOnce()).get();
@@ -444,7 +444,7 @@ public abstract class ResourceOperationsMockTest<C extends KubernetesClient, T e
         AbstractOperations<C, T, L, D, R> op = createResourceOperations(vertx, mockClient);
 
         Async async = context.async();
-        op.waitUntilReady(NAMESPACE, RESOURCE_NAME, 2, TimeUnit.SECONDS).setHandler(ar -> {
+        op.waitUntilReady(NAMESPACE, RESOURCE_NAME, 20, 100, TimeUnit.MILLISECONDS).setHandler(ar -> {
             assertTrue(ar.failed());
             assertThat(ar.cause(), instanceOf(TimeoutException.class));
             async.complete();

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/resource/ResourceOperationsMockTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/resource/ResourceOperationsMockTest.java
@@ -317,7 +317,7 @@ public abstract class ResourceOperationsMockTest<C extends KubernetesClient, T e
         AbstractOperations<C, T, L, D, R> op = createResourceOperations(vertx, mockClient);
 
         Async async = context.async();
-        Future<Void> fut = op.waitUntilReady(NAMESPACE, RESOURCE_NAME, 20, 100, TimeUnit.MILLISECONDS);
+        Future<Void> fut = op.waitUntilReady(NAMESPACE, RESOURCE_NAME, 20, 100);
         fut.setHandler(ar -> {
             assertTrue(ar.failed());
             assertThat(ar.cause(), instanceOf(TimeoutException.class));
@@ -347,7 +347,7 @@ public abstract class ResourceOperationsMockTest<C extends KubernetesClient, T e
         AbstractOperations<C, T, L, D, R> op = createResourceOperations(vertx, mockClient);
 
         Async async = context.async();
-        op.waitUntilReady(NAMESPACE, RESOURCE_NAME, 20, 100, TimeUnit.MILLISECONDS).setHandler(ar -> {
+        op.waitUntilReady(NAMESPACE, RESOURCE_NAME, 20, 100).setHandler(ar -> {
             assertTrue(ar.failed());
             assertThat(ar.cause(), instanceOf(TimeoutException.class));
             verify(mockResource, never()).isReady();
@@ -374,7 +374,7 @@ public abstract class ResourceOperationsMockTest<C extends KubernetesClient, T e
         AbstractOperations<C, T, L, D, R> op = createResourceOperations(vertx, mockClient);
 
         Async async = context.async();
-        op.waitUntilReady(NAMESPACE, RESOURCE_NAME, 20, 100, TimeUnit.MILLISECONDS).setHandler(ar -> {
+        op.waitUntilReady(NAMESPACE, RESOURCE_NAME, 20, 100).setHandler(ar -> {
             assertTrue(ar.succeeded());
             verify(mockResource).get();
 
@@ -409,7 +409,7 @@ public abstract class ResourceOperationsMockTest<C extends KubernetesClient, T e
         AbstractOperations<C, T, L, D, R> op = createResourceOperations(vertx, mockClient);
 
         Async async = context.async();
-        op.waitUntilReady(NAMESPACE, RESOURCE_NAME, 20, 100, TimeUnit.MILLISECONDS).setHandler(ar -> {
+        op.waitUntilReady(NAMESPACE, RESOURCE_NAME, 20, 100).setHandler(ar -> {
             assertTrue(ar.failed());
             assertThat(ar.cause(), instanceOf(TimeoutException.class));
             verify(mockResource, atLeastOnce()).get();
@@ -444,7 +444,7 @@ public abstract class ResourceOperationsMockTest<C extends KubernetesClient, T e
         AbstractOperations<C, T, L, D, R> op = createResourceOperations(vertx, mockClient);
 
         Async async = context.async();
-        op.waitUntilReady(NAMESPACE, RESOURCE_NAME, 20, 100, TimeUnit.MILLISECONDS).setHandler(ar -> {
+        op.waitUntilReady(NAMESPACE, RESOURCE_NAME, 20, 100).setHandler(ar -> {
             assertTrue(ar.failed());
             assertThat(ar.cause(), instanceOf(TimeoutException.class));
             async.complete();


### PR DESCRIPTION
Because there are lots of ResourceOperationsTest subclasses and there are
4 tests for waitUntilReady stuff the tests were taking a while to complete.
By adjusting the poll interval and the timeout for the tests we can make them
run faster.