### PR TITLE
Getting started section in the documentation

### DIFF
--- a/documentation/appendix_deploying_kubernetes_openshift_cluster.adoc
+++ b/documentation/appendix_deploying_kubernetes_openshift_cluster.adoc
@@ -2,7 +2,7 @@
 == Installing Kubernetes and OpenShift cluster
 
 The easiest way to get started with Kubernetes or OpenShift is using the `Minikube`, `Minishift` or `oc cluster up`
-utilities. This section provides a basic guidance on how to use them. More details are provided on the websites of
+utilities. This section provides basic guidance on how to use them. More details are provided on the websites of
 the tools themselves.
 
 === Kubernetes
@@ -11,7 +11,7 @@ In order to interact with a Kubernetes cluster the https://kubernetes.io/docs/ta
 utility needs to be installed.
 
 The easiest way to get a running Kubernetes cluster is using `Minikube`. `Minikube` can be downloaded and installed
-from https://kubernetes.io/docs/getting-started-guides/minikube/[Kubernetes website]. Once installed, it can be started
+from the https://kubernetes.io/docs/getting-started-guides/minikube/[Kubernetes website]. Once installed, it can be started
 using:
 
 [source]
@@ -19,9 +19,9 @@ minikube start
 
 === OpenShift
 
-In order to interact with an OpenShift cluster,the https://github.com/openshift/origin/releases[`oc`] utility is needed.
+In order to interact with an OpenShift cluster, the https://github.com/openshift/origin/releases[`oc`] utility is needed.
 
-An OpenShift cluster can be started in two different ways. The `oc` utility can start the cluster locally using the
+An OpenShift cluster can be started in two different ways. The `oc` utility can start a cluster locally using the
 command:
 
 [source]
@@ -32,7 +32,7 @@ https://github.com/openshift/origin/blob/master/docs/cluster_up_down.md[here].
 
 Another option is to use `Minishift`. `MiniShift` is an OpenShift installation within a VM. It can be downloaded and
 installed from the https://docs.openshift.org/latest/minishift/index.html[Minishift website]. Once installed,
-`Minishift` can be started using following command:
+`Minishift` can be started using the following command:
 
 [source]
 minishift start

--- a/documentation/appendix_deploying_kubernetes_openshift_cluster.adoc
+++ b/documentation/appendix_deploying_kubernetes_openshift_cluster.adoc
@@ -1,16 +1,16 @@
 [appendix]
 == Installing Kubernetes and OpenShift cluster
 
-The easiest way how to get started with Kubernetes or OpenShift is using the `Minikube`, `Minishift` or `oc cluster up`
-utilities. This section provides a simple guide how to start using them. More details are provided on the websites of
-the tools it self.
+The easiest way to get started with Kubernetes or OpenShift is using the `Minikube`, `Minishift` or `oc cluster up`
+utilities. This section provides a basic guidance on how to use them. More details are provided on the websites of
+the tools themselves.
 
 === Kubernetes
 
 In order to interact with a Kubernetes cluster the https://kubernetes.io/docs/tasks/tools/install-kubectl/[`kubectl`]
 utility needs to be installed.
 
-The easiest way how to get a running Kubernetes cluster is using `Minikube`. `Minikube` can be downloaded and installed
+The easiest way to get a running Kubernetes cluster is using `Minikube`. `Minikube` can be downloaded and installed
 from https://kubernetes.io/docs/getting-started-guides/minikube/[Kubernetes website]. Once installed, it can be started
 using:
 
@@ -21,7 +21,7 @@ minikube start
 
 In order to interact with an OpenShift cluster,the https://github.com/openshift/origin/releases[`oc`] utility is needed.
 
-OpenShift cluster can be started in two different ways. The `oc` utility can start the cluster locally using the
+An OpenShift cluster can be started in two different ways. The `oc` utility can start the cluster locally using the
 command:
 
 [source]

--- a/documentation/appendix_deploying_kubernetes_openshift_cluster.adoc
+++ b/documentation/appendix_deploying_kubernetes_openshift_cluster.adoc
@@ -1,0 +1,38 @@
+[appendix]
+== Installing Kubernetes and OpenShift cluster
+
+The easiest way how to get started with Kubernetes or OpenShift is using the `Minikube`, `Minishift` or `oc cluster up`
+utilities. This section provides a simple guide how to start using them. More details are provided on the websites of
+the tools it self.
+
+=== Kubernetes
+
+In order to interact with a Kubernetes cluster the https://kubernetes.io/docs/tasks/tools/install-kubectl/[`kubectl`]
+utility needs to be installed.
+
+The easiest way how to get a running Kubernetes cluster is using `Minikube`. `Minikube` can be downloaded and installed
+from https://kubernetes.io/docs/getting-started-guides/minikube/[Kubernetes website]. Once installed, it can be started
+using:
+
+[source]
+minikube start
+
+=== OpenShift
+
+In order to interact with an OpenShift cluster,the https://github.com/openshift/origin/releases[`oc`] utility is needed.
+
+OpenShift cluster can be started in two different ways. The `oc` utility can start the cluster locally using the
+command:
+
+[source]
+oc cluster up
+
+This command requires Docker to be installed. More information about this way can be found
+https://github.com/openshift/origin/blob/master/docs/cluster_up_down.md[here].
+
+Another option is to use `Minishift`. `MiniShift` is an OpenShift installation within a VM. It can be downloaded and
+installed from the https://docs.openshift.org/latest/minishift/index.html[Minishift website]. Once installed,
+`Minishift` can be started using following command:
+
+[source]
+minishift start

--- a/documentation/cluster-controller.adoc
+++ b/documentation/cluster-controller.adoc
@@ -1,4 +1,4 @@
-= Cluster Controller
+== Cluster Controller
 
 The cluster controller is in charge of deploying a Kafka cluster alongside a Zookeeper ensemble. It's also able to deploy a
 Kafka Connect cluster which connects to an existing Kafka cluster. Such a cluster can be deployed using the Source2Image OpenShift
@@ -20,7 +20,7 @@ This might cause a rolling update which might lead to service disruption.
 Finally, when the ConfigMap is deleted, the controller starts to un-deploy the cluster deleting all the related Kubernets/OpenShift
 resources.
 
-== Reconciliation
+=== Reconciliation
 
 Although the controller reacts to all notifications about the cluster ConfigMaps received from the Kubernetes/OpenShift cluster,
 if the controller is not running, or if a notification is not received for any reason, the ConfigMaps will get out of sync
@@ -30,7 +30,7 @@ In order to handle failovers properly, a periodic reconciliation process is exec
 that it can compare the state of the ConfigMaps with the current cluster deployment in order to have
 a consistent state across all of them.
 
-== Format of the cluster ConfigMap
+=== Format of the cluster ConfigMap
 
 By default, the controller watches for ConfigMaps having the label `strimzi.io/kind=cluster` in order to find and get
 configuration for a Kafka or Kafka Connect cluster to deploy. The label is configurable through the `STRIMZI_CONFIGMAP_LABELS` 
@@ -47,7 +47,7 @@ features (works only with OpenShift)
 The `data` section of such ConfigMaps contains different keys depending on the "type" of deployment as described in the 
 following sections.
 
-=== Kafka
+==== Kafka
 
 In order to configure a Kafka cluster deployment, it's possible to specify the following fields in the `data` section of 
 the related ConfigMap :
@@ -138,7 +138,7 @@ a volume by the Zookeeper node pods
 * `[cluster-name]-kafka-metrics-config` ConfigMap which contains the Kafka metrics configuration and mounted as
 a volume by the Kafka broker pods
 
-==== Storage
+===== Storage
 
 Both Kafka and Zookeeper save data to files.
 
@@ -214,7 +214,7 @@ are generated :
 * `zookeeper-storage-[cluster-name]-zookeeper-[idx]` Persistent Volume Claim for the volume used for storing data for the
 Zookeeper node pod `[idx]`
 
-==== Metrics
+===== Metrics
 
 Because the Strimzi project uses the [JMX exporter](https://github.com/prometheus/jmx_exporter) in order to expose metrics 
 on each node, the JSON string used for metrics configuration in the cluster ConfigMap reflects the related JMX exporter 
@@ -222,7 +222,7 @@ configuration file. For this reason, you can find more information on how to use
 
 For more information on how metrics work, the related documentation is available link:../../metrics/METRICS.md[here]
 
-=== Kafka Connect
+==== Kafka Connect
 
 In order to configure a Kafka Connect cluster deployment, it's possible to specify the following fields in the `data` section of 
 the related ConfigMap:
@@ -293,7 +293,7 @@ The resources created by the cluster controller into the Kubernetes/OpenShift cl
 * [connect-cluster-name]-connect Deployment which is in charge to create the Kafka Connect worker node pods
 * [connect-cluster-name]-connect Service which exposes the REST interface for managing the Kafka Connect cluster
 
-== Controller configuration
+=== Controller configuration
 
 The controller itself can be configured through the following environment variables.
 

--- a/documentation/cluster-controller.adoc
+++ b/documentation/cluster-controller.adoc
@@ -218,7 +218,7 @@ Zookeeper node pod `[idx]`
 
 ===== Metrics
 
-Because the Strimzi project uses the [JMX exporter](https://github.com/prometheus/jmx_exporter) in order to expose metrics 
+Because Strimzi uses the [JMX exporter](https://github.com/prometheus/jmx_exporter) in order to expose metrics
 on each node, the JSON string used for metrics configuration in the cluster ConfigMap reflects the related JMX exporter 
 configuration file. For this reason, you can find more information on how to use it in the corresponding GitHub repo.
 

--- a/documentation/cluster-controller.adoc
+++ b/documentation/cluster-controller.adoc
@@ -47,6 +47,7 @@ features (works only with OpenShift)
 The `data` section of such ConfigMaps contains different keys depending on the "type" of deployment as described in the 
 following sections.
 
+[[kafka_config_map_details]]
 ==== Kafka
 
 In order to configure a Kafka cluster deployment, it's possible to specify the following fields in the `data` section of 
@@ -222,6 +223,7 @@ configuration file. For this reason, you can find more information on how to use
 
 For more information on how metrics work, the related documentation is available link:../../metrics/METRICS.md[here]
 
+[[kafka_connect_config_map_details]]
 ==== Kafka Connect
 
 In order to configure a Kafka Connect cluster deployment, it's possible to specify the following fields in the `data` section of 

--- a/documentation/cluster-controller.adoc
+++ b/documentation/cluster-controller.adoc
@@ -30,6 +30,7 @@ In order to handle failovers properly, a periodic reconciliation process is exec
 that it can compare the state of the ConfigMaps with the current cluster deployment in order to have
 a consistent state across all of them.
 
+[[config_map_details]]
 === Format of the cluster ConfigMap
 
 By default, the controller watches for ConfigMaps having the label `strimzi.io/kind=cluster` in order to find and get

--- a/documentation/docu.adoc
+++ b/documentation/docu.adoc
@@ -7,19 +7,20 @@ Version 0.1
 :imagesdir: ./img
 :xrefstyle: full
 
-This guide describes how to install and use Strimzi. Strimzi provides a way to run an Apache Kafka cluster on Kubernetes
-or OpenShift in various deployment configurations.
+Strimzi provides a way to run an Apache Kafka cluster on Kubernetes or OpenShift in various deployment configurations.
+This guide describes how to install and use Strimzi.
 
 == Overview
 
 Apache Kafka is a popular platform for streaming data delivery and processing. For more details about Apache Kafka
-itself, visit http://kafka.apache.org[Apache Kafka website]. Strimzi is a project which aims to make it easier to run
-Apache Kafka on top of Kubernetes and OpenShift.
+itself visit http://kafka.apache.org[Apache Kafka website]. The aim of the Strimzi project is to make it easy to run
+Apache Kafka on Kubernetes and OpenShift.
 
 Strimzi consists of 2 main components:
 
-Cluster Controller:: Responsible for deploying and managing Apache Kafka clusters
-Topic Controller:: Responsible for managing Kafka Topics
+Cluster Controller:: Responsible for deploying and managing Apache Kafka clusters within a Kuberentes or OpenShift
+cluster
+Topic Controller:: Responsible for managing Kafka Topics within a Kafka cluster running within Kubernetes or OpenShift
 
 include::getting-started.adoc[]
 

--- a/documentation/docu.adoc
+++ b/documentation/docu.adoc
@@ -1,0 +1,27 @@
+= Strimzi: Kafka as a Service running on Kubernetes and OpenShift
+Version 0.1
+:sectnums:
+:toc: preamble
+:toclevels: 3
+:toc-title: Content
+:imagesdir: ./img
+
+This guide describes how to install and use Strimzi. Strimzi provides a way to run an Apache Kafka cluster on Kubernetes
+or OpenShift in various deployment configurations.
+
+== Overview
+
+Apache Kafka is a popular platform for streaming data delivery and processing. For more details about Apache Kafka it
+self, visit http://kafka.apache.org[Apache Kafka website]. Strimzi is a project which aims to make it easier to run
+Apache Kafka on top of Kubernetes and OpenShift.
+
+Strimzi consists from 2 main components:
+
+Cluster Controller:: Responsible for deploying and managing Apache Kafka clusters
+Topic Controller:: Responsible for managing Kafka Topics
+
+include::getting-started.adoc[]
+
+include::cluster-controller.adoc[]
+
+include::topic-controller.adoc[]

--- a/documentation/docu.adoc
+++ b/documentation/docu.adoc
@@ -5,6 +5,7 @@ Version 0.1
 :toclevels: 3
 :toc-title: Content
 :imagesdir: ./img
+:xrefstyle: full
 
 This guide describes how to install and use Strimzi. Strimzi provides a way to run an Apache Kafka cluster on Kubernetes
 or OpenShift in various deployment configurations.
@@ -25,3 +26,5 @@ include::getting-started.adoc[]
 include::cluster-controller.adoc[]
 
 include::topic-controller.adoc[]
+
+include::appendix_deploying_kubernetes_openshift_cluster.adoc[]

--- a/documentation/docu.adoc
+++ b/documentation/docu.adoc
@@ -12,11 +12,11 @@ or OpenShift in various deployment configurations.
 
 == Overview
 
-Apache Kafka is a popular platform for streaming data delivery and processing. For more details about Apache Kafka it
-self, visit http://kafka.apache.org[Apache Kafka website]. Strimzi is a project which aims to make it easier to run
+Apache Kafka is a popular platform for streaming data delivery and processing. For more details about Apache Kafka
+itself, visit http://kafka.apache.org[Apache Kafka website]. Strimzi is a project which aims to make it easier to run
 Apache Kafka on top of Kubernetes and OpenShift.
 
-Strimzi consists from 2 main components:
+Strimzi consists of 2 main components:
 
 Cluster Controller:: Responsible for deploying and managing Apache Kafka clusters
 Topic Controller:: Responsible for managing Kafka Topics

--- a/documentation/docu.adoc
+++ b/documentation/docu.adoc
@@ -13,7 +13,7 @@ This guide describes how to install and use Strimzi.
 == Overview
 
 Apache Kafka is a popular platform for streaming data delivery and processing. For more details about Apache Kafka
-itself visit http://kafka.apache.org[Apache Kafka website]. The aim of the Strimzi project is to make it easy to run
+itself visit http://kafka.apache.org[Apache Kafka website]. The aim of Strimzi is to make it easy to run
 Apache Kafka on Kubernetes and OpenShift.
 
 Strimzi consists of 2 main components:

--- a/documentation/getting-started.adoc
+++ b/documentation/getting-started.adoc
@@ -25,7 +25,7 @@ strimzi.io/kind: cluster
 
 and contain the cluster configuration in a specific format. The ConfigMap format is described in <<config_map_details>>.
 
-The Strimzi project contains example YAML files which make deploying a Cluster Controller easier.
+Strimzi contains example YAML files which make deploying a Cluster Controller easier.
 
 ==== Deploying to Kubernetes
 
@@ -146,7 +146,7 @@ oc new-app strimzi-connect
 ==== Using Kafka Connect with additional plugins
 
 Strimzi Docker images for Kafka Connect contain, by default, only the `FileStreamSinkConnector` and
-`FileStreamSourceConnector` connectors which are part of the Apache Kafka project.
+`FileStreamSourceConnector` connectors which are part of Apache Kafka.
 
 To facilitate deployment with 3rd party connectors, Kafka Connect is configured to automatically load all
 plugins/connectors which are present in the `/opt/kafka/plugins` directory during startup. There are two ways of adding
@@ -181,7 +181,7 @@ OpenShift supports https://docs.openshift.org/3.6/dev_guide/builds/index.html[Bu
 https://docs.openshift.org/3.6/creating_images/s2i.html#creating-images-s2i[Source-to-Image (S2I)] framework to create
 new Docker images. OpenShift Build takes a builder image with S2I support together with source code and/or binaries
 provided by the user and uses them to build a new Docker image. The newly created Docker Image will be stored in
-OpenShift's local Docker repository and can then be used in deployments. The Strimzi project provides a Kafka Connect builder
+OpenShift's local Docker repository and can then be used in deployments. Strimzi provides a Kafka Connect builder
 image https://hub.docker.com/r/strimzi/kafka-connect-s2i/[`strimzi/kafka-connect-s2i`] with such S2I support. It takes user-provided
 binaries (with plugins and connectors) and creates a new Kafka Connect image. This enhanced Kafka Connect image can be
 used with our Kafka Connect deployment.

--- a/documentation/getting-started.adoc
+++ b/documentation/getting-started.adoc
@@ -2,7 +2,7 @@
 
 === Prerequisites
 
-Kubernetes or OpenShift cluster are required to deploy Strimzi. Strimzi supports all kind of clusters - from public and
+Kubernetes or OpenShift cluster is required to deploy Strimzi. Strimzi supports all kind of clusters - from public and
 private clouds up to local deployments intended for development purposes. This guide expects that a Kubernetes or
 OpenShift cluster is available and the `kubectl` or `oc` command line tools are installed and configured to connect
 to the running cluster.

--- a/documentation/getting-started.adoc
+++ b/documentation/getting-started.adoc
@@ -2,15 +2,14 @@
 
 === Prerequisites
 
-Kubernetes or OpenShift cluster are required to deploy Strimzi. It supports all kind of clusters - from public and
-private clouds up to local deployments designed for development purposes.
+Kubernetes or OpenShift cluster are required to deploy Strimzi. Strimzi supports all kind of clusters - from public and
+private clouds up to local deployments designed for development purposes. This guide expects that a Kubernetes or
+OpenShift clusters are available and the `kubectl` or `oc` command line tools are installed and configured to connect
+to the running cluster.
 
-The easiest way to try Strimzi is using https://kubernetes.io/docs/getting-started-guides/minikube/[Minikube] or
-https://docs.openshift.org/latest/minishift/index.html[Minishift]. In order to interact with Kubernetes or OpenShift
-clusters the https://kubernetes.io/docs/tasks/tools/install-kubectl/[kubectl] and
-https://docs.openshift.com/enterprise/3.0/cli_reference/get_started_cli.html[oc] are required as well. As an alternative
-to Minishift, the `oc` utility has a built in OpenShift cluster as well. More details can be found in
-https://github.com/openshift/origin/blob/master/docs/cluster_up_down.md[this document].
+When no Kubernetes or OpenShift cluster is available, `Minikube` or `Minishift` can be used. More details can be found
+in <<_installing_kubernetes_and_openshift_cluster>>
+
 
 === Cluster Controller
 
@@ -86,8 +85,7 @@ should have the following labels:
 strimzi.io/type: kafka
 strimzi.io/kind: cluster
 
-// TODO: Add link
-Example ConfigMaps and the details about the ConfigMap format are in chapter XXX.
+Example ConfigMaps and the details about the ConfigMap format are in <<kafka_config_map_details>>.
 
 ==== Deploying to Kubernetes
 
@@ -123,8 +121,8 @@ configurable number of workers. The default image currently contains only the Co
 Connect -`FileStreamSinkConnector` and `FileStreamSourceConnector`. The REST interface for managing the Kafka Connect
 cluster is exposed internally within the Kubernetes/OpenShift cluster as service `kafka-connect` on port `8083`.
 
-// TODO: Add link
-Example ConfigMaps and the details about the ConfigMap format for deploying Kafka Connect can be found in chapter XXX.
+Example ConfigMaps and the details about the ConfigMap format for deploying Kafka Connect can be found in
+<<kafka_connect_config_map_details>>.
 
 ==== Deploying to Kubernetes
 

--- a/documentation/getting-started.adoc
+++ b/documentation/getting-started.adoc
@@ -3,8 +3,8 @@
 === Prerequisites
 
 Kubernetes or OpenShift cluster are required to deploy Strimzi. Strimzi supports all kind of clusters - from public and
-private clouds up to local deployments designed for development purposes. This guide expects that a Kubernetes or
-OpenShift clusters are available and the `kubectl` or `oc` command line tools are installed and configured to connect
+private clouds up to local deployments intended for development purposes. This guide expects that a Kubernetes or
+OpenShift cluster is available and the `kubectl` or `oc` command line tools are installed and configured to connect
 to the running cluster.
 
 When no Kubernetes or OpenShift cluster is available, `Minikube` or `Minishift` can be used. More details can be found
@@ -13,18 +13,19 @@ in <<_installing_kubernetes_and_openshift_cluster>>
 
 === Cluster Controller
 
-Strimzi is using process called Cluster Controller to deploy and manage Kafka (including Zookeeper) and Kafka Connect
-clusters. Cluster Controller is a process which is running inside your Kubernetes or OpenShift cluster. To deploy a
-Kafka cluster, a ConfigMap with the cluster configuration has to be created. By default, the ConfigMap needs to be
-labeled with following labels:
+Strimzi uses a component called the Cluster Controller to deploy and manage Kafka (including Zookeeper) and Kafka Connect
+clusters. The Cluster Controller is deployed as a process running inside your Kubernetes or OpenShift cluster. To deploy a
+Kafka cluster, a ConfigMap with the cluster configuration has to be created. Based on the information in that ConfigMap,
+the Cluster Controller will deploy a corresponding Kafka cluster. By default, the ConfigMap needs to be labeled with
+following labels:
 
 [source,yaml]
 strimzi.io/type: kafka
 strimzi.io/kind: cluster
 
-and contain the cluster configuration in specific format.
+and contain the cluster configuration in a specific format.
 
-Strimzi project contains example YAML files which make deploying of Cluster Controller easier.
+The Strimzi project contains example YAML files which make deploying of Cluster Controller easier.
 
 ==== Deploying to Kubernetes
 
@@ -54,7 +55,7 @@ oc describe all
 
 === Kafka broker
 
-Strimzi uses StatefulSets (previously known as _PetSets_) feature to deploy Kafka brokers on Kubernetes/OpenShift.
+Strimzi uses StatefulSets feature to deploy Kafka brokers on Kubernetes/OpenShift.
 With StatefulSets, the pods receive a unique name and network identity and that makes it easier to identify the
 individual Kafka broker pods and set their identity (broker ID). The deployment uses **regular** and **headless**
 services:
@@ -63,20 +64,20 @@ services:
 - headless services are needed to have DNS resolve the pods IP addresses directly
 
 Together with Kafka, Strimzi also installs a Zookeeper cluster and configures the Kafka brokers to connect to it. The
-Zookeeper cluster is also using StatefulSets.
+Zookeeper cluster also uses StatefulSets.
 
 Strimzi provides two flavors of Kafka broker deployment: **ephemeral** and **persistent**.
 
 The **ephemeral** flavour is suitable only for development and testing purposes and not for production. The
-ephemeral flavour is using `emptyDir` volumes for storing broker information (Zookeeper) and topics/partitions
+ephemeral flavour uses `emptyDir` volumes for storing broker information (Zookeeper) and topics/partitions
 (Kafka). Using `emptyDir` volume means that its content is strictly related to the pod life cycle (it is
 deleted when the pod goes down). This makes the in-memory deployment well-suited to development and testing because
 you don't have to provide persistent volumes.
 
-The **persistent** flavour is using PersistentVolumes to store Zookeeper and Kafka data. The PersistentVolume is
-acquired using PersistentVolumeClaim – that makes it independent on the actual type of the PersistentVolume. For
+The **persistent** flavour uses PersistentVolumes to store Zookeeper and Kafka data. The PersistentVolume is
+acquired using a PersistentVolumeClaim – that makes it independent on the actual type of the PersistentVolume. For
 example, it can use HostPath volumes on Minikube or Amazon EBS volumes in Amazon AWS deployments without any
-changes in the YAML files. The PersistentVolumeClaim can use StorageClass to trigger automatic volume provisioning.
+changes in the YAML files. The PersistentVolumeClaim can use a StorageClass to trigger automatic volume provisioning.
 
 To deploy a Kafka cluster, a ConfigMap with the cluster configuration has to be created. By default, the ConfigMap
 should have the following labels:
@@ -90,7 +91,7 @@ Example ConfigMaps and the details about the ConfigMap format are in <<kafka_con
 ==== Deploying to Kubernetes
 
 To deploy Kafka broker on Kubernetes, the corresponding ConfigMap has to be created. To create the ephemeral
-cluster using the provided example ConfigMap, following command should be executed:
+cluster using the provided example ConfigMap, the following command should be executed:
 
 [source]
 kubectl apply -f resources/kubernetes/kafka-ephemeral.yaml
@@ -102,20 +103,21 @@ kubectl apply -f resources/kubernetes/kafka-persistent.yaml
 
 ==== Deploying to OpenShift
 
-For OpenShift, Kafka broker is provided in the form of a template. The cluster can be deployed from the template either
-using command line or using the OpenShift console. To create the ephemeral cluster, following command should be executed:
+For OpenShift, the Kafka broker is provided in the form of a template. The cluster can be deployed from the template either
+using the command line or using the OpenShift console. To create the ephemeral cluster, the following command should be
+executed:
 
 [source]
 oc new-app strimzi-ephemeral
 
-Similarly to deploy persistent KAfka cluster, following command should be run:
+Similarly, to deploy persistent Kafka cluster the following command should be run:
 
 [source]
 oc new-app strimzi-persistent
 
 === Kafka Connect
 
-The Cluster Controller can also deploy a https://kafka.apache.org/documentation/#connect[Kafka Connect] clusters which
+The Cluster Controller can also deploy a https://kafka.apache.org/documentation/#connect[Kafka Connect] cluster which
 can be used with either of the Kafka broker deployments described above. It is implemented as a Deployment with a
 configurable number of workers. The default image currently contains only the Connectors distributed with Apache Kafka
 Connect -`FileStreamSinkConnector` and `FileStreamSourceConnector`. The REST interface for managing the Kafka Connect
@@ -127,7 +129,7 @@ Example ConfigMaps and the details about the ConfigMap format for deploying Kafk
 ==== Deploying to Kubernetes
 
 To deploy Kafka Connect on Kubernetes, the corresponding ConfigMap has to be created. An example ConfigMap can be
-created using following command:
+created using the following command:
 
 [source]
 kubectl apply -f resources/kubernetes/kafka-connect.yaml
@@ -135,7 +137,7 @@ kubectl apply -f resources/kubernetes/kafka-connect.yaml
 ==== Deploying to OpenShift
 
 On OpenShift, Kafka Connect is provided in the form of a template. It can be deployed from the template either
-using command line or using the OpenShift console. To create Kafka Connect cluster from the command line, following
+using the command line or using the OpenShift console. To create Kafka Connect cluster from the command line, the following
 command should be run:
 
 [source]
@@ -143,22 +145,23 @@ oc new-app strimzi-connect
 
 ==== Using Kafka Connect with additional plugins
 
-Strimzi Docker images for Kafka Connect contain by default only the `FileStreamSinkConnector` and
+Strimzi Docker images for Kafka Connect contain, by default, only the `FileStreamSinkConnector` and
 `FileStreamSourceConnector` connectors which are part of the Apache Kafka project.
 
-But they configure Kafka Connect to automatically load all plugins/connectors which are present in the
-`/opt/kafka/plugins` directory during startup. There are two ways how to add custom plugins into this directory:
+To facilitate deployment with 3rd party connectors, Kafka Connect is configured to automatically load all
+plugins/connectors which are present in the `/opt/kafka/plugins` directory during startup. There are two ways how to add
+custom plugins into this directory:
 
-- Using custom Docker image
-- Using OpenShift build system and with the Strimzi S2I image
+- Using a custom Docker image
+- Using the OpenShift build system with the Strimzi S2I image
 
 ===== Create a new image based on `strimzi/kafka-connect`
 
 Strimzi provides its own Docker image for running Kafka Connect which can be found on Docker Hub as
 https://hub.docker.com/r/strimzi/kafka-connect/[`strimzi/kafka-connect`]. This image could be used as a base image for
-building a new custom image with additional plugins. Following steps describe the process for creating the custom image:
+building a new custom image with additional plugins. The following steps describe the process for creating such a custom image:
 
-1. Create a new `Dockerfile` which uses `strimzi/kafka-connect` as base image
+1. Create a new `Dockerfile` which uses `strimzi/kafka-connect` as the base image
 
 [source,Dockerfile]
 FROM strimzi/kafka-connect:latest
@@ -166,11 +169,11 @@ USER root:root
 COPY ./my-plugin/ /opt/kafka/plugins/
 USER kafka:kafka
 
-2. Build the Docker image and upload it to your Docker repository
+2. Build the Docker image and upload it to the appropriate Docker repository
 3. To use the new Docker image in the Kafka Connect deployment,
   - On OpenShift, the template parameters `IMAGE_REPO_NAME`, `IMAGE_NAME` and `IMAGE_TAG` can be changed to point to the
-  new image when the KAfka Connect cluster is being deployer
-  - On Kubernetes, the ConfigMap has to be modified to use the new image
+  new image when the Kafka Connect cluster is being deployed
+  - On Kubernetes, the Kafka Connect ConfigMap has to be modified to use the new image
 
 ===== Using OpenShift Build and S2I image
 
@@ -178,19 +181,19 @@ OpenShift supports https://docs.openshift.org/3.6/dev_guide/builds/index.html[Bu
 https://docs.openshift.org/3.6/creating_images/s2i.html#creating-images-s2i[Source-to-Image (S2I)] framework to create
 new Docker images. OpenShift Build takes a builder image with the S2I support together with source code and/or binaries
 provided by the user and uses them to build a new Docker image. The newly created Docker Image will be stored in
-OpenShift's local Docker repository and can be used in deployments. The Strimzi project provides a Kafka Connect S2I
-builder image https://hub.docker.com/r/strimzi/kafka-connect-s2i/[`strimzi/kafka-connect-s2i`] which takes user-provided
+OpenShift's local Docker repository and can then be used in deployments. The Strimzi project provides a Kafka Connect builder
+image https://hub.docker.com/r/strimzi/kafka-connect-s2i/[`strimzi/kafka-connect-s2i`] with S2I support. It takes user-provided
 binaries (with plugins and connectors) and creates a new Kafka Connect image. This enhanced Kafka Connect image can be
 used with our Kafka Connect deployment.
 
-The S2I deployment is again provided as an OpenShift template. It can be deployed from the template either using command
-line or using the OpenShift console. To create Kafka Connect S2I cluster from the command line, following command should
+The S2I deployment is again provided as an OpenShift template. It can be deployed from the template either using the command
+line or using the OpenShift console. To create Kafka Connect S2I cluster from the command line, the following command should
 be run:
 
 [source]
 oc new-app strimzi-connect-s2i
 
-Once the cluster is deployed, a new Builds can be triggered from the command line:
+Once the cluster is deployed, a new Build can be triggered from the command line:
 
 1. A directory with Kafka Connect plugins has to be prepared first. For example:
 +
@@ -232,11 +235,11 @@ $ tree ./my-plugins/
     └── README.md
 ----
 
-2. To start new image build using the prepared directory, following command has to be run:
+2. To start a new image build using the prepared directory, the following command has to be run:
 +
 [source]
 oc start-build my-connect-cluster-connect --from-dir ./my-plugins/
 +
 _The name of the build should be changed according to the cluster name of the deployed Kafka Connect cluster._
 
-3. Once the build is finished, the new image will be automatically used by the Kafka Connect deployment.
+3. Once the build is finished, the new image will be used automatically by the Kafka Connect deployment.

--- a/documentation/getting-started.adoc
+++ b/documentation/getting-started.adoc
@@ -96,7 +96,7 @@ cluster using the provided example ConfigMap, the following command should be ex
 [source]
 kubectl apply -f resources/kubernetes/kafka-ephemeral.yaml
 
-Another example ConfigMap is provided for persistent Kafka cluster. To deploy it, following command should be run:
+Another example ConfigMap is provided for persistent Kafka cluster. To deploy it, the following command should be run:
 
 [source]
 kubectl apply -f resources/kubernetes/kafka-persistent.yaml
@@ -179,7 +179,7 @@ USER kafka:kafka
 
 OpenShift supports https://docs.openshift.org/3.6/dev_guide/builds/index.html[Builds] which can be used together with
 https://docs.openshift.org/3.6/creating_images/s2i.html#creating-images-s2i[Source-to-Image (S2I)] framework to create
-new Docker images. OpenShift Build takes a builder image with the S2I support together with source code and/or binaries
+new Docker images. OpenShift Build takes a builder image with S2I support together with source code and/or binaries
 provided by the user and uses them to build a new Docker image. The newly created Docker Image will be stored in
 OpenShift's local Docker repository and can then be used in deployments. The Strimzi project provides a Kafka Connect builder
 image https://hub.docker.com/r/strimzi/kafka-connect-s2i/[`strimzi/kafka-connect-s2i`] with S2I support. It takes user-provided

--- a/documentation/getting-started.adoc
+++ b/documentation/getting-started.adoc
@@ -1,0 +1,244 @@
+== Getting started
+
+=== Prerequisites
+
+Kubernetes or OpenShift cluster are required to deploy Strimzi. It supports all kind of clusters - from public and
+private clouds up to local deployments designed for development purposes.
+
+The easiest way to try Strimzi is using https://kubernetes.io/docs/getting-started-guides/minikube/[Minikube] or
+https://docs.openshift.org/latest/minishift/index.html[Minishift]. In order to interact with Kubernetes or OpenShift
+clusters the https://kubernetes.io/docs/tasks/tools/install-kubectl/[kubectl] and
+https://docs.openshift.com/enterprise/3.0/cli_reference/get_started_cli.html[oc] are required as well. As an alternative
+to Minishift, the `oc` utility has a built in OpenShift cluster as well. More details can be found in
+https://github.com/openshift/origin/blob/master/docs/cluster_up_down.md[this document].
+
+=== Cluster Controller
+
+Strimzi is using process called Cluster Controller to deploy and manage Kafka (including Zookeeper) and Kafka Connect
+clusters. Cluster Controller is a process which is running inside your Kubernetes or OpenShift cluster. To deploy a
+Kafka cluster, a ConfigMap with the cluster configuration has to be created. By default, the ConfigMap needs to be
+labeled with following labels:
+
+[source,yaml]
+strimzi.io/type: kafka
+strimzi.io/kind: cluster
+
+and contain the cluster configuration in specific format.
+
+Strimzi project contains example YAML files which make deploying of Cluster Controller easier.
+
+==== Deploying to Kubernetes
+
+To deploy the Cluster Controller on Kubernetes, following command should be executed:
+
+[source]
+kubectl create -f resources/kubernetes/cluster-controller.yaml
+
+To verify whether the Cluster Controller has been deployed successfully, the Kubernetes Dashboard or the following
+command can be used:
+
+[soruce]
+kubectl describe all
+
+==== Deploying to OpenShift
+
+To deploy the Cluster Controller on OpenShift, following command should be executed:
+
+[source]
+oc create -f resources/openshift/cluster-controller-with-template.yaml
+
+To verify whether the Cluster Controller has been deployed successfully, the OpenShift console or the following command
+can be used:
+
+[soruce]
+oc describe all
+
+=== Kafka broker
+
+Strimzi uses StatefulSets (previously known as _PetSets_) feature to deploy Kafka brokers on Kubernetes/OpenShift.
+With StatefulSets, the pods receive a unique name and network identity and that makes it easier to identify the
+individual Kafka broker pods and set their identity (broker ID). The deployment uses **regular** and **headless**
+services:
+
+- regular services can be used as bootstrap servers for Kafka clients
+- headless services are needed to have DNS resolve the pods IP addresses directly
+
+Together with Kafka, Strimzi also installs a Zookeeper cluster and configures the Kafka brokers to connect to it. The
+Zookeeper cluster is also using StatefulSets.
+
+Strimzi provides two flavors of Kafka broker deployment: **ephemeral** and **persistent**.
+
+The **ephemeral** flavour is suitable only for development and testing purposes and not for production. The
+ephemeral flavour is using `emptyDir` volumes for storing broker information (Zookeeper) and topics/partitions
+(Kafka). Using `emptyDir` volume means that its content is strictly related to the pod life cycle (it is
+deleted when the pod goes down). This makes the in-memory deployment well-suited to development and testing because
+you don't have to provide persistent volumes.
+
+The **persistent** flavour is using PersistentVolumes to store Zookeeper and Kafka data. The PersistentVolume is
+acquired using PersistentVolumeClaim – that makes it independent on the actual type of the PersistentVolume. For
+example, it can use HostPath volumes on Minikube or Amazon EBS volumes in Amazon AWS deployments without any
+changes in the YAML files. The PersistentVolumeClaim can use StorageClass to trigger automatic volume provisioning.
+
+To deploy a Kafka cluster, a ConfigMap with the cluster configuration has to be created. By default, the ConfigMap
+should have the following labels:
+
+[source,yaml]
+strimzi.io/type: kafka
+strimzi.io/kind: cluster
+
+// TODO: Add link
+Example ConfigMaps and the details about the ConfigMap format are in chapter XXX.
+
+==== Deploying to Kubernetes
+
+To deploy Kafka broker on Kubernetes, the corresponding ConfigMap has to be created. To create the ephemeral
+cluster using the provided example ConfigMap, following command should be executed:
+
+[source]
+kubectl apply -f resources/kubernetes/kafka-ephemeral.yaml
+
+Another example ConfigMap is provided for persistent Kafka cluster. To deploy it, following command should be run:
+
+[source]
+kubectl apply -f resources/kubernetes/kafka-persistent.yaml
+
+==== Deploying to OpenShift
+
+For OpenShift, Kafka broker is provided in the form of a template. The cluster can be deployed from the template either
+using command line or using the OpenShift console. To create the ephemeral cluster, following command should be executed:
+
+[source]
+oc new-app strimzi-ephemeral
+
+Similarly to deploy persistent KAfka cluster, following command should be run:
+
+[source]
+oc new-app strimzi-persistent
+
+=== Kafka Connect
+
+The Cluster Controller can also deploy a https://kafka.apache.org/documentation/#connect[Kafka Connect] clusters which
+can be used with either of the Kafka broker deployments described above. It is implemented as a Deployment with a
+configurable number of workers. The default image currently contains only the Connectors distributed with Apache Kafka
+Connect -`FileStreamSinkConnector` and `FileStreamSourceConnector`. The REST interface for managing the Kafka Connect
+cluster is exposed internally within the Kubernetes/OpenShift cluster as service `kafka-connect` on port `8083`.
+
+// TODO: Add link
+Example ConfigMaps and the details about the ConfigMap format for deploying Kafka Connect can be found in chapter XXX.
+
+==== Deploying to Kubernetes
+
+To deploy Kafka Connect on Kubernetes, the corresponding ConfigMap has to be created. An example ConfigMap can be
+created using following command:
+
+[source]
+kubectl apply -f resources/kubernetes/kafka-connect.yaml
+
+==== Deploying to OpenShift
+
+On OpenShift, Kafka Connect is provided in the form of a template. It can be deployed from the template either
+using command line or using the OpenShift console. To create Kafka Connect cluster from the command line, following
+command should be run:
+
+[source]
+oc new-app strimzi-connect
+
+==== Using Kafka Connect with additional plugins
+
+Strimzi Docker images for Kafka Connect contain by default only the `FileStreamSinkConnector` and
+`FileStreamSourceConnector` connectors which are part of the Apache Kafka project.
+
+But they configure Kafka Connect to automatically load all plugins/connectors which are present in the
+`/opt/kafka/plugins` directory during startup. There are two ways how to add custom plugins into this directory:
+
+- Using custom Docker image
+- Using OpenShift build system and with the Strimzi S2I image
+
+===== Create a new image based on `strimzi/kafka-connect`
+
+Strimzi provides its own Docker image for running Kafka Connect which can be found on Docker Hub as
+https://hub.docker.com/r/strimzi/kafka-connect/[`strimzi/kafka-connect`]. This image could be used as a base image for
+building a new custom image with additional plugins. Following steps describe the process for creating the custom image:
+
+1. Create a new `Dockerfile` which uses `strimzi/kafka-connect` as base image
+
+[source,Dockerfile]
+FROM strimzi/kafka-connect:latest
+USER root:root
+COPY ./my-plugin/ /opt/kafka/plugins/
+USER kafka:kafka
+
+2. Build the Docker image and upload it to your Docker repository
+3. To use the new Docker image in the Kafka Connect deployment,
+  - On OpenShift, the template parameters `IMAGE_REPO_NAME`, `IMAGE_NAME` and `IMAGE_TAG` can be changed to point to the
+  new image when the KAfka Connect cluster is being deployer
+  - On Kubernetes, the ConfigMap has to be modified to use the new image
+
+===== Using OpenShift Build and S2I image
+
+OpenShift supports https://docs.openshift.org/3.6/dev_guide/builds/index.html[Builds] which can be used together with
+https://docs.openshift.org/3.6/creating_images/s2i.html#creating-images-s2i[Source-to-Image (S2I)] framework to create
+new Docker images. OpenShift Build takes a builder image with the S2I support together with source code and/or binaries
+provided by the user and uses them to build a new Docker image. The newly created Docker Image will be stored in
+OpenShift's local Docker repository and can be used in deployments. The Strimzi project provides a Kafka Connect S2I
+builder image https://hub.docker.com/r/strimzi/kafka-connect-s2i/[`strimzi/kafka-connect-s2i`] which takes user-provided
+binaries (with plugins and connectors) and creates a new Kafka Connect image. This enhanced Kafka Connect image can be
+used with our Kafka Connect deployment.
+
+The S2I deployment is again provided as an OpenShift template. It can be deployed from the template either using command
+line or using the OpenShift console. To create Kafka Connect S2I cluster from the command line, following command should
+be run:
+
+[source]
+oc new-app strimzi-connect-s2i
+
+Once the cluster is deployed, a new Builds can be triggered from the command line:
+
+1. A directory with Kafka Connect plugins has to be prepared first. For example:
++
+[source,shell]
+----
+$ tree ./my-plugins/
+./my-plugins/
+├── debezium-connector-mongodb
+│   ├── bson-3.4.2.jar
+│   ├── CHANGELOG.md
+│   ├── CONTRIBUTE.md
+│   ├── COPYRIGHT.txt
+│   ├── debezium-connector-mongodb-0.7.1.jar
+│   ├── debezium-core-0.7.1.jar
+│   ├── LICENSE.txt
+│   ├── mongodb-driver-3.4.2.jar
+│   ├── mongodb-driver-core-3.4.2.jar
+│   └── README.md
+├── debezium-connector-mysql
+│   ├── CHANGELOG.md
+│   ├── CONTRIBUTE.md
+│   ├── COPYRIGHT.txt
+│   ├── debezium-connector-mysql-0.7.1.jar
+│   ├── debezium-core-0.7.1.jar
+│   ├── LICENSE.txt
+│   ├── mysql-binlog-connector-java-0.13.0.jar
+│   ├── mysql-connector-java-5.1.40.jar
+│   ├── README.md
+│   └── wkb-1.0.2.jar
+└── debezium-connector-postgres
+    ├── CHANGELOG.md
+    ├── CONTRIBUTE.md
+    ├── COPYRIGHT.txt
+    ├── debezium-connector-postgres-0.7.1.jar
+    ├── debezium-core-0.7.1.jar
+    ├── LICENSE.txt
+    ├── postgresql-42.0.0.jar
+    ├── protobuf-java-2.6.1.jar
+    └── README.md
+----
+
+2. To start new image build using the prepared directory, following command has to be run:
++
+[source]
+oc start-build my-connect-cluster-connect --from-dir ./my-plugins/
++
+_The name of the build should be changed according to the cluster name of the deployed Kafka Connect cluster._
+
+3. Once the build is finished, the new image will be automatically used by the Kafka Connect deployment.

--- a/documentation/getting-started.adoc
+++ b/documentation/getting-started.adoc
@@ -2,13 +2,13 @@
 
 === Prerequisites
 
-Kubernetes or OpenShift cluster is required to deploy Strimzi. Strimzi supports all kind of clusters - from public and
-private clouds up to local deployments intended for development purposes. This guide expects that a Kubernetes or
+A Kubernetes or OpenShift cluster is required to deploy Strimzi. Strimzi supports all kinds of clusters - from public and
+private clouds down to local deployments intended for development purposes. This guide expects that a Kubernetes or
 OpenShift cluster is available and the `kubectl` or `oc` command line tools are installed and configured to connect
 to the running cluster.
 
-When no Kubernetes or OpenShift cluster is available, `Minikube` or `Minishift` can be used. More details can be found
-in <<_installing_kubernetes_and_openshift_cluster>>
+When no existing Kubernetes or OpenShift cluster is available, `Minikube` or `Minishift` can be used to create a local
+cluster. More details can be found in <<_installing_kubernetes_and_openshift_cluster>>
 
 
 === Cluster Controller
@@ -23,13 +23,13 @@ following labels:
 strimzi.io/type: kafka
 strimzi.io/kind: cluster
 
-and contain the cluster configuration in a specific format.
+and contain the cluster configuration in a specific format. The ConfigMap format is described in <<config_map_details>>.
 
-The Strimzi project contains example YAML files which make deploying of Cluster Controller easier.
+The Strimzi project contains example YAML files which make deploying a Cluster Controller easier.
 
 ==== Deploying to Kubernetes
 
-To deploy the Cluster Controller on Kubernetes, following command should be executed:
+To deploy the Cluster Controller on Kubernetes, the following command should be executed:
 
 [source]
 kubectl create -f resources/kubernetes/cluster-controller.yaml
@@ -42,7 +42,7 @@ kubectl describe all
 
 ==== Deploying to OpenShift
 
-To deploy the Cluster Controller on OpenShift, following command should be executed:
+To deploy the Cluster Controller on OpenShift, the following command should be executed:
 
 [source]
 oc create -f resources/openshift/cluster-controller-with-template.yaml
@@ -55,7 +55,7 @@ oc describe all
 
 === Kafka broker
 
-Strimzi uses StatefulSets feature to deploy Kafka brokers on Kubernetes/OpenShift.
+Strimzi uses StatefulSets feature of Kubernetes/OpenShift to deploy Kafka brokers.
 With StatefulSets, the pods receive a unique name and network identity and that makes it easier to identify the
 individual Kafka broker pods and set their identity (broker ID). The deployment uses **regular** and **headless**
 services:
@@ -63,7 +63,7 @@ services:
 - regular services can be used as bootstrap servers for Kafka clients
 - headless services are needed to have DNS resolve the pods IP addresses directly
 
-Together with Kafka, Strimzi also installs a Zookeeper cluster and configures the Kafka brokers to connect to it. The
+As well as Kafka, Strimzi also installs a Zookeeper cluster and configures the Kafka brokers to connect to it. The
 Zookeeper cluster also uses StatefulSets.
 
 Strimzi provides two flavors of Kafka broker deployment: **ephemeral** and **persistent**.
@@ -75,7 +75,7 @@ deleted when the pod goes down). This makes the in-memory deployment well-suited
 you don't have to provide persistent volumes.
 
 The **persistent** flavour uses PersistentVolumes to store Zookeeper and Kafka data. The PersistentVolume is
-acquired using a PersistentVolumeClaim – that makes it independent on the actual type of the PersistentVolume. For
+acquired using a PersistentVolumeClaim – that makes it independent of the actual type of the PersistentVolume. For
 example, it can use HostPath volumes on Minikube or Amazon EBS volumes in Amazon AWS deployments without any
 changes in the YAML files. The PersistentVolumeClaim can use a StorageClass to trigger automatic volume provisioning.
 
@@ -90,7 +90,7 @@ Example ConfigMaps and the details about the ConfigMap format are in <<kafka_con
 
 ==== Deploying to Kubernetes
 
-To deploy Kafka broker on Kubernetes, the corresponding ConfigMap has to be created. To create the ephemeral
+To deploy a Kafka broker on Kubernetes, the corresponding ConfigMap has to be created. To create the ephemeral
 cluster using the provided example ConfigMap, the following command should be executed:
 
 [source]
@@ -110,7 +110,7 @@ executed:
 [source]
 oc new-app strimzi-ephemeral
 
-Similarly, to deploy persistent Kafka cluster the following command should be run:
+Similarly, to deploy a persistent Kafka cluster the following command should be run:
 
 [source]
 oc new-app strimzi-persistent
@@ -120,8 +120,8 @@ oc new-app strimzi-persistent
 The Cluster Controller can also deploy a https://kafka.apache.org/documentation/#connect[Kafka Connect] cluster which
 can be used with either of the Kafka broker deployments described above. It is implemented as a Deployment with a
 configurable number of workers. The default image currently contains only the Connectors distributed with Apache Kafka
-Connect -`FileStreamSinkConnector` and `FileStreamSourceConnector`. The REST interface for managing the Kafka Connect
-cluster is exposed internally within the Kubernetes/OpenShift cluster as service `kafka-connect` on port `8083`.
+Connect: `FileStreamSinkConnector` and `FileStreamSourceConnector`. The REST interface for managing the Kafka Connect
+cluster is exposed internally within the Kubernetes/OpenShift cluster as `kafka-connect` service on port `8083`.
 
 Example ConfigMaps and the details about the ConfigMap format for deploying Kafka Connect can be found in
 <<kafka_connect_config_map_details>>.
@@ -137,7 +137,7 @@ kubectl apply -f resources/kubernetes/kafka-connect.yaml
 ==== Deploying to OpenShift
 
 On OpenShift, Kafka Connect is provided in the form of a template. It can be deployed from the template either
-using the command line or using the OpenShift console. To create Kafka Connect cluster from the command line, the following
+using the command line or using the OpenShift console. To create a Kafka Connect cluster from the command line, the following
 command should be run:
 
 [source]
@@ -149,7 +149,7 @@ Strimzi Docker images for Kafka Connect contain, by default, only the `FileStrea
 `FileStreamSourceConnector` connectors which are part of the Apache Kafka project.
 
 To facilitate deployment with 3rd party connectors, Kafka Connect is configured to automatically load all
-plugins/connectors which are present in the `/opt/kafka/plugins` directory during startup. There are two ways how to add
+plugins/connectors which are present in the `/opt/kafka/plugins` directory during startup. There are two ways of adding
 custom plugins into this directory:
 
 - Using a custom Docker image
@@ -170,7 +170,7 @@ COPY ./my-plugin/ /opt/kafka/plugins/
 USER kafka:kafka
 
 2. Build the Docker image and upload it to the appropriate Docker repository
-3. To use the new Docker image in the Kafka Connect deployment,
+3. Use the new Docker image in the Kafka Connect deployment:
   - On OpenShift, the template parameters `IMAGE_REPO_NAME`, `IMAGE_NAME` and `IMAGE_TAG` can be changed to point to the
   new image when the Kafka Connect cluster is being deployed
   - On Kubernetes, the Kafka Connect ConfigMap has to be modified to use the new image
@@ -182,7 +182,7 @@ https://docs.openshift.org/3.6/creating_images/s2i.html#creating-images-s2i[Sour
 new Docker images. OpenShift Build takes a builder image with S2I support together with source code and/or binaries
 provided by the user and uses them to build a new Docker image. The newly created Docker Image will be stored in
 OpenShift's local Docker repository and can then be used in deployments. The Strimzi project provides a Kafka Connect builder
-image https://hub.docker.com/r/strimzi/kafka-connect-s2i/[`strimzi/kafka-connect-s2i`] with S2I support. It takes user-provided
+image https://hub.docker.com/r/strimzi/kafka-connect-s2i/[`strimzi/kafka-connect-s2i`] with such S2I support. It takes user-provided
 binaries (with plugins and connectors) and creates a new Kafka Connect image. This enhanced Kafka Connect image can be
 used with our Kafka Connect deployment.
 

--- a/documentation/topic-controller.adoc
+++ b/documentation/topic-controller.adoc
@@ -1,4 +1,4 @@
-= Topic Controller
+== Topic Controller
 
 The role of the topic controller is to keep in-sync a set of K8s ConfigMaps describing Kafka topics, 
 and those Kafka topics. 
@@ -25,7 +25,7 @@ Should the topic be reconfigured, reassigned to different Kafka nodes etc,
 the ConfigMap will always be up to date.
 
 
-== Reconciliation
+=== Reconciliation
 
 A fundamental problem that the controller has to solve is that there is no 
 single source of truth: 
@@ -60,7 +60,7 @@ then Kafka itself cannot run, so the controller will be no less available
 than it would even if it was stateless. 
 
 
-== Usage Recommendations
+=== Usage Recommendations
 
 . Try to either always operate on ConfigMaps or always operate directly on topics.
 . When creating a ConfigMap:
@@ -75,7 +75,7 @@ than it would even if it was stateless.
       the corresponding ConfigMap.
 
     
-== Format of the ConfigMap
+=== Format of the ConfigMap
 
 By default, the controller only considers ConfigMaps having the label `strimzi.io/kind=topic`, 
 but this is configurable via the `STRIMZI_CONFIGMAP_LABELS` environment variable.
@@ -88,7 +88,7 @@ The `data` of such ConfigMaps supports the following keys:
 * `config` A string in JSON format representing the https://kafka.apache.org/documentation/#topicconfigs[topic configuration]. Optional, defaulting to the empty set.
  
 
-== Example
+=== Example
 
 Suppose you want to create a topic called "orders" with 10 partitions and 2 replicas. 
 
@@ -151,7 +151,7 @@ And use `oc update -f` or `kubectl update -f` to up update the ConfigMap
 in OpenShift/Kubernetes.
 
 
-== Unsupported operations
+=== Unsupported operations
 
 * You can't change the `data.name` key in a ConfigMap, because Kafka doesn't support changing topic names.
 * You can't decrease the `data.partitions`, because Kafka doesn't support this.
@@ -159,7 +159,7 @@ in OpenShift/Kubernetes.
   how records are partitioned. 
 
     
-== Controller environment
+=== Controller environment
 
 The controller is configured from environment variables:
 


### PR DESCRIPTION
### Type of change

- ~~Bugfix~~
- Enhancement / new feature

### Description

Add new section _Getting started_ to the documentation. This pretty much covers the content from the README.md file. Only the guide how to get started with minikube / minishift has been moved to appendix. The text has been also restructured to use the passive form.

Additionally, it adds top level document which includes all the subparts to create a single documentation.

The is still a lot of work remaining - such as changing the controller docu to passive mode, add build system to generate HTML docu etc. These should be done in separate PRs.
