### PR TITLE
Simplify ACO

### DIFF
--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/AbstractClusterOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/AbstractClusterOperations.java
@@ -207,6 +207,9 @@ public abstract class AbstractClusterOperations<C extends AbstractCluster,
         return resource.getMetadata().getLabels().get(ClusterController.STRIMZI_CLUSTER_LABEL);
     }
 
+    /**
+     * The type of cluster, used as a component of the lock.
+     */
     protected abstract String clusterType();
 
     /**

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/AbstractClusterOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/AbstractClusterOperations.java
@@ -56,7 +56,7 @@ public abstract class AbstractClusterOperations<C extends AbstractCluster,
      * @param isOpenShift True iff running on OpenShift
      * @param clusterDescription A description of the cluster, for logging. This is a high level description and different from
      *                           the {@code clusterType} passed to {@link #getLockName(String, String, String)}
-     *                           and {@link #execute(String, String, String, String, CompositeOperation, Handler)}
+     *                           and {@link #execute(String, String, CompositeOperation, Handler)}
      */
     protected AbstractClusterOperations(Vertx vertx, boolean isOpenShift, String clusterDescription,
                                         ConfigMapOperations configMapOperations) {

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/AbstractClusterOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/AbstractClusterOperations.java
@@ -112,6 +112,8 @@ public abstract class AbstractClusterOperations<C extends AbstractCluster,
      * @param <C> The type of cluster.
      */
     protected interface CompositeOperation<C extends AbstractCluster> {
+        String operationType();
+        String clusterType();
         /**
          * Create the resources in Kubernetes according to the given {@code cluster},
          * returning a composite future for when the overall operation is done
@@ -131,16 +133,15 @@ public abstract class AbstractClusterOperations<C extends AbstractCluster,
      * <p>The desired cluster state is obtained from {@link CompositeOperation#getCluster(String, String)} and the
      * resource operations are executed via {@link CompositeOperation#composite(String, ClusterOperation)}.</p>
      *
-     * @param clusterType The type of cluster
-     * @param operationType The kind of operation
      * @param namespace The namespace containing the cluster.
      * @param name The name of the cluster
      * @param compositeOperation The operation to execute
      * @param handler A completion handler
      * @param <C> The type of cluster.
      */
-    protected final <C extends AbstractCluster> void execute(String clusterType, String operationType, String namespace, String name, CompositeOperation<C> compositeOperation, Handler<AsyncResult<Void>> handler) {
-
+    protected final <C extends AbstractCluster> void execute(String namespace, String name, CompositeOperation<C> compositeOperation, Handler<AsyncResult<Void>> handler) {
+        String clusterType = compositeOperation.clusterType();
+        String operationType = compositeOperation.operationType();
         ClusterOperation<C> clusterOp;
         try {
             clusterOp = compositeOperation.getCluster(namespace, name);
@@ -165,7 +166,7 @@ public abstract class AbstractClusterOperations<C extends AbstractCluster,
 
     /**
      * Subclasses implement this method to create the cluster. The implementation usually just has to call
-     * {@link #execute(String, String, String, String, CompositeOperation, Handler)} with appropriate arguments.
+     * {@link #execute(String, String, CompositeOperation, Handler)} with appropriate arguments.
      * @param namespace The namespace containing the cluster.
      * @param name The name of the cluster.
      * @param handler Completion handler
@@ -174,7 +175,7 @@ public abstract class AbstractClusterOperations<C extends AbstractCluster,
 
     /**
      * Subclasses implement this method to delete the cluster. The implementation usually just has to call
-     * {@link #execute(String, String, String, String, CompositeOperation, Handler)} with appropriate arguments.
+     * {@link #execute(String, String, CompositeOperation, Handler)} with appropriate arguments.
      * @param namespace The namespace containing the cluster.
      * @param name The name of the cluster.
      * @param handler Completion handler
@@ -183,7 +184,7 @@ public abstract class AbstractClusterOperations<C extends AbstractCluster,
 
     /**
      * Subclasses implement this method to update the cluster. The implementation usually just has to call
-     * {@link #execute(String, String, String, String, CompositeOperation, Handler)} with appropriate arguments.
+     * {@link #execute(String, String, CompositeOperation, Handler)} with appropriate arguments.
      * @param namespace The namespace containing the cluster.
      * @param name The name of the cluster.
      * @param handler Completion handler

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/AbstractClusterOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/AbstractClusterOperations.java
@@ -246,9 +246,9 @@ public abstract class AbstractClusterOperations<C extends AbstractCluster,
      * Reconciliation works by getting the cluster ConfigMap in the given namespace with the given name and
      * comparing with the corresponding {@linkplain #getResources(String, Map) resource}.
      * <ul>
-     * <li>A cluster will be {@linkplain #create(String, String) created} if ConfigMap is without same-named resources</li>
-     * <li>A cluster will be {@linkplain #delete(String, String) deleted} if resources without same-named ConfigMap</li>
-     * <li>A cluster will be {@linkplain #update(String, String) updated} if it has a cluster ConfigMap and a resource with the same name.</li>
+     * <li>A cluster will be {@linkplain #create(String, String, Handler) created} if ConfigMap is without same-named resources</li>
+     * <li>A cluster will be {@linkplain #delete(String, String, Handler) deleted} if resources without same-named ConfigMap</li>
+     * <li>A cluster will be {@linkplain #update(String, String, Handler) updated} if it has a cluster ConfigMap and a resource with the same name.</li>
      * </ul>
      * @param namespace The namespace
      * @param name The name of the cluster
@@ -314,9 +314,9 @@ public abstract class AbstractClusterOperations<C extends AbstractCluster,
      * Reconciliation works by getting the cluster ConfigMaps in the given namespace with the given labels and
      * comparing with the corresponding {@linkplain #getResources(String, Map) resource}.
      * <ul>
-     * <li>A cluster will be {@linkplain #create(String, String) created} for all ConfigMaps without same-named resources</li>
-     * <li>A cluster will be {@linkplain #delete(String, String) deleted} for all resources without same-named ConfigMaps</li>
-     * <li>A cluster will be {@linkplain #update(String, String) updated} if it has a cluster ConfigMap and a resource with the same name.</li>
+     * <li>A cluster will be {@linkplain #create(String, String, Handler) created} for all ConfigMaps without same-named resources</li>
+     * <li>A cluster will be {@linkplain #delete(String, String, Handler) deleted} for all resources without same-named ConfigMaps</li>
+     * <li>A cluster will be {@linkplain #update(String, String, Handler) updated} if it has a cluster ConfigMap and a resource with the same name.</li>
      * </ul>
      * @param namespace The namespace
      * @param labels The labels

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/AbstractClusterOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/AbstractClusterOperations.java
@@ -284,12 +284,17 @@ public abstract class AbstractClusterOperations<C extends AbstractCluster,
 
                     if (cm != null) {
                         if (resources.size() > 0) {
-                            update(namespace, cm);
+                            log.info("Reconciliation: {} cluster {} should be checked for updates", clusterDescription, cm.getMetadata().getName());
+                            update(namespace, name(cm));
                         } else {
-                            create(namespace, cm);
+                            log.info("Reconciliation: {} cluster {} should be created", clusterDescription, cm.getMetadata().getName());
+                            create(namespace, name(cm));
                         }
                     } else if (resources.size() > 0) {
-                        delete(namespace, resources);
+                        for (R resource : resources) {
+                            log.info("Reconciliation: {} cluster {} should be deleted", clusterDescription, resource.getMetadata().getName());
+                            delete(namespace, nameFromLabels(resource));
+                        }
                     }
 
                 } catch (Throwable ex) {
@@ -356,22 +361,5 @@ public abstract class AbstractClusterOperations<C extends AbstractCluster,
      * @return The matching resources.
      */
     protected abstract List<R> getResources(String namespace, Map<String, String> kafkaLabels);
-
-    protected final void create(String namespace, ConfigMap cm)   {
-        log.info("Reconciliation: {} cluster {} should be created", clusterDescription, cm.getMetadata().getName());
-        create(namespace, name(cm));
-    }
-
-    protected final void update(String namespace, ConfigMap cm)   {
-        log.info("Reconciliation: {} cluster {} should be checked for updates", clusterDescription, cm.getMetadata().getName());
-        update(namespace, name(cm));
-    }
-
-    protected final void delete(String namespace, List<R> resources)   {
-        for (R resource : resources) {
-            log.info("Reconciliation: {} cluster {} should be deleted", clusterDescription, resource.getMetadata().getName());
-            delete(namespace, nameFromLabels(resource));
-        }
-    }
 
 }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperations.java
@@ -613,13 +613,8 @@ public class KafkaClusterOperations extends AbstractClusterOperations<KafkaClust
     }
 
     @Override
-    public void reconcileAll(String namespace, Map<String, String> labels) {
-        reconcileAll(CLUSTER_TYPE_KAFKA, namespace, labels);
-    }
-
-    @Override
-    public void reconcile(String namespace, String name) {
-        reconcile(CLUSTER_TYPE_KAFKA, namespace, name);
+    public String clusterType() {
+        return CLUSTER_TYPE_KAFKA;
     }
 
     @Override

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperations.java
@@ -78,17 +78,17 @@ public class KafkaClusterOperations extends AbstractClusterOperations<KafkaClust
 
     @Override
     public void create(String namespace, String name, Handler<AsyncResult<Void>> handler) {
-        execute(CLUSTER_TYPE_ZOOKEEPER, OP_CREATE, namespace, name, createZk, zookeeperResult -> {
+        execute(namespace, name, createZk, zookeeperResult -> {
             if (zookeeperResult.failed()) {
                 handler.handle(zookeeperResult);
             } else {
-                execute(CLUSTER_TYPE_KAFKA, OP_CREATE, namespace, name, createKafka, kafkaResult -> {
+                execute(namespace, name, createKafka, kafkaResult -> {
                     if (kafkaResult.failed()) {
                         handler.handle(kafkaResult);
                     } else {
                         ClusterOperation<TopicController> clusterOp = createTopicController.getCluster(namespace, name);
                         if (clusterOp.cluster() != null) {
-                            execute(CLUSTER_TYPE_TOPIC_CONTROLLER, OP_CREATE, namespace, name, createTopicController, handler);
+                            execute(namespace, name, createTopicController, handler);
                         } else {
                             handler.handle(kafkaResult);
                         }
@@ -99,6 +99,16 @@ public class KafkaClusterOperations extends AbstractClusterOperations<KafkaClust
     }
 
     private final CompositeOperation<KafkaCluster> createKafka = new CompositeOperation<KafkaCluster>() {
+
+        @Override
+        public String operationType() {
+            return OP_CREATE;
+        }
+
+        @Override
+        public String clusterType() {
+            return CLUSTER_TYPE_KAFKA;
+        }
 
         @Override
         public ClusterOperation<KafkaCluster> getCluster(String namespace, String name) {
@@ -153,6 +163,16 @@ public class KafkaClusterOperations extends AbstractClusterOperations<KafkaClust
     private final CompositeOperation<ZookeeperCluster> createZk = new CompositeOperation<ZookeeperCluster>() {
 
         @Override
+        public String operationType() {
+            return OP_CREATE;
+        }
+
+        @Override
+        public String clusterType() {
+            return CLUSTER_TYPE_ZOOKEEPER;
+        }
+
+        @Override
         public ClusterOperation<ZookeeperCluster> getCluster(String namespace, String name) {
             return new ClusterOperation<>(ZookeeperCluster.fromConfigMap(configMapOperations.get(namespace, name)), null);
         }
@@ -203,6 +223,16 @@ public class KafkaClusterOperations extends AbstractClusterOperations<KafkaClust
     private final CompositeOperation<TopicController> createTopicController = new CompositeOperation<TopicController>() {
 
         @Override
+        public String operationType() {
+            return OP_CREATE;
+        }
+
+        @Override
+        public String clusterType() {
+            return CLUSTER_TYPE_TOPIC_CONTROLLER;
+        }
+
+        @Override
         public ClusterOperation<TopicController> getCluster(String namespace, String name) {
             return new ClusterOperation<>(TopicController.fromConfigMap(configMapOperations.get(namespace, name)), null);
         }
@@ -216,6 +246,16 @@ public class KafkaClusterOperations extends AbstractClusterOperations<KafkaClust
     };
 
     private final CompositeOperation<KafkaCluster> deleteKafka = new CompositeOperation<KafkaCluster>() {
+        @Override
+        public String operationType() {
+            return OP_DELETE;
+        }
+
+        @Override
+        public String clusterType() {
+            return CLUSTER_TYPE_KAFKA;
+        }
+
         @Override
         public Future<?> composite(String namespace, ClusterOperation<KafkaCluster> clusterOp) {
             KafkaCluster kafka = clusterOp.cluster();
@@ -251,6 +291,17 @@ public class KafkaClusterOperations extends AbstractClusterOperations<KafkaClust
 
 
     private final CompositeOperation<ZookeeperCluster> deleteZk = new CompositeOperation<ZookeeperCluster>() {
+
+        @Override
+        public String operationType() {
+            return OP_DELETE;
+        }
+
+        @Override
+        public String clusterType() {
+            return CLUSTER_TYPE_ZOOKEEPER;
+        }
+
         @Override
         public Future<?> composite(String namespace, ClusterOperation<ZookeeperCluster> clusterOp) {
             ZookeeperCluster zk = clusterOp.cluster();
@@ -290,6 +341,16 @@ public class KafkaClusterOperations extends AbstractClusterOperations<KafkaClust
     private final CompositeOperation<TopicController> deleteTopicController = new CompositeOperation<TopicController>() {
 
         @Override
+        public String operationType() {
+            return OP_DELETE;
+        }
+
+        @Override
+        public String clusterType() {
+            return CLUSTER_TYPE_TOPIC_CONTROLLER;
+        }
+
+        @Override
         public Future<?> composite(String namespace, ClusterOperation<TopicController> clusterOp) {
             TopicController topicController = clusterOp.cluster();
             return deploymentOperations.delete(namespace, topicController.getName());
@@ -308,7 +369,7 @@ public class KafkaClusterOperations extends AbstractClusterOperations<KafkaClust
         // first check if the topic controller was really deployed
         ClusterOperation<TopicController> clusterOp = deleteTopicController.getCluster(namespace, name);
         if (clusterOp.cluster() != null) {
-            execute(CLUSTER_TYPE_TOPIC_CONTROLLER, OP_DELETE, namespace, name, deleteTopicController, topicControllerResult -> {
+            execute(namespace, name, deleteTopicController, topicControllerResult -> {
                 if (topicControllerResult.failed()) {
                     handler.handle(topicControllerResult);
                 } else {
@@ -322,16 +383,26 @@ public class KafkaClusterOperations extends AbstractClusterOperations<KafkaClust
 
     private void deleteKafkaAndZookeeper(String namespace, String name, Handler<AsyncResult<Void>> handler) {
 
-        execute(CLUSTER_TYPE_KAFKA, OP_DELETE, namespace, name, deleteKafka, kafkaResult -> {
+        execute(namespace, name, deleteKafka, kafkaResult -> {
             if (kafkaResult.failed()) {
                 handler.handle(kafkaResult);
             } else {
-                execute(CLUSTER_TYPE_ZOOKEEPER, OP_DELETE, namespace, name, deleteZk, handler);
+                execute(namespace, name, deleteZk, handler);
             }
         });
     }
 
     private final CompositeOperation<KafkaCluster> updateKafka = new CompositeOperation<KafkaCluster>() {
+        @Override
+        public String operationType() {
+            return OP_UPDATE;
+        }
+
+        @Override
+        public String clusterType() {
+            return CLUSTER_TYPE_KAFKA;
+        }
+
         @Override
         public Future<?> composite(String namespace, ClusterOperation<KafkaCluster> clusterOp) {
             KafkaCluster kafka = clusterOp.cluster();
@@ -437,6 +508,15 @@ public class KafkaClusterOperations extends AbstractClusterOperations<KafkaClust
 
     private final CompositeOperation<ZookeeperCluster> updateZk = new CompositeOperation<ZookeeperCluster>() {
         @Override
+        public String operationType() {
+            return OP_UPDATE;
+        }
+
+        @Override
+        public String clusterType() {
+            return CLUSTER_TYPE_ZOOKEEPER;
+        }
+        @Override
         public Future<?> composite(String namespace, ClusterOperation<ZookeeperCluster> operation) {
             ZookeeperCluster zk = operation.cluster();
             ClusterDiffResult diff = operation.diff();
@@ -541,6 +621,15 @@ public class KafkaClusterOperations extends AbstractClusterOperations<KafkaClust
     };
 
     private final CompositeOperation<TopicController> updateTopicController = new CompositeOperation<TopicController>() {
+        @Override
+        public String operationType() {
+            return OP_UPDATE;
+        }
+
+        @Override
+        public String clusterType() {
+            return CLUSTER_TYPE_TOPIC_CONTROLLER;
+        }
 
         @Override
         public Future<?> composite(String namespace, ClusterOperation<TopicController> operation) {
@@ -592,17 +681,17 @@ public class KafkaClusterOperations extends AbstractClusterOperations<KafkaClust
 
     @Override
     public void update(String namespace, String name, Handler<AsyncResult<Void>> handler) {
-        execute(CLUSTER_TYPE_ZOOKEEPER, OP_UPDATE, namespace, name, updateZk, zookeeperResult -> {
+        execute(namespace, name, updateZk, zookeeperResult -> {
             if (zookeeperResult.failed()) {
                 handler.handle(zookeeperResult);
             } else {
-                execute(CLUSTER_TYPE_KAFKA, OP_UPDATE, namespace, name, updateKafka, kafkaResult -> {
+                execute(namespace, name, updateKafka, kafkaResult -> {
                     if (kafkaResult.failed()) {
                         handler.handle(kafkaResult);
                     } else {
                         ClusterOperation<TopicController> clusterOp = updateTopicController.getCluster(namespace, name);
                         if (clusterOp.cluster() != null) {
-                            execute(CLUSTER_TYPE_TOPIC_CONTROLLER, OP_UPDATE, namespace, name, updateTopicController, handler);
+                            execute(namespace, name, updateTopicController, handler);
                         } else {
                             handler.handle(kafkaResult);
                         }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectClusterOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectClusterOperations.java
@@ -50,6 +50,15 @@ public class KafkaConnectClusterOperations extends AbstractClusterOperations<Kaf
     }
 
     private final CompositeOperation<KafkaConnectCluster> create = new CompositeOperation<KafkaConnectCluster>() {
+        @Override
+        public String operationType() {
+            return OP_CREATE;
+        }
+
+        @Override
+        public String clusterType() {
+            return CLUSTER_TYPE_CONNECT;
+        }
 
         @Override
         public ClusterOperation<KafkaConnectCluster> getCluster(String namespace, String name) {
@@ -70,7 +79,15 @@ public class KafkaConnectClusterOperations extends AbstractClusterOperations<Kaf
 
 
     private final CompositeOperation<KafkaConnectCluster> delete = new CompositeOperation<KafkaConnectCluster>() {
+        @Override
+        public String operationType() {
+            return OP_DELETE;
+        }
 
+        @Override
+        public String clusterType() {
+            return CLUSTER_TYPE_CONNECT;
+        }
         @Override
         public Future<?> composite(String namespace, ClusterOperation<KafkaConnectCluster> clusterOp) {
             KafkaConnectCluster connect = clusterOp.cluster();
@@ -91,6 +108,15 @@ public class KafkaConnectClusterOperations extends AbstractClusterOperations<Kaf
     };
 
     private final CompositeOperation<KafkaConnectCluster> update = new CompositeOperation<KafkaConnectCluster>() {
+        @Override
+        public String operationType() {
+            return OP_UPDATE;
+        }
+
+        @Override
+        public String clusterType() {
+            return CLUSTER_TYPE_CONNECT;
+        }
         @Override
         public Future<?> composite(String namespace, ClusterOperation<KafkaConnectCluster> operation) {
             KafkaConnectCluster connect = operation.cluster();
@@ -162,17 +188,17 @@ public class KafkaConnectClusterOperations extends AbstractClusterOperations<Kaf
 
     @Override
     protected void create(String namespace, String name, Handler<AsyncResult<Void>> handler) {
-        execute(CLUSTER_TYPE_CONNECT, OP_CREATE, namespace, name, create, handler);
+        execute(namespace, name, create, handler);
     }
 
     @Override
     protected void delete(String namespace, String name, Handler<AsyncResult<Void>> handler) {
-        execute(CLUSTER_TYPE_CONNECT, OP_DELETE, namespace, name, delete, handler);
+        execute(namespace, name, delete, handler);
     }
 
     @Override
     protected void update(String namespace, String name, Handler<AsyncResult<Void>> handler) {
-        execute(CLUSTER_TYPE_CONNECT, OP_UPDATE, namespace, name, update, handler);
+        execute(namespace, name, update, handler);
     }
 
     @Override

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectClusterOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectClusterOperations.java
@@ -176,13 +176,8 @@ public class KafkaConnectClusterOperations extends AbstractClusterOperations<Kaf
     }
 
     @Override
-    public void reconcileAll(String namespace, Map<String, String> labels) {
-        reconcileAll(CLUSTER_TYPE_CONNECT, namespace, labels);
-    }
-
-    @Override
-    public void reconcile(String namespace, String name) {
-        reconcile(CLUSTER_TYPE_CONNECT, namespace, name);
+    public String clusterType() {
+        return CLUSTER_TYPE_CONNECT;
     }
 
     @Override

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectS2IClusterOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectS2IClusterOperations.java
@@ -236,13 +236,8 @@ public class KafkaConnectS2IClusterOperations extends AbstractClusterOperations<
     };
 
     @Override
-    public void reconcileAll(String namespace, Map<String, String> labels) {
-        reconcileAll(CLUSTER_TYPE_CONNECT_S2I, namespace, labels);
-    }
-
-    @Override
-    public void reconcile(String namespace, String name) {
-        reconcile(CLUSTER_TYPE_CONNECT_S2I, namespace, name);
+    public String clusterType() {
+        return CLUSTER_TYPE_CONNECT_S2I;
     }
 
     @Override

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectS2IClusterOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectS2IClusterOperations.java
@@ -64,7 +64,7 @@ public class KafkaConnectS2IClusterOperations extends AbstractClusterOperations<
     @Override
     public void create(String namespace, String name, Handler<AsyncResult<Void>> handler) {
         if (isOpenShift) {
-            execute(CLUSTER_TYPE_CONNECT_S2I, OP_CREATE, namespace, name, create, handler);
+            execute(namespace, name, create, handler);
         } else {
             handler.handle(Future.failedFuture("S2I only available on OpenShift"));
         }
@@ -75,6 +75,16 @@ public class KafkaConnectS2IClusterOperations extends AbstractClusterOperations<
         @Override
         public ClusterOperation<KafkaConnectS2ICluster> getCluster(String namespace, String name) {
             return new ClusterOperation<>(KafkaConnectS2ICluster.fromConfigMap(configMapOperations.get(namespace, name)), null);
+        }
+
+        @Override
+        public String operationType() {
+            return OP_CREATE;
+        }
+
+        @Override
+        public String clusterType() {
+            return CLUSTER_TYPE_CONNECT_S2I;
         }
 
         @Override
@@ -94,13 +104,23 @@ public class KafkaConnectS2IClusterOperations extends AbstractClusterOperations<
     @Override
     protected void delete(String namespace, String name, Handler<AsyncResult<Void>> handler) {
         if (isOpenShift) {
-            execute(CLUSTER_TYPE_CONNECT_S2I, OP_DELETE, namespace, name, delete, handler);
+            execute(namespace, name, delete, handler);
         } else {
             handler.handle(Future.failedFuture("S2I only available on OpenShift"));
         }
     }
 
     private final CompositeOperation<KafkaConnectS2ICluster> delete = new CompositeOperation<KafkaConnectS2ICluster>() {
+
+        @Override
+        public String operationType() {
+            return OP_DELETE;
+        }
+
+        @Override
+        public String clusterType() {
+            return CLUSTER_TYPE_CONNECT_S2I;
+        }
 
         @Override
         public Future<?> composite(String namespace, ClusterOperation<KafkaConnectS2ICluster> clusterOp) {
@@ -126,13 +146,23 @@ public class KafkaConnectS2IClusterOperations extends AbstractClusterOperations<
     @Override
     public void update(String namespace, String name, Handler<AsyncResult<Void>> handler) {
         if (isOpenShift) {
-            execute(CLUSTER_TYPE_CONNECT_S2I, OP_UPDATE, namespace, name, update, handler);
+            execute(namespace, name, update, handler);
         } else {
             handler.handle(Future.failedFuture("S2I only available on OpenShift"));
         }
     }
 
     private final CompositeOperation<KafkaConnectS2ICluster> update = new CompositeOperation<KafkaConnectS2ICluster>() {
+        @Override
+        public String operationType() {
+            return CLUSTER_TYPE_CONNECT_S2I;
+        }
+
+        @Override
+        public String clusterType() {
+            return OP_UPDATE;
+        }
+
         @Override
         public Future<?> composite(String namespace, ClusterOperation<KafkaConnectS2ICluster> operation) {
             KafkaConnectS2ICluster connect = operation.cluster();

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperationsTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperationsTest.java
@@ -678,17 +678,17 @@ public class KafkaClusterOperationsTest {
                 mockServiceOps, mockSsOps,
                 mockPvcOps, mockPodOps, mockEndpointOps, mockDepOps) {
             @Override
-            public void create(String namespace, String name) {
+            public void create(String namespace, String name, Handler h) {
                 created.add(name);
                 async.countDown();
             }
             @Override
-            public void update(String namespace, String name) {
+            public void update(String namespace, String name, Handler h) {
                 updated.add(name);
                 async.countDown();
             }
             @Override
-            public void delete(String namespace, String name) {
+            public void delete(String namespace, String name, Handler h) {
                 deleted.add(name);
                 async.countDown();
             }


### PR DESCRIPTION
### Type of change

Refactoring to simplify the ACO

### Description

This PR reduces the number of overloaded create/update/delete methods in the ACO, replacing them with a single `abstract clusterType()` method. It also simplifies `execute()` putting methods on the `CompositeOperation` instead of relying on them being passed into the `execute()` method. This PR also highlights an existing "problem" with the ACO: That we're using the term `clusterType` two slightly different ways: In the create(),update() and delete() methods it refers to the type of the Strimzi cluster/component (kafka, connect, s2i), but in execute() it means the type of the subcomponent (in the kafka cluster case it could be kafka,zk,topicController). We should chose distinct names for these distinct concepts.

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Check coding style
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging

