### PR TITLE
Make operation timeout configurable - Closes #272

### DIFF
--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterControllerConfig.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterControllerConfig.java
@@ -19,30 +19,30 @@ public class ClusterControllerConfig {
 
     public static final String STRIMZI_NAMESPACE = "STRIMZI_NAMESPACE";
     public static final String STRIMZI_CONFIGMAP_LABELS = "STRIMZI_CONFIGMAP_LABELS";
-    public static final String STRIMZI_FULL_RECONCILIATION_INTERVAL = "STRIMZI_FULL_RECONCILIATION_INTERVAL";
-    public static final String STRIMZI_OPERATION_TIMEOUT = "STRIMZI_OPERATION_TIMEOUT";
+    public static final String STRIMZI_FULL_RECONCILIATION_INTERVAL_MS = "STRIMZI_FULL_RECONCILIATION_INTERVAL_MS";
+    public static final String STRIMZI_OPERATION_TIMEOUT_MS = "STRIMZI_OPERATION_TIMEOUT_MS";
 
-    public static final long DEFAULT_FULL_RECONCILIATION_INTERVAL = 120_000; // in ms (2 minutes)
-    public static final long DEFAULT_OPERATION_TIMEOUT = 60_000; // in ms (1 minute)
+    public static final long DEFAULT_FULL_RECONCILIATION_INTERVAL_MS = 120_000;
+    public static final long DEFAULT_OPERATION_TIMEOUT_MS = 60_000;
 
     private Map<String, String> labels;
     private Set<String> namespaces;
-    private long reconciliationInterval;
-    private long operationTimeout;
+    private long reconciliationIntervalMs;
+    private long operationTimeoutMs;
 
     /**
      * Constructor
      *
      * @param namespaces namespace in which the controller will run and create resources
      * @param labels    labels used for watching the cluster ConfigMap
-     * @param reconciliationInterval    specify every how many milliseconds the reconciliation runs
-     * @param operationTimeout    timeout for internal operations specified in milliseconds
+     * @param reconciliationIntervalMs    specify every how many milliseconds the reconciliation runs
+     * @param operationTimeoutMs    timeout for internal operations specified in milliseconds
      */
-    public ClusterControllerConfig(Set<String> namespaces, Map<String, String> labels, long reconciliationInterval, long operationTimeout) {
+    public ClusterControllerConfig(Set<String> namespaces, Map<String, String> labels, long reconciliationIntervalMs, long operationTimeoutMs) {
         this.namespaces = unmodifiableSet(new HashSet<>(namespaces));
         this.labels = labels;
-        this.reconciliationInterval = reconciliationInterval;
-        this.operationTimeout = operationTimeout;
+        this.reconciliationIntervalMs = reconciliationIntervalMs;
+        this.operationTimeoutMs = operationTimeoutMs;
     }
 
     /**
@@ -52,7 +52,7 @@ public class ClusterControllerConfig {
      * @param labels    labels used for watching the cluster ConfigMap
      */
     public ClusterControllerConfig(Set<String> namespaces, Map<String, String> labels) {
-        this(namespaces, labels, DEFAULT_FULL_RECONCILIATION_INTERVAL, DEFAULT_OPERATION_TIMEOUT);
+        this(namespaces, labels, DEFAULT_FULL_RECONCILIATION_INTERVAL_MS, DEFAULT_OPERATION_TIMEOUT_MS);
     }
 
     /**
@@ -75,16 +75,16 @@ public class ClusterControllerConfig {
             throw new IllegalArgumentException(ClusterControllerConfig.STRIMZI_CONFIGMAP_LABELS + " cannot be null");
         }
 
-        Long reconciliationInterval = DEFAULT_FULL_RECONCILIATION_INTERVAL;
-        String reconciliationIntervalEnvVar = map.get(ClusterControllerConfig.STRIMZI_FULL_RECONCILIATION_INTERVAL);
+        long reconciliationInterval = DEFAULT_FULL_RECONCILIATION_INTERVAL_MS;
+        String reconciliationIntervalEnvVar = map.get(ClusterControllerConfig.STRIMZI_FULL_RECONCILIATION_INTERVAL_MS);
         if (reconciliationIntervalEnvVar != null) {
-            reconciliationInterval = Long.valueOf(reconciliationIntervalEnvVar);
+            reconciliationInterval = Long.parseLong(reconciliationIntervalEnvVar);
         }
 
-        Long operationTimeout = DEFAULT_OPERATION_TIMEOUT;
-        String operationTimeoutEnvVar = map.get(ClusterControllerConfig.STRIMZI_OPERATION_TIMEOUT);
+        long operationTimeout = DEFAULT_OPERATION_TIMEOUT_MS;
+        String operationTimeoutEnvVar = map.get(ClusterControllerConfig.STRIMZI_OPERATION_TIMEOUT_MS);
         if (operationTimeoutEnvVar != null) {
-            operationTimeout = Long.valueOf(operationTimeoutEnvVar);
+            operationTimeout = Long.parseLong(operationTimeoutEnvVar);
         }
 
         Map<String, String> labelsMap = new HashMap<>();
@@ -124,15 +124,15 @@ public class ClusterControllerConfig {
     /**
      * @return  how many milliseconds the reconciliation runs
      */
-    public long getReconciliationInterval() {
-        return reconciliationInterval;
+    public long getReconciliationIntervalMs() {
+        return reconciliationIntervalMs;
     }
 
     /**
      * @return  how many milliseconds should we wait for Kubernetes operations
      */
-    public long getOperationTimeout() {
-        return operationTimeout;
+    public long getOperationTimeoutMs() {
+        return operationTimeoutMs;
     }
 
     @Override
@@ -140,7 +140,7 @@ public class ClusterControllerConfig {
         return "ClusterControllerConfig(" +
                 "namespaces=" + namespaces +
                 ",labels=" + labels +
-                ",reconciliationInterval=" + reconciliationInterval +
+                ",reconciliationIntervalMs=" + reconciliationIntervalMs +
                 ")";
     }
 }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/Main.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/Main.java
@@ -54,7 +54,7 @@ public class Main {
         EndpointOperations endpointOperations = new EndpointOperations(vertx, client);
 
         boolean isOpenShift = Boolean.TRUE.equals(client.isAdaptable(OpenShiftClient.class));
-        KafkaClusterOperations kafkaClusterOperations = new KafkaClusterOperations(vertx, isOpenShift, config.getOperationTimeout(), configMapOperations, serviceOperations, statefulSetOperations, pvcOperations, podOperations, endpointOperations, deploymentOperations);
+        KafkaClusterOperations kafkaClusterOperations = new KafkaClusterOperations(vertx, isOpenShift, config.getOperationTimeoutMs(), configMapOperations, serviceOperations, statefulSetOperations, pvcOperations, podOperations, endpointOperations, deploymentOperations);
         KafkaConnectClusterOperations kafkaConnectClusterOperations = new KafkaConnectClusterOperations(vertx, isOpenShift, configMapOperations, deploymentOperations, serviceOperations);
 
         DeploymentConfigOperations deploymentConfigOperations = null;
@@ -75,7 +75,7 @@ public class Main {
             futures.add(fut);
             ClusterController controller = new ClusterController(namespace,
                     config.getLabels(),
-                    config.getReconciliationInterval(),
+                    config.getReconciliationIntervalMs(),
                     client,
                     kafkaClusterOperations,
                     kafkaConnectClusterOperations,

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/Main.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/Main.java
@@ -43,6 +43,8 @@ public class Main {
     }
 
     static CompositeFuture run(Vertx vertx, KubernetesClient client, Map<String, String> env) {
+        ClusterControllerConfig config = ClusterControllerConfig.fromMap(env);
+
         ServiceOperations serviceOperations = new ServiceOperations(vertx, client);
         StatefulSetOperations statefulSetOperations = new StatefulSetOperations(vertx, client);
         ConfigMapOperations configMapOperations = new ConfigMapOperations(vertx, client);
@@ -52,7 +54,7 @@ public class Main {
         EndpointOperations endpointOperations = new EndpointOperations(vertx, client);
 
         boolean isOpenShift = Boolean.TRUE.equals(client.isAdaptable(OpenShiftClient.class));
-        KafkaClusterOperations kafkaClusterOperations = new KafkaClusterOperations(vertx, isOpenShift, configMapOperations, serviceOperations, statefulSetOperations, pvcOperations, podOperations, endpointOperations, deploymentOperations);
+        KafkaClusterOperations kafkaClusterOperations = new KafkaClusterOperations(vertx, isOpenShift, config.getOperationTimeout(), configMapOperations, serviceOperations, statefulSetOperations, pvcOperations, podOperations, endpointOperations, deploymentOperations);
         KafkaConnectClusterOperations kafkaConnectClusterOperations = new KafkaConnectClusterOperations(vertx, isOpenShift, configMapOperations, deploymentOperations, serviceOperations);
 
         DeploymentConfigOperations deploymentConfigOperations = null;
@@ -67,7 +69,6 @@ public class Main {
                 configMapOperations, deploymentConfigOperations,
                 serviceOperations, imagesStreamOperations, buildConfigOperations);
 
-        ClusterControllerConfig config = ClusterControllerConfig.fromMap(env);
         List<Future> futures = new ArrayList<>();
         for (String namespace : config.getNamespaces()) {
             Future<String> fut = Future.future();

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperations.java
@@ -42,7 +42,7 @@ public class KafkaClusterOperations extends AbstractClusterOperations<KafkaClust
     private static final String CLUSTER_TYPE_KAFKA = "kafka";
     private static final String CLUSTER_TYPE_TOPIC_CONTROLLER = "topic-controller";
 
-    private final long operationTimeout;
+    private final long operationTimeoutMs;
 
     private final StatefulSetOperations statefulSetOperations;
     private final ServiceOperations serviceOperations;
@@ -62,7 +62,7 @@ public class KafkaClusterOperations extends AbstractClusterOperations<KafkaClust
      * @param deploymentOperations For operating on Deployments
      */
     public KafkaClusterOperations(Vertx vertx, boolean isOpenShift,
-                                  long operationTimeout,
+                                  long operationTimeoutMs,
                                   ConfigMapOperations configMapOperations,
                                   ServiceOperations serviceOperations,
                                   StatefulSetOperations statefulSetOperations,
@@ -71,7 +71,7 @@ public class KafkaClusterOperations extends AbstractClusterOperations<KafkaClust
                                   EndpointOperations endpointOperations,
                                   DeploymentOperations deploymentOperations) {
         super(vertx, isOpenShift, "Kafka", configMapOperations);
-        this.operationTimeout = operationTimeout;
+        this.operationTimeoutMs = operationTimeoutMs;
         this.statefulSetOperations = statefulSetOperations;
         this.serviceOperations = serviceOperations;
         this.pvcOperations = pvcOperations;
@@ -138,21 +138,21 @@ public class KafkaClusterOperations extends AbstractClusterOperations<KafkaClust
 
             CompositeFuture
                 .join(result)
-                .compose(res -> statefulSetOperations.readiness(namespace, kafka.getName(), 1_000, operationTimeout))
+                .compose(res -> statefulSetOperations.readiness(namespace, kafka.getName(), 1_000, operationTimeoutMs))
                 .compose(res -> {
                     List<Future> waitPodResult = new ArrayList<>(kafka.getReplicas());
 
                     for (int i = 0; i < kafka.getReplicas(); i++) {
                         String podName = kafka.getPodName(i);
-                        waitPodResult.add(podOperations.readiness(namespace, podName, 1_000, operationTimeout));
+                        waitPodResult.add(podOperations.readiness(namespace, podName, 1_000, operationTimeoutMs));
                     }
 
                     return CompositeFuture.join(waitPodResult);
                 })
                 .compose(res -> {
                     List<Future> waitEndpointResult = new ArrayList<>(2);
-                    waitEndpointResult.add(endpointOperations.readiness(namespace, kafka.getName(), 1_000, operationTimeout));
-                    waitEndpointResult.add(endpointOperations.readiness(namespace, kafka.getHeadlessName(), 1_000, operationTimeout));
+                    waitEndpointResult.add(endpointOperations.readiness(namespace, kafka.getName(), 1_000, operationTimeoutMs));
+                    waitEndpointResult.add(endpointOperations.readiness(namespace, kafka.getHeadlessName(), 1_000, operationTimeoutMs));
                     return CompositeFuture.join(waitEndpointResult);
                 })
                 .compose(res -> {
@@ -199,21 +199,21 @@ public class KafkaClusterOperations extends AbstractClusterOperations<KafkaClust
 
             CompositeFuture
                 .join(createResult)
-                .compose(res -> statefulSetOperations.readiness(namespace, zk.getName(), 1_000, operationTimeout))
+                .compose(res -> statefulSetOperations.readiness(namespace, zk.getName(), 1_000, operationTimeoutMs))
                 .compose(res -> {
                     List<Future> waitPodResult = new ArrayList<>(zk.getReplicas());
 
                     for (int i = 0; i < zk.getReplicas(); i++) {
                         String podName = zk.getPodName(i);
-                        waitPodResult.add(podOperations.readiness(namespace, podName, 1_000, operationTimeout));
+                        waitPodResult.add(podOperations.readiness(namespace, podName, 1_000, operationTimeoutMs));
                     }
 
                     return CompositeFuture.join(waitPodResult);
                 })
                 .compose(res -> {
                     List<Future> waitEndpointResult = new ArrayList<>(2);
-                    waitEndpointResult.add(endpointOperations.readiness(namespace, zk.getName(), 1_000, operationTimeout));
-                    waitEndpointResult.add(endpointOperations.readiness(namespace, zk.getHeadlessName(), 1_000, operationTimeout));
+                    waitEndpointResult.add(endpointOperations.readiness(namespace, zk.getName(), 1_000, operationTimeoutMs));
+                    waitEndpointResult.add(endpointOperations.readiness(namespace, zk.getHeadlessName(), 1_000, operationTimeoutMs));
                     return CompositeFuture.join(waitEndpointResult);
                 })
                 .compose(res -> {

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/TopicController.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/TopicController.java
@@ -57,7 +57,7 @@ public class TopicController extends AbstractCluster {
     public static final String KEY_KAFKA_BOOTSTRAP_SERVERS = "STRIMZI_KAFKA_BOOTSTRAP_SERVERS";
     public static final String KEY_ZOOKEEPER_CONNECT = "STRIMZI_ZOOKEEPER_CONNECT";
     public static final String KEY_NAMESPACE = "STRIMZI_NAMESPACE";
-    public static final String KEY_FULL_RECONCILIATION_INTERVAL = "STRIMZI_FULL_RECONCILIATION_INTERVAL_MS";
+    public static final String KEY_FULL_RECONCILIATION_INTERVAL = "STRIMZI_FULL_RECONCILIATION_INTERVAL";
     public static final String KEY_ZOOKEEPER_SESSION_TIMEOUT = "STRIMZI_ZOOKEEPER_SESSION_TIMEOUT";
 
     // Kafka bootstrap servers and Zookeeper nodes can't be specified in the JSON

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/TopicController.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/TopicController.java
@@ -57,7 +57,7 @@ public class TopicController extends AbstractCluster {
     public static final String KEY_KAFKA_BOOTSTRAP_SERVERS = "STRIMZI_KAFKA_BOOTSTRAP_SERVERS";
     public static final String KEY_ZOOKEEPER_CONNECT = "STRIMZI_ZOOKEEPER_CONNECT";
     public static final String KEY_NAMESPACE = "STRIMZI_NAMESPACE";
-    public static final String KEY_FULL_RECONCILIATION_INTERVAL = "STRIMZI_FULL_RECONCILIATION_INTERVAL";
+    public static final String KEY_FULL_RECONCILIATION_INTERVAL = "STRIMZI_FULL_RECONCILIATION_INTERVAL_MS";
     public static final String KEY_ZOOKEEPER_SESSION_TIMEOUT = "STRIMZI_ZOOKEEPER_SESSION_TIMEOUT";
 
     // Kafka bootstrap servers and Zookeeper nodes can't be specified in the JSON

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/ClusterControllerConfigTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/ClusterControllerConfigTest.java
@@ -25,8 +25,8 @@ public class ClusterControllerConfigTest {
 
         envVars.put(ClusterControllerConfig.STRIMZI_NAMESPACE, "namespace");
         envVars.put(ClusterControllerConfig.STRIMZI_CONFIGMAP_LABELS, "strimzi.io/kind=cluster");
-        envVars.put(ClusterControllerConfig.STRIMZI_FULL_RECONCILIATION_INTERVAL, "30000");
-        envVars.put(ClusterControllerConfig.STRIMZI_OPERATION_TIMEOUT, "30000");
+        envVars.put(ClusterControllerConfig.STRIMZI_FULL_RECONCILIATION_INTERVAL_MS, "30000");
+        envVars.put(ClusterControllerConfig.STRIMZI_OPERATION_TIMEOUT_MS, "30000");
     }
 
     @Test
@@ -36,8 +36,8 @@ public class ClusterControllerConfigTest {
 
         assertEquals(singleton("namespace"), config.getNamespaces());
         assertEquals(labels, config.getLabels());
-        assertEquals(ClusterControllerConfig.DEFAULT_FULL_RECONCILIATION_INTERVAL, config.getReconciliationInterval());
-        assertEquals(ClusterControllerConfig.DEFAULT_OPERATION_TIMEOUT, config.getOperationTimeout());
+        assertEquals(ClusterControllerConfig.DEFAULT_FULL_RECONCILIATION_INTERVAL_MS, config.getReconciliationIntervalMs());
+        assertEquals(ClusterControllerConfig.DEFAULT_OPERATION_TIMEOUT_MS, config.getOperationTimeoutMs());
     }
 
     @Test
@@ -47,8 +47,8 @@ public class ClusterControllerConfigTest {
 
         assertEquals(singleton("namespace"), config.getNamespaces());
         assertEquals(labels, config.getLabels());
-        assertEquals(60_000, config.getReconciliationInterval());
-        assertEquals(30_000, config.getOperationTimeout());
+        assertEquals(60_000, config.getReconciliationIntervalMs());
+        assertEquals(30_000, config.getOperationTimeoutMs());
     }
 
     @Test
@@ -58,8 +58,8 @@ public class ClusterControllerConfigTest {
 
         assertEquals(singleton("namespace"), config.getNamespaces());
         assertEquals(labels, config.getLabels());
-        assertEquals(30_000, config.getReconciliationInterval());
-        assertEquals(30_000, config.getOperationTimeout());
+        assertEquals(30_000, config.getReconciliationIntervalMs());
+        assertEquals(30_000, config.getOperationTimeoutMs());
     }
 
     @Test
@@ -73,8 +73,8 @@ public class ClusterControllerConfigTest {
 
         assertEquals(singleton("namespace"), config.getNamespaces());
         assertEquals(labels, config.getLabels());
-        assertEquals(ClusterControllerConfig.DEFAULT_FULL_RECONCILIATION_INTERVAL, config.getReconciliationInterval());
-        assertEquals(ClusterControllerConfig.DEFAULT_OPERATION_TIMEOUT, config.getOperationTimeout());
+        assertEquals(ClusterControllerConfig.DEFAULT_FULL_RECONCILIATION_INTERVAL_MS, config.getReconciliationIntervalMs());
+        assertEquals(ClusterControllerConfig.DEFAULT_OPERATION_TIMEOUT_MS, config.getOperationTimeoutMs());
     }
 
     @Test
@@ -86,8 +86,8 @@ public class ClusterControllerConfigTest {
         ClusterControllerConfig config = ClusterControllerConfig.fromMap(envVars);
         assertEquals(new HashSet<>(asList("foo", "bar", "baz")), config.getNamespaces());
         assertEquals(labels, config.getLabels());
-        assertEquals(30_000, config.getReconciliationInterval());
-        assertEquals(30_000, config.getOperationTimeout());
+        assertEquals(30_000, config.getReconciliationIntervalMs());
+        assertEquals(30_000, config.getOperationTimeoutMs());
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/ClusterControllerConfigTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/ClusterControllerConfigTest.java
@@ -18,7 +18,7 @@ import static org.junit.Assert.assertEquals;
 public class ClusterControllerConfigTest {
 
     private static Map<String, String> labels = new HashMap<>(1);
-    private static Map<String, String> envVars = new HashMap<>(3);
+    private static Map<String, String> envVars = new HashMap<>(4);
 
     static {
         labels.put("strimzi.io/kind", "cluster");
@@ -26,6 +26,7 @@ public class ClusterControllerConfigTest {
         envVars.put(ClusterControllerConfig.STRIMZI_NAMESPACE, "namespace");
         envVars.put(ClusterControllerConfig.STRIMZI_CONFIGMAP_LABELS, "strimzi.io/kind=cluster");
         envVars.put(ClusterControllerConfig.STRIMZI_FULL_RECONCILIATION_INTERVAL, "30000");
+        envVars.put(ClusterControllerConfig.STRIMZI_OPERATION_TIMEOUT, "30000");
     }
 
     @Test
@@ -36,16 +37,18 @@ public class ClusterControllerConfigTest {
         assertEquals(singleton("namespace"), config.getNamespaces());
         assertEquals(labels, config.getLabels());
         assertEquals(ClusterControllerConfig.DEFAULT_FULL_RECONCILIATION_INTERVAL, config.getReconciliationInterval());
+        assertEquals(ClusterControllerConfig.DEFAULT_OPERATION_TIMEOUT, config.getOperationTimeout());
     }
 
     @Test
     public void testReconciliationInterval() {
 
-        ClusterControllerConfig config = new ClusterControllerConfig(singleton("namespace"), labels, 60000);
+        ClusterControllerConfig config = new ClusterControllerConfig(singleton("namespace"), labels, 60_000, 30_000);
 
         assertEquals(singleton("namespace"), config.getNamespaces());
         assertEquals(labels, config.getLabels());
         assertEquals(60_000, config.getReconciliationInterval());
+        assertEquals(30_000, config.getOperationTimeout());
     }
 
     @Test
@@ -56,6 +59,7 @@ public class ClusterControllerConfigTest {
         assertEquals(singleton("namespace"), config.getNamespaces());
         assertEquals(labels, config.getLabels());
         assertEquals(30_000, config.getReconciliationInterval());
+        assertEquals(30_000, config.getOperationTimeout());
     }
 
     @Test
@@ -70,6 +74,7 @@ public class ClusterControllerConfigTest {
         assertEquals(singleton("namespace"), config.getNamespaces());
         assertEquals(labels, config.getLabels());
         assertEquals(ClusterControllerConfig.DEFAULT_FULL_RECONCILIATION_INTERVAL, config.getReconciliationInterval());
+        assertEquals(ClusterControllerConfig.DEFAULT_OPERATION_TIMEOUT, config.getOperationTimeout());
     }
 
     @Test
@@ -81,7 +86,8 @@ public class ClusterControllerConfigTest {
         ClusterControllerConfig config = ClusterControllerConfig.fromMap(envVars);
         assertEquals(new HashSet<>(asList("foo", "bar", "baz")), config.getNamespaces());
         assertEquals(labels, config.getLabels());
-        assertEquals(30000, config.getReconciliationInterval());
+        assertEquals(30_000, config.getReconciliationInterval());
+        assertEquals(30_000, config.getOperationTimeout());
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/ClusterControllerTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/ClusterControllerTest.java
@@ -87,7 +87,7 @@ public class ClusterControllerTest {
         Map<String, String> env = new HashMap<>();
         env.put(ClusterControllerConfig.STRIMZI_NAMESPACE, namespaces);
         env.put(ClusterControllerConfig.STRIMZI_CONFIGMAP_LABELS, STRIMZI_IO_KIND_CLUSTER);
-        env.put(ClusterControllerConfig.STRIMZI_FULL_RECONCILIATION_INTERVAL, "120000");
+        env.put(ClusterControllerConfig.STRIMZI_FULL_RECONCILIATION_INTERVAL_MS, "120000");
         Main.run(vertx, client, env).setHandler(ar -> {
             context.assertNull(ar.cause(), "Expected all verticles to start OK");
             async.complete();

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperationsTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperationsTest.java
@@ -188,7 +188,7 @@ public class KafkaClusterOperationsTest {
 
 
         KafkaClusterOperations ops = new KafkaClusterOperations(vertx, openShift,
-                ClusterControllerConfig.DEFAULT_OPERATION_TIMEOUT,
+                ClusterControllerConfig.DEFAULT_OPERATION_TIMEOUT_MS,
                 mockCmOps,
                 mockServiceOps, mockSsOps,
                 mockPvcOps, mockPodOps, mockEndpointOps, mockDepOps);
@@ -288,7 +288,7 @@ public class KafkaClusterOperationsTest {
         }
 
         KafkaClusterOperations ops = new KafkaClusterOperations(vertx, openShift,
-                ClusterControllerConfig.DEFAULT_OPERATION_TIMEOUT,
+                ClusterControllerConfig.DEFAULT_OPERATION_TIMEOUT_MS,
                 mockCmOps,
                 mockServiceOps, mockSsOps,
                 mockPvcOps,
@@ -540,7 +540,7 @@ public class KafkaClusterOperationsTest {
         when(mockDepOps.patch(anyString(), depCaptor.capture(), any())).thenReturn(Future.succeededFuture());
 
         KafkaClusterOperations ops = new KafkaClusterOperations(vertx, openShift,
-                ClusterControllerConfig.DEFAULT_OPERATION_TIMEOUT,
+                ClusterControllerConfig.DEFAULT_OPERATION_TIMEOUT_MS,
                 mockCmOps,
                 mockServiceOps, mockSsOps,
                 mockPvcOps, mockPodOps, mockEndpointOps, mockDepOps);
@@ -672,7 +672,7 @@ public class KafkaClusterOperationsTest {
         Set<String> deleted = new HashSet<>();
 
         KafkaClusterOperations ops = new KafkaClusterOperations(vertx, openShift,
-                ClusterControllerConfig.DEFAULT_OPERATION_TIMEOUT,
+                ClusterControllerConfig.DEFAULT_OPERATION_TIMEOUT_MS,
                 mockCmOps,
                 mockServiceOps, mockSsOps,
                 mockPvcOps, mockPodOps, mockEndpointOps, mockDepOps) {

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperationsTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperationsTest.java
@@ -10,6 +10,7 @@ import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.extensions.Deployment;
 import io.fabric8.kubernetes.api.model.extensions.StatefulSet;
 import io.strimzi.controller.cluster.ClusterController;
+import io.strimzi.controller.cluster.ClusterControllerConfig;
 import io.strimzi.controller.cluster.ResourceUtils;
 import io.strimzi.controller.cluster.operations.resource.ConfigMapOperations;
 import io.strimzi.controller.cluster.operations.resource.DeploymentOperations;
@@ -187,6 +188,7 @@ public class KafkaClusterOperationsTest {
 
 
         KafkaClusterOperations ops = new KafkaClusterOperations(vertx, openShift,
+                ClusterControllerConfig.DEFAULT_OPERATION_TIMEOUT,
                 mockCmOps,
                 mockServiceOps, mockSsOps,
                 mockPvcOps, mockPodOps, mockEndpointOps, mockDepOps);
@@ -286,6 +288,7 @@ public class KafkaClusterOperationsTest {
         }
 
         KafkaClusterOperations ops = new KafkaClusterOperations(vertx, openShift,
+                ClusterControllerConfig.DEFAULT_OPERATION_TIMEOUT,
                 mockCmOps,
                 mockServiceOps, mockSsOps,
                 mockPvcOps,
@@ -537,6 +540,7 @@ public class KafkaClusterOperationsTest {
         when(mockDepOps.patch(anyString(), depCaptor.capture(), any())).thenReturn(Future.succeededFuture());
 
         KafkaClusterOperations ops = new KafkaClusterOperations(vertx, openShift,
+                ClusterControllerConfig.DEFAULT_OPERATION_TIMEOUT,
                 mockCmOps,
                 mockServiceOps, mockSsOps,
                 mockPvcOps, mockPodOps, mockEndpointOps, mockDepOps);
@@ -668,6 +672,7 @@ public class KafkaClusterOperationsTest {
         Set<String> deleted = new HashSet<>();
 
         KafkaClusterOperations ops = new KafkaClusterOperations(vertx, openShift,
+                ClusterControllerConfig.DEFAULT_OPERATION_TIMEOUT,
                 mockCmOps,
                 mockServiceOps, mockSsOps,
                 mockPvcOps, mockPodOps, mockEndpointOps, mockDepOps) {

--- a/documentation/adoc/cluster-controller.adoc
+++ b/documentation/adoc/cluster-controller.adoc
@@ -390,6 +390,9 @@ Default: 120000 ms
 should operate in. This is a required environment variable, but the example YAML resources
 supplied with Strimzi use the namespace in which the controller itself is deployed as a
 default value. See the following section.
+* `STRIMZI_OPERATION_TIMEOUT` : Timeout for internal operations specified in milliseconds. This value should be
+increased when using Strimzi on clusters where regular Kubernetes operations take longer than usually (for example
+because of slow downloading of Docker images etc.). Default value is 60000 ms.
 
 [[multi-namespace]]
 ==== Watching multiple namespaces

--- a/documentation/adoc/cluster-controller.adoc
+++ b/documentation/adoc/cluster-controller.adoc
@@ -246,13 +246,13 @@ The configurable fields are the following :
 * `image`: Docker image to use for the topic controller. Default is `strimzi/topic-controller:latest`
 * `namespace`: the Kubernetes namespace (OpenShift project) in which the topic controller watches for topic ConfigMaps.
 Default is the namespace where the topic controller is running
-* `reconciliationInterval`: the interval between periodic reconciliations. Default is "15 minutes"
+* `reconciliationIntervalMs`: the interval between periodic reconciliations. Default is "15 minutes"
 * `zookeeperSessionTimeout`: the Zookeeper session timeout. Default is "20 seconds"
 
 .Example Topic Controller JSON configuration
 [source,json]
 ----
-{ "reconciliationInterval": "10 minutes", "zookeeperSessionTimeout": "10 seconds" }
+{ "reconciliationIntervalMs": "10 minutes", "zookeeperSessionTimeout": "10 seconds" }
 ----
 
 More information about these configuration parameters in the related <<Topic Controller>> documentation page.
@@ -382,15 +382,18 @@ include::../../examples/install/cluster-controller/03-role-binding.yaml[]
 
 The controller itself can be configured through the following environment variables.
 
-* `STRIMZI_CONFIGMAP_LABELS`: the Kubernetes/OpenShift label selector used to identify ConfigMaps to be managed by the controller.
-Default: `strimzi.io/kind=cluster`.  
-* `STRIMZI_FULL_RECONCILIATION_INTERVAL` : the interval between periodic reconciliations.
+`STRIMZI_CONFIGMAP_LABELS`:: the Kubernetes/OpenShift label selector used to identify ConfigMaps to be managed by the controller.
+Default: `strimzi.io/kind=cluster`.
+
+`STRIMZI_FULL_RECONCILIATION_INTERVAL_MS`:: the interval between periodic reconciliations.
 Default: 120000 ms
- * `STRIMZI_NAMESPACE`: A comma-separated list of namespaces that the controller
+
+`STRIMZI_NAMESPACE`:: A comma-separated list of namespaces that the controller
 should operate in. This is a required environment variable, but the example YAML resources
 supplied with Strimzi use the namespace in which the controller itself is deployed as a
 default value. See the following section.
-* `STRIMZI_OPERATION_TIMEOUT` : Timeout for internal operations specified in milliseconds. This value should be
+
+`STRIMZI_OPERATION_TIMEOUT_MS`:: Timeout for internal operations specified in milliseconds. This value should be
 increased when using Strimzi on clusters where regular Kubernetes operations take longer than usually (for example
 because of slow downloading of Docker images etc.). Default value is 60000 ms.
 

--- a/documentation/adoc/cluster-controller.adoc
+++ b/documentation/adoc/cluster-controller.adoc
@@ -252,7 +252,7 @@ Default is the namespace where the topic controller is running
 .Example Topic Controller JSON configuration
 [source,json]
 ----
-{ "reconciliationIntervalMs": "10 minutes", "zookeeperSessionTimeout": "10 seconds" }
+{ "reconciliationInterval": "10 minutes", "zookeeperSessionTimeout": "10 seconds" }
 ----
 
 More information about these configuration parameters in the related <<Topic Controller>> documentation page.

--- a/examples/install/cluster-controller/04-deployment.yaml
+++ b/examples/install/cluster-controller/04-deployment.yaml
@@ -20,6 +20,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: STRIMZI_FULL_RECONCILIATION_INTERVAL
+              value: "120000"
+            - name: STRIMZI_OPERATION_TIMEOUT
+              value: "60000"
           livenessProbe:
             httpGet:
               path: /healthy

--- a/examples/install/cluster-controller/04-deployment.yaml
+++ b/examples/install/cluster-controller/04-deployment.yaml
@@ -20,9 +20,9 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            - name: STRIMZI_FULL_RECONCILIATION_INTERVAL
+            - name: STRIMZI_FULL_RECONCILIATION_INTERVAL_MS
               value: "120000"
-            - name: STRIMZI_OPERATION_TIMEOUT
+            - name: STRIMZI_OPERATION_TIMEOUT_MS
               value: "60000"
           livenessProbe:
             httpGet:


### PR DESCRIPTION
### Type of change

- ~~Bugfix~~
- Enhancement / new feature
- ~~Refactoring~~

### Description

This PR makes it possible to configure the Operation timeout. This option is currently used only in KafkaClusteroperation where we use the `readiness` method. But we should over time use it also in other clusters. When that is the case, it should move to `AbstractClusterOperation` . But right now this was not needed.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging

