### PR TITLE
Release the lock only for exception or when the handler completes

### DIFF
--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/AbstractClusterOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/AbstractClusterOperations.java
@@ -253,6 +253,7 @@ public abstract class AbstractClusterOperations<C extends AbstractCluster,
                                 } else {
                                     log.error("Failed to update {} cluster {}.", clusterDescription, nameFromCm);
                                 }
+                                lock.release();
                             });
                         } else {
                             log.info("Reconciliation: {} cluster {} should be created", clusterDescription, cm.getMetadata().getName());
@@ -263,6 +264,7 @@ public abstract class AbstractClusterOperations<C extends AbstractCluster,
                                 } else {
                                     log.error("Failed to add {} cluster {}.", clusterDescription, nameFromCm);
                                 }
+                                lock.release();
                             });
                         }
                     } else if (resources.size() > 0) {
@@ -276,16 +278,14 @@ public abstract class AbstractClusterOperations<C extends AbstractCluster,
                                 } else {
                                     log.error("Failed to delete {} cluster {} in namespace {}", clusterDescription, nameFromResource, namespace);
                                 }
+                                lock.release();
                             });
                         }
                     }
-
                 } catch (Throwable ex) {
                     log.error("Error while reconciling {} cluster", clusterDescription, ex);
-                } finally {
                     lock.release();
                 }
-
             } else {
                 log.error("Failed to acquire lock for {} cluster {}", clusterType, lockName);
             }

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperationsTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperationsTest.java
@@ -617,12 +617,6 @@ public class KafkaClusterOperationsTest {
 
     @Test
     public void testReconcile(TestContext context) {
-        ConfigMap clusterCm = getConfigMap("bar");
-        reconcileCluster(context, getConfigMap("bar"), clusterCm);
-    }
-
-    private void reconcileCluster(TestContext context, ConfigMap originalCm, ConfigMap clusterCm) {
-
         Async async = context.async(3);
 
         // create CM, Service, headless service, statefulset
@@ -634,7 +628,7 @@ public class KafkaClusterOperationsTest {
         EndpointOperations mockEndpointOps = mock(EndpointOperations.class);
         DeploymentOperations mockDepOps = mock(DeploymentOperations.class);
 
-        String clusterCmNamespace = clusterCm.getMetadata().getNamespace();
+        String clusterCmNamespace = "myNamespace";
 
         ConfigMap foo = getConfigMap("foo");
         ConfigMap bar = getConfigMap("bar");
@@ -681,19 +675,21 @@ public class KafkaClusterOperationsTest {
             public void create(String namespace, String name, Handler h) {
                 created.add(name);
                 async.countDown();
+                h.handle(Future.succeededFuture());
             }
             @Override
             public void update(String namespace, String name, Handler h) {
                 updated.add(name);
                 async.countDown();
+                h.handle(Future.succeededFuture());
             }
             @Override
             public void delete(String namespace, String name, Handler h) {
                 deleted.add(name);
                 async.countDown();
+                h.handle(Future.succeededFuture());
             }
         };
-
 
         // Now try to reconcile all the Kafka clusters
         ops.reconcileAll(clusterCmNamespace, Collections.emptyMap());
@@ -704,6 +700,4 @@ public class KafkaClusterOperationsTest {
         context.assertEquals(singleton("bar"), updated);
         context.assertEquals(singleton("baz"), deleted);
     }
-
-
 }

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectClusterOperationsTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectClusterOperationsTest.java
@@ -499,16 +499,19 @@ public class KafkaConnectClusterOperationsTest {
             public void create(String namespace, String name, Handler h) {
                 created.add(name);
                 async.countDown();
+                h.handle(Future.succeededFuture());
             }
             @Override
             public void update(String namespace, String name, Handler h) {
                 updated.add(name);
                 async.countDown();
+                h.handle(Future.succeededFuture());
             }
             @Override
             public void delete(String namespace, String name, Handler h) {
                 deleted.add(name);
                 async.countDown();
+                h.handle(Future.succeededFuture());
             }
         };
 

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectS2IClusterOperationsTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectS2IClusterOperationsTest.java
@@ -681,16 +681,19 @@ public class KafkaConnectS2IClusterOperationsTest {
             public void create(String namespace, String name, Handler h) {
                 created.add(name);
                 async.countDown();
+                h.handle(Future.succeededFuture());
             }
             @Override
             public void update(String namespace, String name, Handler h) {
                 updated.add(name);
                 async.countDown();
+                h.handle(Future.succeededFuture());
             }
             @Override
             public void delete(String namespace, String name, Handler h) {
                 deleted.add(name);
                 async.countDown();
+                h.handle(Future.succeededFuture());
             }
         };
 


### PR DESCRIPTION
### Type of change

- Bugfix
- ~~Enhancement / new feature~~
- ~~Refactoring~~

### Description

This PR move the release of the lock in `reconcile` method either to the exception handler or into the handlers of the individual operations (`create`, `delete`, ...). It also fixes the tests to work even when the locks are properly handled.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging

