### PR TITLE
Use interval polling for waitUntilReady()

### DIFF
--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/resource/AbstractOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/resource/AbstractOperations.java
@@ -10,6 +10,7 @@ import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.internal.readiness.Readiness;
 import io.vertx.core.Future;
+import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -185,38 +186,46 @@ public abstract class AbstractOperations<C, T extends HasMetadata, L extends Kub
     public Future<Void> waitUntilReady(String namespace, String name, long pollIntervalMs, long timeoutMs) {
         Future<Void> fut = Future.future();
         log.info("Waiting for {} resource {} in namespace {} to get ready", resourceKind, name, namespace);
-        long startTime = System.currentTimeMillis();
+        long deadline = System.currentTimeMillis() + timeoutMs;
 
-        vertx.setPeriodic(pollIntervalMs, timerId -> {
-            vertx.createSharedWorkerExecutor("kubernetes-ops-pool").executeBlocking(
-                future -> {
-                    try {
-                        if (isReady(namespace, name))   {
-                            future.complete();
+        Handler<Long> handler = new Handler<Long>() {
+            @Override
+            public void handle(Long timerId) {
+
+                vertx.createSharedWorkerExecutor("kubernetes-ops-pool").executeBlocking(
+                    future -> {
+                        try {
+                            if (isReady(namespace, name))   {
+                                future.complete();
+                            } else {
+                                future.fail("Not ready yet");
+                            }
+                        } catch (Exception e) {
+                            log.warn("Caught exception while waiting for {} {} in namespace {} to get ready", resourceKind, name, namespace, e);
+                            future.fail(e);
+                        }
+                    },
+                    false,
+                    res -> {
+                        if (res.succeeded()) {
+                            log.info("{} {} in namespace {} is ready", resourceKind, name, namespace);
+                            fut.complete();
                         } else {
-                            future.fail("Not ready yet");
-                        }
-                    } catch (Exception e) {
-                        log.warn("Caught exception while waiting for {} {} in namespace {} to get ready", resourceKind, name, namespace, e);
-                        future.fail(e);
-                    }
-                },
-                false,
-                res -> {
-                    if (res.succeeded())    {
-                        vertx.cancelTimer(timerId);
-                        log.info("{} {} in namespace {} is ready", resourceKind, name, namespace);
-                        fut.complete();
-                    } else {
-                        if (System.currentTimeMillis() - startTime > timeoutMs)   {
-                            vertx.cancelTimer(timerId);
-                            log.error("Exceeded timeoutMs of {} ms while waiting for {} {} in namespace {} to be ready", timeoutMs, resourceKind, name, namespace);
-                            fut.fail(new TimeoutException());
+                            long timeLeft = deadline - System.currentTimeMillis();
+                            if (timeLeft <= 0) {
+                                log.error("Exceeded timeoutMs of {} ms while waiting for {} {} in namespace {} to be ready", timeoutMs, resourceKind, name, namespace);
+                                fut.fail(new TimeoutException());
+                            }
+                            // Schedule ourselves to run again
+                            vertx.setTimer(Math.min(pollIntervalMs, timeLeft), this);
                         }
                     }
-                }
-            );
-        });
+                );
+            }
+        };
+
+        // Call the handler ourselves the first time
+        handler.handle(null);
 
         return fut;
     }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/resource/AbstractOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/resource/AbstractOperations.java
@@ -198,6 +198,9 @@ public abstract class AbstractOperations<C, T extends HasMetadata, L extends Kub
                             if (isReady(namespace, name))   {
                                 future.complete();
                             } else {
+                                if (log.isTraceEnabled()) {
+                                    log.trace("{} {} in namespace {} is not ready", resourceKind, name, namespace);
+                                }
                                 future.fail("Not ready yet");
                             }
                         } catch (Exception e) {

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/resource/AbstractOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/resource/AbstractOperations.java
@@ -218,9 +218,10 @@ public abstract class AbstractOperations<C, T extends HasMetadata, L extends Kub
                             if (timeLeft <= 0) {
                                 log.error("Exceeded timeoutMs of {} ms while waiting for {} {} in namespace {} to be ready", timeoutMs, resourceKind, name, namespace);
                                 fut.fail(new TimeoutException());
+                            } else {
+                                // Schedule ourselves to run again
+                                vertx.setTimer(Math.min(pollIntervalMs, timeLeft), this);
                             }
-                            // Schedule ourselves to run again
-                            vertx.setTimer(Math.min(pollIntervalMs, timeLeft), this);
                         }
                     }
                 );

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/resource/BuildConfigOperationsMockTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/resource/BuildConfigOperationsMockTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.when;
 public class BuildConfigOperationsMockTest extends ResourceOperationsMockTest<OpenShiftClient, BuildConfig,
         BuildConfigList, DoneableBuildConfig, BuildConfigResource<BuildConfig, DoneableBuildConfig, Void, Build>> {
 
+    @Override
     protected void mocker(OpenShiftClient mockClient, MixedOperation mockCms) {
         when(mockClient.buildConfigs()).thenReturn(mockCms);
     }

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/resource/ConfigMapOperationsTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/resource/ConfigMapOperationsTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.when;
 
 public class ConfigMapOperationsTest extends ResourceOperationsMockTest<KubernetesClient, ConfigMap, ConfigMapList, DoneableConfigMap, Resource<ConfigMap, DoneableConfigMap>> {
 
+    @Override
     protected void  mocker(KubernetesClient mockClient, MixedOperation mockCms) {
         when(mockClient.configMaps()).thenReturn(mockCms);
     }

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/resource/ResourceOperationsMockTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/resource/ResourceOperationsMockTest.java
@@ -400,7 +400,7 @@ public abstract class ResourceOperationsMockTest<C extends KubernetesClient, T e
         Async async = context.async();
         op.waitUntilReady(NAMESPACE, RESOURCE_NAME, 20, 5_000).setHandler(ar -> {
             assertTrue(ar.succeeded());
-            verify(mockResource, times(unreadyCount + 1)).get();
+            verify(mockResource, times(Readiness.isReadinessApplicable(resource) ? unreadyCount + 1 : 1)).get();
 
             if (Readiness.isReadinessApplicable(resource)) {
                 verify(mockResource, times(unreadyCount + 1)).isReady();


### PR DESCRIPTION
### Type of change

- Bugfix

specifically it aims to fix some flaky tests.

### Description

The waitReadySuccessful test still seems prone to failing even with the increased timeout I added yesterday. Using `setPeriodic()` as we were meant we had an initial wait time of the given poll interval  before the first test. This change switches to interval-based polling so `isReady()` more or less immediately (depending on the poll of worker threads), without first waiting an initial poll interval. It is also a little more accurate wrt timeouts. 

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Check coding style
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging

