### PR TITLE
Removed isOpenShift unused parameter

### DIFF
--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectClusterOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectClusterOperations.java
@@ -53,7 +53,7 @@ public class KafkaConnectClusterOperations extends AbstractClusterOperations<Kaf
 
         @Override
         public ClusterOperation<KafkaConnectCluster> getCluster(String namespace, String name) {
-            return new ClusterOperation<>(KafkaConnectCluster.fromConfigMap(isOpenShift, configMapOperations.get(namespace, name)), null);
+            return new ClusterOperation<>(KafkaConnectCluster.fromConfigMap(configMapOperations.get(namespace, name)), null);
         }
 
         @Override
@@ -113,7 +113,7 @@ public class KafkaConnectClusterOperations extends AbstractClusterOperations<Kaf
             ConfigMap connectConfigMap = configMapOperations.get(namespace, name);
 
             if (connectConfigMap != null)    {
-                connect = KafkaConnectCluster.fromConfigMap(isOpenShift, connectConfigMap);
+                connect = KafkaConnectCluster.fromConfigMap(connectConfigMap);
                 Deployment dep = deploymentOperations.get(namespace, connect.getName());
                 log.info("Updating Kafka Connect cluster {} in namespace {}", connect.getName(), namespace);
                 diff = connect.diff(dep);

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectS2IClusterOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectS2IClusterOperations.java
@@ -74,7 +74,7 @@ public class KafkaConnectS2IClusterOperations extends AbstractClusterOperations<
 
         @Override
         public ClusterOperation<KafkaConnectS2ICluster> getCluster(String namespace, String name) {
-            return new ClusterOperation<>(KafkaConnectS2ICluster.fromConfigMap(isOpenShift, configMapOperations.get(namespace, name)), null);
+            return new ClusterOperation<>(KafkaConnectS2ICluster.fromConfigMap(configMapOperations.get(namespace, name)), null);
         }
 
         @Override
@@ -158,7 +158,7 @@ public class KafkaConnectS2IClusterOperations extends AbstractClusterOperations<
             ConfigMap connectConfigMap = configMapOperations.get(namespace, name);
 
             if (connectConfigMap != null)    {
-                connect = KafkaConnectS2ICluster.fromConfigMap(isOpenShift, connectConfigMap);
+                connect = KafkaConnectS2ICluster.fromConfigMap(connectConfigMap);
                 log.info("Updating {} cluster {} in namespace {}", clusterDescription, connect.getName(), namespace);
                 DeploymentConfig dep = deploymentConfigOperations.get(namespace, connect.getName());
                 ImageStream sis = imagesStreamOperations.get(namespace, connect.getSourceImageStreamName());

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/KafkaConnectCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/KafkaConnectCluster.java
@@ -94,11 +94,10 @@ public class KafkaConnectCluster extends AbstractCluster {
     /**
      * Create a Kafka Connect cluster from the related ConfigMap resource
      *
-     * @param isOpenShift    Whether we're running with OpenShift
-     * @param cm    ConfigMap with cluster configuration
-     * @return  Kafka Connect cluster instance
+     * @param cm ConfigMap with cluster configuration
+     * @return Kafka Connect cluster instance
      */
-    public static KafkaConnectCluster fromConfigMap(boolean isOpenShift, ConfigMap cm) {
+    public static KafkaConnectCluster fromConfigMap(ConfigMap cm) {
         KafkaConnectCluster kafkaConnect = new KafkaConnectCluster(cm.getMetadata().getNamespace(), cm.getMetadata().getName());
 
         kafkaConnect.setLabels(cm.getMetadata().getLabels());

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/KafkaConnectS2ICluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/KafkaConnectS2ICluster.java
@@ -53,11 +53,10 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
     /**
      * Create a Kafka Connect cluster from the related ConfigMap resource
      *
-     * @param isOpenShift    Whether we're running with OpenShift
-     * @param cm    ConfigMap with cluster configuration
-     * @return  Kafka Connect cluster instance
+     * @param cm ConfigMap with cluster configuration
+     * @return Kafka Connect cluster instance
      */
-    public static KafkaConnectS2ICluster fromConfigMap(boolean isOpenShift, ConfigMap cm) {
+    public static KafkaConnectS2ICluster fromConfigMap(ConfigMap cm) {
         KafkaConnectS2ICluster kafkaConnect = new KafkaConnectS2ICluster(cm.getMetadata().getNamespace(), cm.getMetadata().getName());
 
         kafkaConnect.setLabels(cm.getMetadata().getLabels());

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectClusterOperationsTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectClusterOperationsTest.java
@@ -64,7 +64,7 @@ public class KafkaConnectClusterOperationsTest {
         KafkaConnectClusterOperations ops = new KafkaConnectClusterOperations(vertx, true,
                 mockCmOps, mockDcOps, mockServiceOps);
 
-        KafkaConnectCluster connect = KafkaConnectCluster.fromConfigMap(true, clusterCm);
+        KafkaConnectCluster connect = KafkaConnectCluster.fromConfigMap(clusterCm);
 
         Async async = context.async();
         ops.create(clusterCmNamespace, clusterCmName, createResult -> {
@@ -98,7 +98,7 @@ public class KafkaConnectClusterOperationsTest {
         String clusterCmNamespace = "test";
 
         ConfigMap clusterCm = ResourceUtils.createEmptyKafkaConnectClusterConfigMap(clusterCmNamespace, clusterCmName);
-        KafkaConnectCluster connect = KafkaConnectCluster.fromConfigMap(true, clusterCm);
+        KafkaConnectCluster connect = KafkaConnectCluster.fromConfigMap(clusterCm);
         when(mockCmOps.get(clusterCmNamespace, clusterCmName)).thenReturn(clusterCm);
         when(mockServiceOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateService());
         when(mockDcOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateDeployment());
@@ -156,7 +156,7 @@ public class KafkaConnectClusterOperationsTest {
         String clusterCmNamespace = "test";
 
         ConfigMap clusterCm = ResourceUtils.createEmptyKafkaConnectClusterConfigMap(clusterCmNamespace, clusterCmName);
-        KafkaConnectCluster connect = KafkaConnectCluster.fromConfigMap(true, clusterCm);
+        KafkaConnectCluster connect = KafkaConnectCluster.fromConfigMap(clusterCm);
         clusterCm.getData().put("image", "some/different:image"); // Change the image to generate some diff
 
         when(mockCmOps.get(clusterCmNamespace, clusterCmName)).thenReturn(clusterCm);
@@ -190,7 +190,7 @@ public class KafkaConnectClusterOperationsTest {
         ops.update(clusterCmNamespace, clusterCmName, createResult -> {
             context.assertTrue(createResult.succeeded());
 
-            KafkaConnectCluster compareTo = KafkaConnectCluster.fromConfigMap(true, clusterCm);
+            KafkaConnectCluster compareTo = KafkaConnectCluster.fromConfigMap(clusterCm);
 
             // Vertify service
             List<Service> capturedServices = serviceCaptor.getAllValues();
@@ -224,7 +224,7 @@ public class KafkaConnectClusterOperationsTest {
         String clusterCmNamespace = "test";
 
         ConfigMap clusterCm = ResourceUtils.createEmptyKafkaConnectClusterConfigMap(clusterCmNamespace, clusterCmName);
-        KafkaConnectCluster connect = KafkaConnectCluster.fromConfigMap(true, clusterCm);
+        KafkaConnectCluster connect = KafkaConnectCluster.fromConfigMap(clusterCm);
         clusterCm.getData().put("image", "some/different:image"); // Change the image to generate some diff
 
         when(mockCmOps.get(clusterCmNamespace, clusterCmName)).thenReturn(clusterCm);
@@ -274,7 +274,7 @@ public class KafkaConnectClusterOperationsTest {
         String clusterCmNamespace = "test";
 
         ConfigMap clusterCm = ResourceUtils.createEmptyKafkaConnectClusterConfigMap(clusterCmNamespace, clusterCmName);
-        KafkaConnectCluster connect = KafkaConnectCluster.fromConfigMap(true, clusterCm);
+        KafkaConnectCluster connect = KafkaConnectCluster.fromConfigMap(clusterCm);
         clusterCm.getData().put(KafkaConnectCluster.KEY_REPLICAS, newReplicas); // Change replicas to create ScaleUp
 
         when(mockCmOps.get(clusterCmNamespace, clusterCmName)).thenReturn(clusterCm);
@@ -341,7 +341,7 @@ public class KafkaConnectClusterOperationsTest {
         String clusterCmNamespace = "test";
 
         ConfigMap clusterCm = ResourceUtils.createEmptyKafkaConnectClusterConfigMap(clusterCmNamespace, clusterCmName);
-        KafkaConnectCluster connect = KafkaConnectCluster.fromConfigMap(true, clusterCm);
+        KafkaConnectCluster connect = KafkaConnectCluster.fromConfigMap(clusterCm);
         clusterCm.getData().put(KafkaConnectCluster.KEY_REPLICAS, newReplicas); // Change replicas to create ScaleDown
 
         when(mockCmOps.get(clusterCmNamespace, clusterCmName)).thenReturn(clusterCm);
@@ -405,7 +405,7 @@ public class KafkaConnectClusterOperationsTest {
         String clusterCmName = "foo";
         String clusterCmNamespace = "test";
 
-        KafkaConnectCluster connect = KafkaConnectCluster.fromConfigMap(true, ResourceUtils.createEmptyKafkaConnectClusterConfigMap(clusterCmNamespace, clusterCmName));
+        KafkaConnectCluster connect = KafkaConnectCluster.fromConfigMap(ResourceUtils.createEmptyKafkaConnectClusterConfigMap(clusterCmNamespace, clusterCmName));
 
         when(mockDcOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateDeployment());
 

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectS2IClusterOperationsTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectS2IClusterOperationsTest.java
@@ -77,7 +77,7 @@ public class KafkaConnectS2IClusterOperationsTest {
         KafkaConnectS2IClusterOperations ops = new KafkaConnectS2IClusterOperations(vertx, true,
                 mockCmOps, mockDcOps, mockServiceOps, mockIsOps, mockBcOps);
 
-        KafkaConnectS2ICluster connect = KafkaConnectS2ICluster.fromConfigMap(true, clusterCm);
+        KafkaConnectS2ICluster connect = KafkaConnectS2ICluster.fromConfigMap(clusterCm);
 
         Async async = context.async();
         ops.create(clusterCmNamespace, clusterCmName, createResult -> {
@@ -134,7 +134,7 @@ public class KafkaConnectS2IClusterOperationsTest {
         String clusterCmNamespace = "test";
 
         ConfigMap clusterCm = ResourceUtils.createEmptyKafkaConnectS2IClusterConfigMap(clusterCmNamespace, clusterCmName);
-        KafkaConnectS2ICluster connect = KafkaConnectS2ICluster.fromConfigMap(true, clusterCm);
+        KafkaConnectS2ICluster connect = KafkaConnectS2ICluster.fromConfigMap(clusterCm);
         when(mockCmOps.get(clusterCmNamespace, clusterCmName)).thenReturn(clusterCm);
         when(mockServiceOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateService());
         when(mockDcOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateDeploymentConfig());
@@ -215,7 +215,7 @@ public class KafkaConnectS2IClusterOperationsTest {
         String clusterCmNamespace = "test";
 
         ConfigMap clusterCm = ResourceUtils.createEmptyKafkaConnectS2IClusterConfigMap(clusterCmNamespace, clusterCmName);
-        KafkaConnectS2ICluster connect = KafkaConnectS2ICluster.fromConfigMap(true, clusterCm);
+        KafkaConnectS2ICluster connect = KafkaConnectS2ICluster.fromConfigMap(clusterCm);
         clusterCm.getData().put("image", "some/different:image"); // Change the image to generate some diff
 
         when(mockCmOps.get(clusterCmNamespace, clusterCmName)).thenReturn(clusterCm);
@@ -262,7 +262,7 @@ public class KafkaConnectS2IClusterOperationsTest {
         ops.update(clusterCmNamespace, clusterCmName, createResult -> {
             context.assertTrue(createResult.succeeded());
 
-            KafkaConnectS2ICluster compareTo = KafkaConnectS2ICluster.fromConfigMap(true, clusterCm);
+            KafkaConnectS2ICluster compareTo = KafkaConnectS2ICluster.fromConfigMap(clusterCm);
 
             // Vertify service
             List<Service> capturedServices = serviceCaptor.getAllValues();
@@ -319,7 +319,7 @@ public class KafkaConnectS2IClusterOperationsTest {
         String clusterCmNamespace = "test";
 
         ConfigMap clusterCm = ResourceUtils.createEmptyKafkaConnectS2IClusterConfigMap(clusterCmNamespace, clusterCmName);
-        KafkaConnectS2ICluster connect = KafkaConnectS2ICluster.fromConfigMap(true, clusterCm);
+        KafkaConnectS2ICluster connect = KafkaConnectS2ICluster.fromConfigMap(clusterCm);
         clusterCm.getData().put("image", "some/different:image"); // Change the image to generate some diff
 
         when(mockCmOps.get(clusterCmNamespace, clusterCmName)).thenReturn(clusterCm);
@@ -384,7 +384,7 @@ public class KafkaConnectS2IClusterOperationsTest {
         String clusterCmNamespace = "test";
 
         ConfigMap clusterCm = ResourceUtils.createEmptyKafkaConnectS2IClusterConfigMap(clusterCmNamespace, clusterCmName);
-        KafkaConnectS2ICluster connect = KafkaConnectS2ICluster.fromConfigMap(true, clusterCm);
+        KafkaConnectS2ICluster connect = KafkaConnectS2ICluster.fromConfigMap(clusterCm);
         clusterCm.getData().put(KafkaConnectCluster.KEY_REPLICAS, newReplicas); // Change replicas to create ScaleUp
 
         when(mockCmOps.get(clusterCmNamespace, clusterCmName)).thenReturn(clusterCm);
@@ -474,7 +474,7 @@ public class KafkaConnectS2IClusterOperationsTest {
         String clusterCmNamespace = "test";
 
         ConfigMap clusterCm = ResourceUtils.createEmptyKafkaConnectS2IClusterConfigMap(clusterCmNamespace, clusterCmName);
-        KafkaConnectS2ICluster connect = KafkaConnectS2ICluster.fromConfigMap(true, clusterCm);
+        KafkaConnectS2ICluster connect = KafkaConnectS2ICluster.fromConfigMap(clusterCm);
         clusterCm.getData().put(KafkaConnectCluster.KEY_REPLICAS, newReplicas); // Change replicas to create ScaleDown
 
         when(mockCmOps.get(clusterCmNamespace, clusterCmName)).thenReturn(clusterCm);
@@ -561,7 +561,7 @@ public class KafkaConnectS2IClusterOperationsTest {
         String clusterCmName = "foo";
         String clusterCmNamespace = "test";
 
-        KafkaConnectS2ICluster connect = KafkaConnectS2ICluster.fromConfigMap(true, ResourceUtils.createEmptyKafkaConnectS2IClusterConfigMap(clusterCmNamespace, clusterCmName));
+        KafkaConnectS2ICluster connect = KafkaConnectS2ICluster.fromConfigMap(ResourceUtils.createEmptyKafkaConnectS2IClusterConfigMap(clusterCmNamespace, clusterCmName));
 
         when(mockDcOps.get(clusterCmNamespace, connect.getName())).thenReturn(connect.generateDeploymentConfig());
         when(mockIsOps.get(clusterCmNamespace, connect.getSourceImageStreamName())).thenReturn(connect.generateSourceImageStream());

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/resources/KafkaConnectClusterTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/resources/KafkaConnectClusterTest.java
@@ -42,7 +42,7 @@ public class KafkaConnectClusterTest {
     private final ConfigMap cm = ResourceUtils.createKafkaConnectClusterConfigMap(namespace, cluster, replicas, image,
             healthDelay, healthTimeout, bootstrapServers, groupID, configReplicationFactor, offsetReplicationFactor,
             statusReplicationFactor, keyConverter, valueConverter, keyConverterSchemas, valuesConverterSchema);
-    private final KafkaConnectCluster kc = KafkaConnectCluster.fromConfigMap(true, cm);
+    private final KafkaConnectCluster kc = KafkaConnectCluster.fromConfigMap(cm);
 
     protected List<EnvVar> getExpectedEnvVars() {
         List<EnvVar> expected = new ArrayList<EnvVar>();
@@ -61,7 +61,7 @@ public class KafkaConnectClusterTest {
 
     @Test
     public void testDefaultValues() {
-        KafkaConnectCluster kc = KafkaConnectCluster.fromConfigMap(true, ResourceUtils.createEmptyKafkaConnectClusterConfigMap(namespace, cluster));
+        KafkaConnectCluster kc = KafkaConnectCluster.fromConfigMap(ResourceUtils.createEmptyKafkaConnectClusterConfigMap(namespace, cluster));
 
         assertEquals(KafkaConnectCluster.DEFAULT_IMAGE, kc.image);
         assertEquals(KafkaConnectCluster.DEFAULT_REPLICAS, kc.replicas);
@@ -116,7 +116,7 @@ public class KafkaConnectClusterTest {
 
     @Test
     public void testFromDeploymentWithDefaultValues() {
-        KafkaConnectCluster defaultsKc = KafkaConnectCluster.fromConfigMap(true, ResourceUtils.createEmptyKafkaConnectClusterConfigMap(namespace, cluster));
+        KafkaConnectCluster defaultsKc = KafkaConnectCluster.fromConfigMap(ResourceUtils.createEmptyKafkaConnectClusterConfigMap(namespace, cluster));
         KafkaConnectCluster newKc = KafkaConnectCluster.fromDeployment(namespace, cluster, defaultsKc.generateDeployment());
 
         assertEquals(KafkaConnectCluster.DEFAULT_REPLICAS, newKc.replicas);
@@ -190,7 +190,7 @@ public class KafkaConnectClusterTest {
         KafkaConnectCluster newKc;
         ClusterDiffResult diff;
 
-        newKc = KafkaConnectCluster.fromConfigMap(true, ResourceUtils.createKafkaConnectClusterConfigMap(namespace, cluster, replicas, image,
+        newKc = KafkaConnectCluster.fromConfigMap(ResourceUtils.createKafkaConnectClusterConfigMap(namespace, cluster, replicas, image,
                 123, healthTimeout, bootstrapServers, groupID, configReplicationFactor, offsetReplicationFactor,
                 statusReplicationFactor, keyConverter, valueConverter, keyConverterSchemas, valuesConverterSchema));
         diff = kc.diff(newKc.generateDeployment());
@@ -200,7 +200,7 @@ public class KafkaConnectClusterTest {
         assertTrue(diff.isRollingUpdate());
         assertFalse(diff.isMetricsChanged());
 
-        newKc = KafkaConnectCluster.fromConfigMap(true, ResourceUtils.createKafkaConnectClusterConfigMap(namespace, cluster, replicas, image,
+        newKc = KafkaConnectCluster.fromConfigMap(ResourceUtils.createKafkaConnectClusterConfigMap(namespace, cluster, replicas, image,
                 healthDelay, 123, bootstrapServers, groupID, configReplicationFactor, offsetReplicationFactor,
                 statusReplicationFactor, keyConverter, valueConverter, keyConverterSchemas, valuesConverterSchema));
         diff = kc.diff(newKc.generateDeployment());
@@ -210,7 +210,7 @@ public class KafkaConnectClusterTest {
         assertTrue(diff.isRollingUpdate());
         assertFalse(diff.isMetricsChanged());
 
-        newKc = KafkaConnectCluster.fromConfigMap(true, ResourceUtils.createKafkaConnectClusterConfigMap(namespace, cluster, replicas, image,
+        newKc = KafkaConnectCluster.fromConfigMap(ResourceUtils.createKafkaConnectClusterConfigMap(namespace, cluster, replicas, image,
                 healthDelay, healthTimeout, "some-kafka-broker:9092", groupID, configReplicationFactor, offsetReplicationFactor,
                 statusReplicationFactor, keyConverter, valueConverter, keyConverterSchemas, valuesConverterSchema));
         diff = kc.diff(newKc.generateDeployment());
@@ -220,7 +220,7 @@ public class KafkaConnectClusterTest {
         assertTrue(diff.isRollingUpdate());
         assertFalse(diff.isMetricsChanged());
 
-        newKc = KafkaConnectCluster.fromConfigMap(true, ResourceUtils.createKafkaConnectClusterConfigMap(namespace, cluster, replicas, image,
+        newKc = KafkaConnectCluster.fromConfigMap(ResourceUtils.createKafkaConnectClusterConfigMap(namespace, cluster, replicas, image,
                 healthDelay, healthTimeout, bootstrapServers, "some-other-group-id", configReplicationFactor, offsetReplicationFactor,
                 statusReplicationFactor, keyConverter, valueConverter, keyConverterSchemas, valuesConverterSchema));
         diff = kc.diff(newKc.generateDeployment());
@@ -230,7 +230,7 @@ public class KafkaConnectClusterTest {
         assertTrue(diff.isRollingUpdate());
         assertFalse(diff.isMetricsChanged());
 
-        newKc = KafkaConnectCluster.fromConfigMap(true, ResourceUtils.createKafkaConnectClusterConfigMap(namespace, cluster, replicas, image,
+        newKc = KafkaConnectCluster.fromConfigMap(ResourceUtils.createKafkaConnectClusterConfigMap(namespace, cluster, replicas, image,
                 healthDelay, healthTimeout, bootstrapServers, groupID, 5, offsetReplicationFactor,
                 statusReplicationFactor, keyConverter, valueConverter, keyConverterSchemas, valuesConverterSchema));
         diff = kc.diff(newKc.generateDeployment());
@@ -240,7 +240,7 @@ public class KafkaConnectClusterTest {
         assertTrue(diff.isRollingUpdate());
         assertFalse(diff.isMetricsChanged());
 
-        newKc = KafkaConnectCluster.fromConfigMap(true, ResourceUtils.createKafkaConnectClusterConfigMap(namespace, cluster, replicas, image,
+        newKc = KafkaConnectCluster.fromConfigMap(ResourceUtils.createKafkaConnectClusterConfigMap(namespace, cluster, replicas, image,
                 healthDelay, healthTimeout, bootstrapServers, groupID, configReplicationFactor, 5,
                 statusReplicationFactor, keyConverter, valueConverter, keyConverterSchemas, valuesConverterSchema));
         diff = kc.diff(newKc.generateDeployment());
@@ -250,7 +250,7 @@ public class KafkaConnectClusterTest {
         assertTrue(diff.isRollingUpdate());
         assertFalse(diff.isMetricsChanged());
 
-        newKc = KafkaConnectCluster.fromConfigMap(true, ResourceUtils.createKafkaConnectClusterConfigMap(namespace, cluster, replicas, image,
+        newKc = KafkaConnectCluster.fromConfigMap(ResourceUtils.createKafkaConnectClusterConfigMap(namespace, cluster, replicas, image,
                 healthDelay, healthTimeout, bootstrapServers, groupID, configReplicationFactor, offsetReplicationFactor,
                 5, keyConverter, valueConverter, keyConverterSchemas, valuesConverterSchema));
         diff = kc.diff(newKc.generateDeployment());
@@ -260,7 +260,7 @@ public class KafkaConnectClusterTest {
         assertTrue(diff.isRollingUpdate());
         assertFalse(diff.isMetricsChanged());
 
-        newKc = KafkaConnectCluster.fromConfigMap(true, ResourceUtils.createKafkaConnectClusterConfigMap(namespace, cluster, replicas, image,
+        newKc = KafkaConnectCluster.fromConfigMap(ResourceUtils.createKafkaConnectClusterConfigMap(namespace, cluster, replicas, image,
                 healthDelay, healthTimeout, bootstrapServers, groupID, configReplicationFactor, offsetReplicationFactor,
                 statusReplicationFactor, "some-other-converter", valueConverter, keyConverterSchemas, valuesConverterSchema));
         diff = kc.diff(newKc.generateDeployment());
@@ -270,7 +270,7 @@ public class KafkaConnectClusterTest {
         assertTrue(diff.isRollingUpdate());
         assertFalse(diff.isMetricsChanged());
 
-        newKc = KafkaConnectCluster.fromConfigMap(true, ResourceUtils.createKafkaConnectClusterConfigMap(namespace, cluster, replicas, image,
+        newKc = KafkaConnectCluster.fromConfigMap(ResourceUtils.createKafkaConnectClusterConfigMap(namespace, cluster, replicas, image,
                 healthDelay, healthTimeout, bootstrapServers, groupID, configReplicationFactor, offsetReplicationFactor,
                 statusReplicationFactor, keyConverter, "some-other-converter", keyConverterSchemas, valuesConverterSchema));
         diff = kc.diff(newKc.generateDeployment());
@@ -280,7 +280,7 @@ public class KafkaConnectClusterTest {
         assertTrue(diff.isRollingUpdate());
         assertFalse(diff.isMetricsChanged());
 
-        newKc = KafkaConnectCluster.fromConfigMap(true, ResourceUtils.createKafkaConnectClusterConfigMap(namespace, cluster, replicas, image,
+        newKc = KafkaConnectCluster.fromConfigMap(ResourceUtils.createKafkaConnectClusterConfigMap(namespace, cluster, replicas, image,
                 healthDelay, healthTimeout, bootstrapServers, groupID, configReplicationFactor, offsetReplicationFactor,
                 statusReplicationFactor, keyConverter, valueConverter, true, valuesConverterSchema));
         diff = kc.diff(newKc.generateDeployment());
@@ -290,7 +290,7 @@ public class KafkaConnectClusterTest {
         assertTrue(diff.isRollingUpdate());
         assertFalse(diff.isMetricsChanged());
 
-        newKc = KafkaConnectCluster.fromConfigMap(true, ResourceUtils.createKafkaConnectClusterConfigMap(namespace, cluster, replicas, image,
+        newKc = KafkaConnectCluster.fromConfigMap(ResourceUtils.createKafkaConnectClusterConfigMap(namespace, cluster, replicas, image,
                 healthDelay, healthTimeout, bootstrapServers, groupID, configReplicationFactor, offsetReplicationFactor,
                 statusReplicationFactor, keyConverter, valueConverter, keyConverterSchemas, true));
         diff = kc.diff(newKc.generateDeployment());
@@ -363,7 +363,7 @@ public class KafkaConnectClusterTest {
 
     @Test
     public void testPatchDeployment()   {
-        Deployment orig = KafkaConnectCluster.fromConfigMap(true, ResourceUtils.createEmptyKafkaConnectClusterConfigMap(namespace, cluster)).generateDeployment();
+        Deployment orig = KafkaConnectCluster.fromConfigMap(ResourceUtils.createEmptyKafkaConnectClusterConfigMap(namespace, cluster)).generateDeployment();
         orig.getMetadata().setLabels(Collections.EMPTY_MAP);
         orig.getSpec().getTemplate().getMetadata().setLabels(Collections.EMPTY_MAP);
 

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/resources/KafkaConnectS2IClusterTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/resources/KafkaConnectS2IClusterTest.java
@@ -52,7 +52,7 @@ public class KafkaConnectS2IClusterTest {
     private final ConfigMap cm = ResourceUtils.createKafkaConnectS2IClusterConfigMap(namespace, cluster, replicas, image,
             healthDelay, healthTimeout, bootstrapServers, groupID, configReplicationFactor, offsetReplicationFactor,
             statusReplicationFactor, keyConverter, valueConverter, keyConverterSchemas, valuesConverterSchema);
-    private final KafkaConnectS2ICluster kc = KafkaConnectS2ICluster.fromConfigMap(true, cm);
+    private final KafkaConnectS2ICluster kc = KafkaConnectS2ICluster.fromConfigMap(cm);
 
     protected List<EnvVar> getExpectedEnvVars() {
         List<EnvVar> expected = new ArrayList<EnvVar>();
@@ -71,7 +71,7 @@ public class KafkaConnectS2IClusterTest {
 
     @Test
     public void testDefaultValues() {
-        KafkaConnectS2ICluster kc = KafkaConnectS2ICluster.fromConfigMap(true, ResourceUtils.createEmptyKafkaConnectS2IClusterConfigMap(namespace, cluster));
+        KafkaConnectS2ICluster kc = KafkaConnectS2ICluster.fromConfigMap(ResourceUtils.createEmptyKafkaConnectS2IClusterConfigMap(namespace, cluster));
 
         assertEquals(kc.kafkaConnectClusterName(cluster) + ":latest", kc.image);
         assertEquals(KafkaConnectS2ICluster.DEFAULT_REPLICAS, kc.replicas);
@@ -129,7 +129,7 @@ public class KafkaConnectS2IClusterTest {
 
     @Test
     public void testFromDeploymentWithDefaultValues() {
-        KafkaConnectS2ICluster defaultsKc = KafkaConnectS2ICluster.fromConfigMap(true, ResourceUtils.createEmptyKafkaConnectS2IClusterConfigMap(namespace, cluster));
+        KafkaConnectS2ICluster defaultsKc = KafkaConnectS2ICluster.fromConfigMap(ResourceUtils.createEmptyKafkaConnectS2IClusterConfigMap(namespace, cluster));
         KafkaConnectS2ICluster newKc = KafkaConnectS2ICluster.fromDeployment(namespace, cluster, defaultsKc.generateDeploymentConfig(), defaultsKc.generateSourceImageStream());
 
         assertEquals(newKc.kafkaConnectClusterName(cluster) + ":latest", newKc.image);
@@ -255,7 +255,7 @@ public class KafkaConnectS2IClusterTest {
         KafkaConnectS2ICluster newKc;
         ClusterDiffResult diff;
 
-        newKc = KafkaConnectS2ICluster.fromConfigMap(true, ResourceUtils.createKafkaConnectS2IClusterConfigMap(namespace, cluster, replicas, image,
+        newKc = KafkaConnectS2ICluster.fromConfigMap(ResourceUtils.createKafkaConnectS2IClusterConfigMap(namespace, cluster, replicas, image,
                 123, healthTimeout, bootstrapServers, groupID, configReplicationFactor, offsetReplicationFactor,
                 statusReplicationFactor, keyConverter, valueConverter, keyConverterSchemas, valuesConverterSchema));
         diff = kc.diff(newKc.generateDeploymentConfig(), newKc.generateSourceImageStream(), newKc.generateTargetImageStream(), newKc.generateBuildConfig());
@@ -265,7 +265,7 @@ public class KafkaConnectS2IClusterTest {
         assertTrue(diff.isRollingUpdate());
         assertFalse(diff.isMetricsChanged());
 
-        newKc = KafkaConnectS2ICluster.fromConfigMap(true, ResourceUtils.createKafkaConnectS2IClusterConfigMap(namespace, cluster, replicas, image,
+        newKc = KafkaConnectS2ICluster.fromConfigMap(ResourceUtils.createKafkaConnectS2IClusterConfigMap(namespace, cluster, replicas, image,
                 healthDelay, 123, bootstrapServers, groupID, configReplicationFactor, offsetReplicationFactor,
                 statusReplicationFactor, keyConverter, valueConverter, keyConverterSchemas, valuesConverterSchema));
         diff = kc.diff(newKc.generateDeploymentConfig(), newKc.generateSourceImageStream(), newKc.generateTargetImageStream(), newKc.generateBuildConfig());
@@ -275,7 +275,7 @@ public class KafkaConnectS2IClusterTest {
         assertTrue(diff.isRollingUpdate());
         assertFalse(diff.isMetricsChanged());
 
-        newKc = KafkaConnectS2ICluster.fromConfigMap(true, ResourceUtils.createKafkaConnectS2IClusterConfigMap(namespace, cluster, replicas, image,
+        newKc = KafkaConnectS2ICluster.fromConfigMap(ResourceUtils.createKafkaConnectS2IClusterConfigMap(namespace, cluster, replicas, image,
                 healthDelay, healthTimeout, "some-kafka-broker:9092", groupID, configReplicationFactor, offsetReplicationFactor,
                 statusReplicationFactor, keyConverter, valueConverter, keyConverterSchemas, valuesConverterSchema));
         diff = kc.diff(newKc.generateDeploymentConfig(), newKc.generateSourceImageStream(), newKc.generateTargetImageStream(), newKc.generateBuildConfig());
@@ -285,7 +285,7 @@ public class KafkaConnectS2IClusterTest {
         assertTrue(diff.isRollingUpdate());
         assertFalse(diff.isMetricsChanged());
 
-        newKc = KafkaConnectS2ICluster.fromConfigMap(true, ResourceUtils.createKafkaConnectS2IClusterConfigMap(namespace, cluster, replicas, image,
+        newKc = KafkaConnectS2ICluster.fromConfigMap(ResourceUtils.createKafkaConnectS2IClusterConfigMap(namespace, cluster, replicas, image,
                 healthDelay, healthTimeout, bootstrapServers, "some-other-group-id", configReplicationFactor, offsetReplicationFactor,
                 statusReplicationFactor, keyConverter, valueConverter, keyConverterSchemas, valuesConverterSchema));
         diff = kc.diff(newKc.generateDeploymentConfig(), newKc.generateSourceImageStream(), newKc.generateTargetImageStream(), newKc.generateBuildConfig());
@@ -295,7 +295,7 @@ public class KafkaConnectS2IClusterTest {
         assertTrue(diff.isRollingUpdate());
         assertFalse(diff.isMetricsChanged());
 
-        newKc = KafkaConnectS2ICluster.fromConfigMap(true, ResourceUtils.createKafkaConnectS2IClusterConfigMap(namespace, cluster, replicas, image,
+        newKc = KafkaConnectS2ICluster.fromConfigMap(ResourceUtils.createKafkaConnectS2IClusterConfigMap(namespace, cluster, replicas, image,
                 healthDelay, healthTimeout, bootstrapServers, groupID, 5, offsetReplicationFactor,
                 statusReplicationFactor, keyConverter, valueConverter, keyConverterSchemas, valuesConverterSchema));
         diff = kc.diff(newKc.generateDeploymentConfig(), newKc.generateSourceImageStream(), newKc.generateTargetImageStream(), newKc.generateBuildConfig());
@@ -305,7 +305,7 @@ public class KafkaConnectS2IClusterTest {
         assertTrue(diff.isRollingUpdate());
         assertFalse(diff.isMetricsChanged());
 
-        newKc = KafkaConnectS2ICluster.fromConfigMap(true, ResourceUtils.createKafkaConnectS2IClusterConfigMap(namespace, cluster, replicas, image,
+        newKc = KafkaConnectS2ICluster.fromConfigMap(ResourceUtils.createKafkaConnectS2IClusterConfigMap(namespace, cluster, replicas, image,
                 healthDelay, healthTimeout, bootstrapServers, groupID, configReplicationFactor, 5,
                 statusReplicationFactor, keyConverter, valueConverter, keyConverterSchemas, valuesConverterSchema));
         diff = kc.diff(newKc.generateDeploymentConfig(), newKc.generateSourceImageStream(), newKc.generateTargetImageStream(), newKc.generateBuildConfig());
@@ -315,7 +315,7 @@ public class KafkaConnectS2IClusterTest {
         assertTrue(diff.isRollingUpdate());
         assertFalse(diff.isMetricsChanged());
 
-        newKc = KafkaConnectS2ICluster.fromConfigMap(true, ResourceUtils.createKafkaConnectS2IClusterConfigMap(namespace, cluster, replicas, image,
+        newKc = KafkaConnectS2ICluster.fromConfigMap(ResourceUtils.createKafkaConnectS2IClusterConfigMap(namespace, cluster, replicas, image,
                 healthDelay, healthTimeout, bootstrapServers, groupID, configReplicationFactor, offsetReplicationFactor,
                 5, keyConverter, valueConverter, keyConverterSchemas, valuesConverterSchema));
         diff = kc.diff(newKc.generateDeploymentConfig(), newKc.generateSourceImageStream(), newKc.generateTargetImageStream(), newKc.generateBuildConfig());
@@ -325,7 +325,7 @@ public class KafkaConnectS2IClusterTest {
         assertTrue(diff.isRollingUpdate());
         assertFalse(diff.isMetricsChanged());
 
-        newKc = KafkaConnectS2ICluster.fromConfigMap(true, ResourceUtils.createKafkaConnectS2IClusterConfigMap(namespace, cluster, replicas, image,
+        newKc = KafkaConnectS2ICluster.fromConfigMap(ResourceUtils.createKafkaConnectS2IClusterConfigMap(namespace, cluster, replicas, image,
                 healthDelay, healthTimeout, bootstrapServers, groupID, configReplicationFactor, offsetReplicationFactor,
                 statusReplicationFactor, "some-other-converter", valueConverter, keyConverterSchemas, valuesConverterSchema));
         diff = kc.diff(newKc.generateDeploymentConfig(), newKc.generateSourceImageStream(), newKc.generateTargetImageStream(), newKc.generateBuildConfig());
@@ -335,7 +335,7 @@ public class KafkaConnectS2IClusterTest {
         assertTrue(diff.isRollingUpdate());
         assertFalse(diff.isMetricsChanged());
 
-        newKc = KafkaConnectS2ICluster.fromConfigMap(true, ResourceUtils.createKafkaConnectS2IClusterConfigMap(namespace, cluster, replicas, image,
+        newKc = KafkaConnectS2ICluster.fromConfigMap(ResourceUtils.createKafkaConnectS2IClusterConfigMap(namespace, cluster, replicas, image,
                 healthDelay, healthTimeout, bootstrapServers, groupID, configReplicationFactor, offsetReplicationFactor,
                 statusReplicationFactor, keyConverter, "some-other-converter", keyConverterSchemas, valuesConverterSchema));
         diff = kc.diff(newKc.generateDeploymentConfig(), newKc.generateSourceImageStream(), newKc.generateTargetImageStream(), newKc.generateBuildConfig());
@@ -345,7 +345,7 @@ public class KafkaConnectS2IClusterTest {
         assertTrue(diff.isRollingUpdate());
         assertFalse(diff.isMetricsChanged());
 
-        newKc = KafkaConnectS2ICluster.fromConfigMap(true, ResourceUtils.createKafkaConnectS2IClusterConfigMap(namespace, cluster, replicas, image,
+        newKc = KafkaConnectS2ICluster.fromConfigMap(ResourceUtils.createKafkaConnectS2IClusterConfigMap(namespace, cluster, replicas, image,
                 healthDelay, healthTimeout, bootstrapServers, groupID, configReplicationFactor, offsetReplicationFactor,
                 statusReplicationFactor, keyConverter, valueConverter, true, valuesConverterSchema));
         diff = kc.diff(newKc.generateDeploymentConfig(), newKc.generateSourceImageStream(), newKc.generateTargetImageStream(), newKc.generateBuildConfig());
@@ -355,7 +355,7 @@ public class KafkaConnectS2IClusterTest {
         assertTrue(diff.isRollingUpdate());
         assertFalse(diff.isMetricsChanged());
 
-        newKc = KafkaConnectS2ICluster.fromConfigMap(true, ResourceUtils.createKafkaConnectS2IClusterConfigMap(namespace, cluster, replicas, image,
+        newKc = KafkaConnectS2ICluster.fromConfigMap(ResourceUtils.createKafkaConnectS2IClusterConfigMap(namespace, cluster, replicas, image,
                 healthDelay, healthTimeout, bootstrapServers, groupID, configReplicationFactor, offsetReplicationFactor,
                 statusReplicationFactor, keyConverter, valueConverter, keyConverterSchemas, true));
         diff = kc.diff(newKc.generateDeploymentConfig(), newKc.generateSourceImageStream(), newKc.generateTargetImageStream(), newKc.generateBuildConfig());
@@ -436,7 +436,7 @@ public class KafkaConnectS2IClusterTest {
 
     @Test
     public void testPatchDeploymentConfig()   {
-        DeploymentConfig orig = KafkaConnectS2ICluster.fromConfigMap(true, ResourceUtils.createEmptyKafkaConnectS2IClusterConfigMap(namespace, cluster)).generateDeploymentConfig();
+        DeploymentConfig orig = KafkaConnectS2ICluster.fromConfigMap(ResourceUtils.createEmptyKafkaConnectS2IClusterConfigMap(namespace, cluster)).generateDeploymentConfig();
         orig.getMetadata().setLabels(Collections.EMPTY_MAP);
         orig.getSpec().getTemplate().getMetadata().setLabels(Collections.EMPTY_MAP);
 


### PR DESCRIPTION
### Type of change

- Bugfix (but not really a bug)

### Description

It removes the un-used `isOpenShift` parameter in the `fromConfigMap` method for Kafka Connect clusters.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [x] Check coding style
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging

