### PR TITLE
Fixed typo, Javadoc and if statement simplified

### DIFF
--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperations.java
@@ -68,6 +68,7 @@ public class KafkaClusterOperations extends AbstractClusterOperations<KafkaClust
         this.endpointOperations = endpointOperations;
     }
 
+    @Override
     public void create(String namespace, String name, Handler<AsyncResult<Void>> handler) {
         execute(CLUSTER_TYPE_ZOOKEEPER, OP_CREATE, namespace, name, createZk, ar -> {
             if (ar.failed()) {

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectS2IClusterOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectS2IClusterOperations.java
@@ -67,6 +67,7 @@ public class KafkaConnectS2IClusterOperations extends AbstractClusterOperations<
         this.buildConfigOperations = buildConfigOperations;
     }
 
+    @Override
     public void create(String namespace, String name, Handler<AsyncResult<Void>> handler) {
         if (isOpenShift) {
             execute(CLUSTER_TYPE, OP_CREATE, namespace, name, create, handler);
@@ -128,6 +129,7 @@ public class KafkaConnectS2IClusterOperations extends AbstractClusterOperations<
         }
     };
 
+    @Override
     public void update(String namespace, String name, Handler<AsyncResult<Void>> handler) {
         if (isOpenShift) {
             execute(CLUSTER_TYPE, OP_UPDATE, namespace, name, update, handler);
@@ -259,6 +261,7 @@ public class KafkaConnectS2IClusterOperations extends AbstractClusterOperations<
         reconcile(namespace, labels, CLUSTER_TYPE);
     }
 
+    @Override
     protected List<DeploymentConfig> getResources(String namespace, Map<String, String> kafkaLabels) {
         return deploymentConfigOperations.list(namespace, kafkaLabels);
     }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/resource/AbstractOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/resource/AbstractOperations.java
@@ -116,7 +116,7 @@ public abstract class AbstractOperations<C, T extends HasMetadata, L extends Kub
     /**
      * Asynchronously patch the resource with the given {@code name} in the given {@code namespace}
      * to reflect the state given in the {@code patch}, returning a future for the outcome.
-     * The patch cascades to related resources
+     * The patch cascades to related resources.
      * @param namespace The namespace of the resource to patch.
      * @param name The name of the resource to patch.
      * @param patch The desired state of the resource.
@@ -130,7 +130,7 @@ public abstract class AbstractOperations<C, T extends HasMetadata, L extends Kub
      * to reflect the state given in the {@code patch}, returning a future for the outcome.
      * @param namespace The namespace of the resource to patch.
      * @param name The name of the resource to patch.
-     * @param cascading If the patch applies to the related resource in cascade
+     * @param cascading If the patch applies to the related resource in cascade.
      * @param patch The desired state of the resource.
      */
     public Future<Void> patch(String namespace, String name, boolean cascading, T patch) {
@@ -223,7 +223,7 @@ public abstract class AbstractOperations<C, T extends HasMetadata, L extends Kub
     }
 
     /**
-     * Check if a resource is in the Ready state
+     * Check if a resource is in the Ready state.
      *
      * @param namespace The namespace.
      * @param name The resource name.

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/resource/AbstractOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/resource/AbstractOperations.java
@@ -116,14 +116,23 @@ public abstract class AbstractOperations<C, T extends HasMetadata, L extends Kub
     /**
      * Asynchronously patch the resource with the given {@code name} in the given {@code namespace}
      * with reflect the state given in the {@code patch}, returning a future for the outcome.
+     * The patch is applied to the related resource in cascade as well.
      * @param namespace The namespace of the resource to patch.
      * @param name The name of the resource to patch.
-     * @param patch The desired state of the resource..
+     * @param patch The desired state of the resource.
      */
     public Future<Void> patch(String namespace, String name, T patch) {
         return patch(namespace, name, true, patch);
     }
 
+    /**
+     * Asynchronously patch the resource with the given {@code name} in the given {@code namespace}
+     * with reflect the state given in the {@code patch}, returning a future for the outcome.
+     * @param namespace The namespace of the resource to patch.
+     * @param name  The name of the resource to patch.
+     * @param cascading If the patch applies to the related resource in cascade
+     * @param patch The desired state of the resource.
+     */
     public Future<Void> patch(String namespace, String name, boolean cascading, T patch) {
         Future<Void> fut = Future.future();
         vertx.createSharedWorkerExecutor("kubernetes-ops-pool").executeBlocking(

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/resource/AbstractOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/resource/AbstractOperations.java
@@ -115,8 +115,8 @@ public abstract class AbstractOperations<C, T extends HasMetadata, L extends Kub
 
     /**
      * Asynchronously patch the resource with the given {@code name} in the given {@code namespace}
-     * with reflect the state given in the {@code patch}, returning a future for the outcome.
-     * The patch is applied to the related resource in cascade as well.
+     * to reflect the state given in the {@code patch}, returning a future for the outcome.
+     * The patch cascades to related resources
      * @param namespace The namespace of the resource to patch.
      * @param name The name of the resource to patch.
      * @param patch The desired state of the resource.
@@ -127,9 +127,9 @@ public abstract class AbstractOperations<C, T extends HasMetadata, L extends Kub
 
     /**
      * Asynchronously patch the resource with the given {@code name} in the given {@code namespace}
-     * with reflect the state given in the {@code patch}, returning a future for the outcome.
+     * to reflect the state given in the {@code patch}, returning a future for the outcome.
      * @param namespace The namespace of the resource to patch.
-     * @param name  The name of the resource to patch.
+     * @param name The name of the resource to patch.
      * @param cascading If the patch applies to the related resource in cascade
      * @param patch The desired state of the resource.
      */
@@ -226,8 +226,7 @@ public abstract class AbstractOperations<C, T extends HasMetadata, L extends Kub
      * Check if a resource is in the Ready state
      *
      * @param namespace The namespace.
-     * @param name  The resource name.
-     * @return  if it's in the Ready state
+     * @param name The resource name.
      */
     public boolean isReady(String namespace, String name) {
         R resourceOp = operation().inNamespace(namespace).withName(name);

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/resource/PodOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/resource/PodOperations.java
@@ -37,7 +37,7 @@ public class PodOperations extends AbstractOperations<KubernetesClient, Pod, Pod
      * Returns whether the pod given by {@code namespace} and {@code name} is ready
      * @param namespace The namespace.
      * @param name The name.
-     * @return True iff the pod is ready.
+     * @return True if the pod is ready.
      */
     public boolean isPodReady(String namespace, String name) {
         return operation().inNamespace(namespace).withName(name).isReady();


### PR DESCRIPTION
Fixed typo on pollIntervalMs parameter
Added Javadoc to isReady method
Simplified if statement in the isReady method

### Type of change

- Enhancement / new feature

### Description

This PR just fixes a typo, adds Javadoc and simplifies an if statement in the `isReady` method.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [x] Check coding style
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging

