### PR TITLE
Build warnings

### DIFF
--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/AbstractClusterOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/AbstractClusterOperations.java
@@ -279,7 +279,7 @@ public abstract class AbstractClusterOperations<C extends AbstractCluster,
     protected void reconcile(String namespace, Map<String, String> labels, String type) {
         log.info("Reconciling {} clusters ...", clusterDescription);
 
-        Map<String, String> kafkaLabels = new HashMap(labels);
+        Map<String, String> kafkaLabels = new HashMap<>(labels);
         kafkaLabels.put(ClusterController.STRIMZI_TYPE_LABEL, type);
 
         List<ConfigMap> cms = configMapOperations.list(namespace, kafkaLabels);

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/resource/AbstractOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/resource/AbstractOperations.java
@@ -54,6 +54,7 @@ public abstract class AbstractOperations<C, T extends HasMetadata, L extends Kub
      * If the resource with that name already exists the future completes successfully.
      * @param resource The resource to create.
      */
+    @SuppressWarnings("unchecked")
     public Future<Void> create(T resource) {
         Future<Void> fut = Future.future();
         vertx.createSharedWorkerExecutor("kubernetes-ops-pool").executeBlocking(
@@ -89,7 +90,7 @@ public abstract class AbstractOperations<C, T extends HasMetadata, L extends Kub
      * @param name The name of the resource to delete.
      */
     public Future<Void> delete(String namespace, String name) {
-        Future fut = Future.future();
+        Future<Void> fut = Future.future();
         vertx.createSharedWorkerExecutor("kubernetes-ops-pool").executeBlocking(
             future -> {
                 if (operation().inNamespace(namespace).withName(name).get() != null) {
@@ -168,6 +169,7 @@ public abstract class AbstractOperations<C, T extends HasMetadata, L extends Kub
      * @param labels The labels.
      * @return A list of matching resources.
      */
+    @SuppressWarnings("unchecked")
     public List<T> list(String namespace, Map<String, String> labels) {
         return operation().inNamespace(namespace).withLabels(labels).list().getItems();
     }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/AbstractCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/AbstractCluster.java
@@ -347,7 +347,7 @@ public abstract class AbstractCluster {
     }
 
     protected Service createHeadlessService(String name, List<ServicePort> ports) {
-        return createHeadlessService(name, ports, Collections.EMPTY_MAP);
+        return createHeadlessService(name, ports, Collections.emptyMap());
     }
 
     protected Service createHeadlessService(String name, List<ServicePort> ports, Map<String, String> annotations) {

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/KafkaConnectCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/KafkaConnectCluster.java
@@ -229,8 +229,8 @@ public class KafkaConnectCluster extends AbstractCluster {
                 Collections.singletonList(createContainerPort(REST_API_PORT_NAME, REST_API_PORT, "TCP")),
                 createHttpProbe(healthCheckPath, REST_API_PORT_NAME, healthCheckInitialDelay, healthCheckTimeout),
                 createHttpProbe(healthCheckPath, REST_API_PORT_NAME, healthCheckInitialDelay, healthCheckTimeout),
-                Collections.EMPTY_MAP,
-                Collections.EMPTY_MAP
+                Collections.emptyMap(),
+                Collections.emptyMap()
                 );
     }
 
@@ -238,8 +238,8 @@ public class KafkaConnectCluster extends AbstractCluster {
         return patchDeployment(dep,
                 createHttpProbe(healthCheckPath, REST_API_PORT_NAME, healthCheckInitialDelay, healthCheckTimeout),
                 createHttpProbe(healthCheckPath, REST_API_PORT_NAME, healthCheckInitialDelay, healthCheckTimeout),
-                Collections.EMPTY_MAP,
-                Collections.EMPTY_MAP
+                Collections.emptyMap(),
+                Collections.emptyMap()
                 );
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,7 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.surefire.version>2.20.1</maven.surefire.version>

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/Session.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/Session.java
@@ -47,7 +47,7 @@ public class Session extends AbstractVerticle {
         this.kubeClient = kubeClient;
         this.config = config;
         StringBuilder sb = new StringBuilder(System.lineSeparator());
-        for (Config.Value v: config.keys()) {
+        for (Config.Value<?> v: Config.keys()) {
             sb.append("\t").append(v.key).append(": ").append(config.get(v)).append(System.lineSeparator());
         }
         LOGGER.info("Using config:{}", sb.toString());
@@ -56,6 +56,7 @@ public class Session extends AbstractVerticle {
     /**
      * Stop the controller.
      */
+    @Override
     public void stop(Future<Void> stopFuture) throws Exception {
         this.stopped = true;
         vertx.executeBlocking(blockingResult -> {

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/TopicDiff.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/TopicDiff.java
@@ -325,11 +325,11 @@ public class TopicDiff {
      * Return true if this TopicDiff conflicts with the given other TopicDiff
      */
     public String conflict(TopicDiff other) {
-        Set<String> intersection = new HashSet(this.differences.keySet());
+        Set<String> intersection = new HashSet<>(this.differences.keySet());
         intersection.retainAll(other.differences.keySet());
         // they could still be OK if they're applying the _same_ differences
         StringBuilder sb = new StringBuilder();
-        for (Object address : intersection) {
+        for (String address : intersection) {
             Difference difference = this.differences.get(address);
             Difference otherDifference = other.differences.get(address);
             if (!difference.equals(otherDifference)) {
@@ -355,7 +355,7 @@ public class TopicDiff {
         if (confict != null) {
             throw new IllegalArgumentException("Conflict: " + confict);
         }
-        Map<String, Difference> union = new HashMap(this.differences);
+        Map<String, Difference> union = new HashMap<>(this.differences);
         union.putAll(other.differences);
         return new TopicDiff(union);
     }

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/TopicSerialization.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/TopicSerialization.java
@@ -49,10 +49,11 @@ public class TopicSerialization {
     public static final String JSON_KEY_REPLICAS = "replicas";
     public static final String JSON_KEY_CONFIG = "config";
 
+    @SuppressWarnings("unchecked")
     private static Map<String, String> topicConfigFromConfigMapString(ConfigMap cm) {
         Map<String, String> mapData = cm.getData();
         String value = mapData.get(CM_KEY_CONFIG);
-        Map<Object, Object> result;
+        Map<?, ?> result;
         if (value == null || value.isEmpty()) {
             result = Collections.emptyMap();
         } else {
@@ -70,7 +71,7 @@ public class TopicSerialization {
             }
         }
         Set<String> supportedConfigs = getSupportedTopicConfigs();
-        for (Map.Entry<Object, Object> entry : result.entrySet()) {
+        for (Map.Entry<?, ?> entry : result.entrySet()) {
             Object key = entry.getKey();
             String msg = null;
             if (!(key instanceof String)) {
@@ -90,7 +91,7 @@ public class TopicSerialization {
                         CM_KEY_CONFIG + "': The key '" + key + "' of the topic config is invalid: " + msg);
             }
         }
-        return (Map) result;
+        return (Map<String, String>) result;
     }
 
     private static Set<String> getSupportedTopicConfigs() {
@@ -302,6 +303,7 @@ public class TopicSerialization {
      * Returns the Topic represented by the given UTF-8 encoded JSON.
      * This is what is stored in the znodes owned by the {@link ZkTopicStore}.
      */
+    @SuppressWarnings("unchecked")
     public static Topic fromJson(byte[] json) {
         ObjectMapper mapper = objectMapper();
         Map<String, Object> root = null;

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/TopicsWatcher.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/TopicsWatcher.java
@@ -68,9 +68,9 @@ class TopicsWatcher {
             }
             List<String> result = childResult.result();
             LOGGER.debug("znode {} now has children {}, previous children {}", TOPICS_ZNODE, result, this.children);
-            Set<String> deleted = new HashSet(this.children);
+            Set<String> deleted = new HashSet<>(this.children);
             deleted.removeAll(result);
-            Set<String> created = new HashSet(result);
+            Set<String> created = new HashSet<>(result);
             created.removeAll(this.children);
             this.children = result;
 

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/zk/AclBuilder.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/zk/AclBuilder.java
@@ -180,7 +180,7 @@ public class AclBuilder {
         if (auth != null) {
             result.add(auth);
         }
-        for (Map<String, ACL> m : new Map[]{digests, hosts, ips}) {
+        for (Map<String, ACL> m : asList(digests, hosts, ips)) {
             if (m != null) {
                 result.addAll(m.values());
             }

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/zk/ZkImpl.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/zk/ZkImpl.java
@@ -53,7 +53,7 @@ public class ZkImpl implements Zk {
         this.zkConnectionString = zkConnectionString;
         this.sessionTimeout = sessionTimeout;
         this.readOnly = readOnly;
-        CompletableFuture f = new CompletableFuture();
+        CompletableFuture<Void> f = new CompletableFuture<>();
         try {
             zk = new ZooKeeper(zkConnectionString, sessionTimeout, watchedEvent -> {
                 // See https://wiki.apache.org/hadoop/ZooKeeper/FAQ
@@ -220,14 +220,17 @@ public class ZkImpl implements Zk {
         return this;
     }
 
+    @SuppressWarnings("unchecked")
     private Handler<AsyncResult<byte[]>> getDataWatchHandler(String path) {
         return (Handler<AsyncResult<byte[]>>) watches.get(PREFIX_DATA + path);
     }
 
+    @SuppressWarnings("unchecked")
     private Handler<AsyncResult<List<String>>> getChildrenWatchHandler(String path) {
         return (Handler<AsyncResult<List<String>>>) watches.get(PREFIX_CHILDREN + path);
     }
 
+    @SuppressWarnings("unchecked")
     private Handler<AsyncResult<Stat>> getExistsWatchHandler(String path) {
         return (Handler<AsyncResult<Stat>>) watches.get(PREFIX_EXISTS + path);
     }


### PR DESCRIPTION
### Type of change

Bugfix, but really it's just about removing compiler warnings

### Description

Fixes lots of compiler warnings, mostly about unchecked generics. Doing this stops my IDE from highlighting all these things in yellow. The only really interesting things to see here are where I've had to use `@SuppressWarnings`.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Check coding style
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging

This change doesn't actually change the code in any substantive way, it just removes some compiler warnings.

