### PR TITLE
Failing to acquire lock should throw only a warning

### DIFF
--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/AbstractClusterOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/AbstractClusterOperations.java
@@ -287,7 +287,7 @@ public abstract class AbstractClusterOperations<C extends AbstractCluster,
                 }
 
             } else {
-                log.error("Failed to acquire lock for {} cluster {}", clusterType, lockName);
+                log.warn("Failed to acquire lock for {} cluster {}.", clusterType, lockName);
             }
         });
     }

--- a/documentation/adoc/docu.adoc
+++ b/documentation/adoc/docu.adoc
@@ -28,4 +28,6 @@ include::cluster-controller.adoc[]
 
 include::topic-controller.adoc[]
 
+include::faq.adoc[]
+
 include::appendix_deploying_kubernetes_openshift_cluster.adoc[]

--- a/documentation/adoc/faq.adoc
+++ b/documentation/adoc/faq.adoc
@@ -1,0 +1,31 @@
+[appendix]
+== Frequently Asked Questions
+
+=== Cluster Controller
+
+==== Log contains warnings about failing to acquire lock
+
+For each cluster, the Cluster Controller always executes only one operation at a time. Cluster Controller is using locks
+to make sure that there are never two parallel operations running for the same cluster. In case an operation requires
+more time to complete, other operations will wait until it is completed and the lock is released.
+
+INFO:: Examples of cluster operations are _cluster creation_, _rolling update_, _scale down_ or _scale up_ etc.
+
+If the waiting for the lock takes too much time, the operation timeouts and following warning message will be printed to
+the log:
+
+[source]
+---
+2018-03-04 17:09:24 WARNING AbstractClusterOperations:290 - Failed to acquire lock for kafka cluster lock::kafka::myproject::my-cluster
+---
+
+Depending on the exact configuration of `STRIMZI_FULL_RECONCILIATION_INTERVAL` and `STRIMZI_OPERATION_TIMEOUT`, this
+warning message may appear regularly without indicating any problems. The operations which time out will be picked up by
+the next periodic reconciliation. It will try to acquire the lock again and execute.
+
+Should this message appear periodically even in situation when there should be no other operations running for given
+cluster, it might indicate that due to some error the lock was not properly released. In such case it is recommended to
+restart the cluster controller.
+
+
+

--- a/documentation/adoc/faq.adoc
+++ b/documentation/adoc/faq.adoc
@@ -5,13 +5,13 @@
 
 ==== Log contains warnings about failing to acquire lock
 
-For each cluster, the Cluster Controller always executes only one operation at a time. Cluster Controller is using locks
+For each cluster, the Cluster Controller always executes only one operation at a time. The Cluster Controller uses locks
 to make sure that there are never two parallel operations running for the same cluster. In case an operation requires
 more time to complete, other operations will wait until it is completed and the lock is released.
 
 INFO:: Examples of cluster operations are _cluster creation_, _rolling update_, _scale down_ or _scale up_ etc.
 
-If the waiting for the lock takes too much time, the operation timeouts and following warning message will be printed to
+If the wait for the lock takes too long, the operation times out and the following warning message will be printed to
 the log:
 
 [source]
@@ -23,8 +23,8 @@ Depending on the exact configuration of `STRIMZI_FULL_RECONCILIATION_INTERVAL` a
 warning message may appear regularly without indicating any problems. The operations which time out will be picked up by
 the next periodic reconciliation. It will try to acquire the lock again and execute.
 
-Should this message appear periodically even in situation when there should be no other operations running for given
-cluster, it might indicate that due to some error the lock was not properly released. In such case it is recommended to
+Should this message appear periodically even in situations when there should be no other operations running for a given
+cluster, it might indicate that due to some error the lock was not properly released. In such cases it is recommended to
 restart the cluster controller.
 
 


### PR DESCRIPTION
### Type of change

- ~~Bugfix~~
- Enhancement / new feature
- ~~Refactoring~~

### Description

When we fail to acquire the lock in `reconcile`, it usually simply means that other operation is running and needs more time. Therefore we should not print an error message but only a warning. This PR changes the log level and additionally adds FAQ section to the documentation which explains more details about this warning.

Grammar edits to the documentation should go directly into the branch

### Checklist

- [x] Update documentation
