### PR TITLE
Refactoring create/update/delete operations with a common reconcile path

### DIFF
--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterController.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterController.java
@@ -136,18 +136,12 @@ public class ClusterController extends AbstractVerticle {
                             return;
                         }
                         String name = cm.getMetadata().getName();
+                        log.info("ConfigMap {} in namespace {} {}", name, namespace, action);
                         switch (action) {
                             case ADDED:
-                                log.info("New ConfigMap {} in namespace {}", name, namespace);
-                                cluster.create(namespace, name);
-                                break;
                             case DELETED:
-                                log.info("Deleted ConfigMap {} in namespace {}", name, namespace);
-                                cluster.delete(namespace, name);
-                                break;
                             case MODIFIED:
-                                log.info("Modified ConfigMap {} in namespace {}", name, namespace);
-                                cluster.update(namespace, name);
+                                cluster.reconcile(namespace, name);
                                 break;
                             case ERROR:
                                 log.error("Failed ConfigMap {} in namespace{} ", name, namespace);
@@ -199,13 +193,14 @@ public class ClusterController extends AbstractVerticle {
         });
     }
 
-    /*
+    /**
       Periodical reconciliation (in case we lost some event)
      */
     private void reconcile() {
-        kafkaClusterOperations.reconcile(namespace, labels);
-        kafkaConnectClusterOperations.reconcile(namespace, labels);
-        kafkaConnectS2IClusterOperations.reconcile(namespace, labels);
+
+        kafkaClusterOperations.reconcileAll(namespace, labels);
+        kafkaConnectClusterOperations.reconcileAll(namespace, labels);
+        kafkaConnectS2IClusterOperations.reconcileAll(namespace, labels);
     }
 
     /**

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterController.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterController.java
@@ -136,11 +136,11 @@ public class ClusterController extends AbstractVerticle {
                             return;
                         }
                         String name = cm.getMetadata().getName();
-                        log.info("ConfigMap {} in namespace {} {}", name, namespace, action);
                         switch (action) {
                             case ADDED:
                             case DELETED:
                             case MODIFIED:
+                                log.info("ConfigMap {} in namespace {} was {}", name, namespace, action);
                                 cluster.reconcile(namespace, name);
                                 break;
                             case ERROR:

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperations.java
@@ -614,12 +614,12 @@ public class KafkaClusterOperations extends AbstractClusterOperations<KafkaClust
 
     @Override
     public void reconcileAll(String namespace, Map<String, String> labels) {
-        reconcileAll(namespace, labels, CLUSTER_TYPE_KAFKA);
+        reconcileAll(CLUSTER_TYPE_KAFKA, namespace, labels);
     }
 
     @Override
     public void reconcile(String namespace, String name) {
-        reconcile(namespace, name, CLUSTER_TYPE_KAFKA);
+        reconcile(CLUSTER_TYPE_KAFKA, namespace, name);
     }
 
     @Override

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperations.java
@@ -613,8 +613,13 @@ public class KafkaClusterOperations extends AbstractClusterOperations<KafkaClust
     }
 
     @Override
-    public void reconcile(String namespace, Map<String, String> labels) {
-        reconcile(namespace, labels, CLUSTER_TYPE_KAFKA);
+    public void reconcileAll(String namespace, Map<String, String> labels) {
+        reconcileAll(namespace, labels, CLUSTER_TYPE_KAFKA);
+    }
+
+    @Override
+    public void reconcile(String namespace, String name) {
+        reconcile(namespace, name, CLUSTER_TYPE_KAFKA);
     }
 
     @Override

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectClusterOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectClusterOperations.java
@@ -176,8 +176,13 @@ public class KafkaConnectClusterOperations extends AbstractClusterOperations<Kaf
     }
 
     @Override
-    public void reconcile(String namespace, Map<String, String> labels) {
-        reconcile(namespace, labels, CLUSTER_TYPE_CONNECT);
+    public void reconcileAll(String namespace, Map<String, String> labels) {
+        reconcileAll(namespace, labels, CLUSTER_TYPE_CONNECT);
+    }
+
+    @Override
+    public void reconcile(String namespace, String name) {
+        reconcile(namespace, name, CLUSTER_TYPE_CONNECT);
     }
 
     @Override

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectClusterOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectClusterOperations.java
@@ -177,12 +177,12 @@ public class KafkaConnectClusterOperations extends AbstractClusterOperations<Kaf
 
     @Override
     public void reconcileAll(String namespace, Map<String, String> labels) {
-        reconcileAll(namespace, labels, CLUSTER_TYPE_CONNECT);
+        reconcileAll(CLUSTER_TYPE_CONNECT, namespace, labels);
     }
 
     @Override
     public void reconcile(String namespace, String name) {
-        reconcile(namespace, name, CLUSTER_TYPE_CONNECT);
+        reconcile(CLUSTER_TYPE_CONNECT, namespace, name);
     }
 
     @Override

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectS2IClusterOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectS2IClusterOperations.java
@@ -33,7 +33,7 @@ import java.util.Map;
 public class KafkaConnectS2IClusterOperations extends AbstractClusterOperations<KafkaConnectS2ICluster, DeploymentConfig> {
 
     private static final Logger log = LoggerFactory.getLogger(KafkaConnectS2IClusterOperations.class.getName());
-    private static final String CLUSTER_TYPE = "kafka-connect-s2i";
+    private static final String CLUSTER_TYPE_CONNECT_S2I = "kafka-connect-s2i";
     private final ServiceOperations serviceOperations;
     private final DeploymentConfigOperations deploymentConfigOperations;
     private final ImageStreamOperations imagesStreamOperations;
@@ -64,7 +64,7 @@ public class KafkaConnectS2IClusterOperations extends AbstractClusterOperations<
     @Override
     public void create(String namespace, String name, Handler<AsyncResult<Void>> handler) {
         if (isOpenShift) {
-            execute(CLUSTER_TYPE, OP_CREATE, namespace, name, create, handler);
+            execute(CLUSTER_TYPE_CONNECT_S2I, OP_CREATE, namespace, name, create, handler);
         } else {
             handler.handle(Future.failedFuture("S2I only available on OpenShift"));
         }
@@ -94,7 +94,7 @@ public class KafkaConnectS2IClusterOperations extends AbstractClusterOperations<
     @Override
     protected void delete(String namespace, String name, Handler<AsyncResult<Void>> handler) {
         if (isOpenShift) {
-            execute(CLUSTER_TYPE, OP_DELETE, namespace, name, delete, handler);
+            execute(CLUSTER_TYPE_CONNECT_S2I, OP_DELETE, namespace, name, delete, handler);
         } else {
             handler.handle(Future.failedFuture("S2I only available on OpenShift"));
         }
@@ -126,7 +126,7 @@ public class KafkaConnectS2IClusterOperations extends AbstractClusterOperations<
     @Override
     public void update(String namespace, String name, Handler<AsyncResult<Void>> handler) {
         if (isOpenShift) {
-            execute(CLUSTER_TYPE, OP_UPDATE, namespace, name, update, handler);
+            execute(CLUSTER_TYPE_CONNECT_S2I, OP_UPDATE, namespace, name, update, handler);
         } else {
             handler.handle(Future.failedFuture("S2I only available on OpenShift"));
         }
@@ -236,11 +236,13 @@ public class KafkaConnectS2IClusterOperations extends AbstractClusterOperations<
     };
 
     @Override
-    public void reconcile(String namespace, Map<String, String> labels) {
-        if (!isOpenShift) {
-            return;
-        }
-        reconcile(namespace, labels, CLUSTER_TYPE);
+    public void reconcileAll(String namespace, Map<String, String> labels) {
+        reconcileAll(namespace, labels, CLUSTER_TYPE_CONNECT_S2I);
+    }
+
+    @Override
+    public void reconcile(String namespace, String name) {
+        reconcile(namespace, name, CLUSTER_TYPE_CONNECT_S2I);
     }
 
     @Override

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectS2IClusterOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectS2IClusterOperations.java
@@ -237,12 +237,12 @@ public class KafkaConnectS2IClusterOperations extends AbstractClusterOperations<
 
     @Override
     public void reconcileAll(String namespace, Map<String, String> labels) {
-        reconcileAll(namespace, labels, CLUSTER_TYPE_CONNECT_S2I);
+        reconcileAll(CLUSTER_TYPE_CONNECT_S2I, namespace, labels);
     }
 
     @Override
     public void reconcile(String namespace, String name) {
-        reconcile(namespace, name, CLUSTER_TYPE_CONNECT_S2I);
+        reconcile(CLUSTER_TYPE_CONNECT_S2I, namespace, name);
     }
 
     @Override

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperationsTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperationsTest.java
@@ -672,7 +672,7 @@ public class KafkaClusterOperationsTest {
 
 
         // Now try to create a KafkaCluster based on this CM
-        ops.reconcile(clusterCmNamespace, Collections.emptyMap());
+        ops.reconcile(clusterCmNamespace, clusterCmName);
 
         context.assertEquals(singleton("foo"), created);
         context.assertEquals(singleton("bar"), updated);


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

This PR is mostly focused on fixing #171 but then #124 as well. It contains a refactoring of doing create/update/delete operations through a common reconcile path. At same time the operations lock was moved to an upper level from the single "execute" to the whole "reconcile" operation.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [x] Check coding style
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging

