### PR TITLE
Controllers should use Recreate update strategy instead of RollingUpdate

### DIFF
--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/AbstractCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/AbstractCluster.java
@@ -13,7 +13,6 @@ import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.ContainerPort;
 import io.fabric8.kubernetes.api.model.ContainerPortBuilder;
 import io.fabric8.kubernetes.api.model.EnvVar;
-import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaimBuilder;
@@ -32,8 +31,7 @@ import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
 import io.fabric8.kubernetes.api.model.extensions.Deployment;
 import io.fabric8.kubernetes.api.model.extensions.DeploymentBuilder;
-import io.fabric8.kubernetes.api.model.extensions.DeploymentStrategyBuilder;
-import io.fabric8.kubernetes.api.model.extensions.RollingUpdateDeploymentBuilder;
+import io.fabric8.kubernetes.api.model.extensions.DeploymentStrategy;
 import io.fabric8.kubernetes.api.model.extensions.StatefulSet;
 import io.fabric8.kubernetes.api.model.extensions.StatefulSetBuilder;
 import io.fabric8.kubernetes.api.model.extensions.StatefulSetUpdateStrategyBuilder;
@@ -476,6 +474,7 @@ public abstract class AbstractCluster {
             List<ContainerPort> ports,
             Probe livenessProbe,
             Probe readinessProbe,
+            DeploymentStrategy updateStrategy,
             Map<String, String> deploymentAnnotations,
             Map<String, String> podAnnotations) {
 
@@ -496,7 +495,7 @@ public abstract class AbstractCluster {
                 .withAnnotations(deploymentAnnotations)
                 .endMetadata()
                 .withNewSpec()
-                .withStrategy(new DeploymentStrategyBuilder().withType("RollingUpdate").withRollingUpdate(new RollingUpdateDeploymentBuilder().withMaxSurge(new IntOrString(1)).withMaxUnavailable(new IntOrString(0)).build()).build())
+                .withStrategy(updateStrategy)
                 .withReplicas(replicas)
                 .withNewTemplate()
                 .withNewMetadata()

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/KafkaConnectS2ICluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/KafkaConnectS2ICluster.java
@@ -8,7 +8,10 @@ import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.ObjectReference;
+import io.fabric8.openshift.api.model.DeploymentStrategy;
+import io.fabric8.openshift.api.model.DeploymentStrategyBuilder;
 import io.fabric8.openshift.api.model.BinaryBuildSource;
 import io.fabric8.openshift.api.model.BuildConfig;
 import io.fabric8.openshift.api.model.BuildConfigBuilder;
@@ -231,6 +234,14 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
                 .endImageChangeParams()
                 .build();
 
+        DeploymentStrategy updateStrategy = new DeploymentStrategyBuilder()
+                .withType("Rolling")
+                .withNewRollingParams()
+                    .withMaxSurge(new IntOrString(1))
+                    .withMaxUnavailable(new IntOrString(0))
+                .endRollingParams()
+                .build();
+
         DeploymentConfig dc = new DeploymentConfigBuilder()
                 .withNewMetadata()
                     .withName(name)
@@ -248,6 +259,7 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
                         .endSpec()
                     .endTemplate()
                     .withTriggers(configChangeTrigger, imageChangeTrigger)
+                .withStrategy(updateStrategy)
                 .endSpec()
                 .build();
 

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/TopicController.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/TopicController.java
@@ -9,6 +9,8 @@ import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 import io.fabric8.kubernetes.api.model.extensions.Deployment;
+import io.fabric8.kubernetes.api.model.extensions.DeploymentStrategy;
+import io.fabric8.kubernetes.api.model.extensions.DeploymentStrategyBuilder;
 import io.strimzi.controller.cluster.ClusterController;
 import io.vertx.core.json.JsonObject;
 
@@ -289,11 +291,15 @@ public class TopicController extends AbstractCluster {
     }
 
     public Deployment generateDeployment() {
+        DeploymentStrategy updateStrategy = new DeploymentStrategyBuilder()
+                .withType("Recreate")
+                .build();
 
         return createDeployment(
                 Collections.singletonList(createContainerPort(HEALTHCHECK_PORT_NAME, HEALTHCHECK_PORT, "TCP")),
                 createHttpProbe(healthCheckPath + "healthy", HEALTHCHECK_PORT_NAME, DEFAULT_HEALTHCHECK_DELAY, DEFAULT_HEALTHCHECK_TIMEOUT),
                 createHttpProbe(healthCheckPath + "ready", HEALTHCHECK_PORT_NAME, DEFAULT_HEALTHCHECK_DELAY, DEFAULT_HEALTHCHECK_TIMEOUT),
+                updateStrategy,
                 Collections.emptyMap(),
                 Collections.emptyMap());
     }

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/resources/KafkaConnectClusterTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/resources/KafkaConnectClusterTest.java
@@ -359,6 +359,9 @@ public class KafkaConnectClusterTest {
         assertEquals(new Integer(KafkaConnectCluster.REST_API_PORT), dep.getSpec().getTemplate().getSpec().getContainers().get(0).getPorts().get(0).getContainerPort());
         assertEquals(KafkaConnectCluster.REST_API_PORT_NAME, dep.getSpec().getTemplate().getSpec().getContainers().get(0).getPorts().get(0).getName());
         assertEquals("TCP", dep.getSpec().getTemplate().getSpec().getContainers().get(0).getPorts().get(0).getProtocol());
+        assertEquals("RollingUpdate", dep.getSpec().getStrategy().getType());
+        assertEquals(new Integer(1), dep.getSpec().getStrategy().getRollingUpdate().getMaxSurge().getIntVal());
+        assertEquals(new Integer(0), dep.getSpec().getStrategy().getRollingUpdate().getMaxUnavailable().getIntVal());
     }
 
     @Test

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/resources/KafkaConnectS2IClusterTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/resources/KafkaConnectS2IClusterTest.java
@@ -432,6 +432,9 @@ public class KafkaConnectS2IClusterTest {
         assertEquals(kc.kafkaConnectClusterName(cluster), dep.getSpec().getTriggers().get(1).getImageChangeParams().getContainerNames().get(0));
         assertEquals(kc.kafkaConnectClusterName(cluster) + ":latest", dep.getSpec().getTriggers().get(1).getImageChangeParams().getFrom().getName());
         assertEquals("ImageStreamTag", dep.getSpec().getTriggers().get(1).getImageChangeParams().getFrom().getKind());
+        assertEquals("Rolling", dep.getSpec().getStrategy().getType());
+        assertEquals(new Integer(1), dep.getSpec().getStrategy().getRollingParams().getMaxSurge().getIntVal());
+        assertEquals(new Integer(0), dep.getSpec().getStrategy().getRollingParams().getMaxUnavailable().getIntVal());
     }
 
     @Test

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/resources/TopicControllerTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/resources/TopicControllerTest.java
@@ -140,6 +140,7 @@ public class TopicControllerTest {
         assertEquals(new Integer(TopicController.HEALTHCHECK_PORT), dep.getSpec().getTemplate().getSpec().getContainers().get(0).getPorts().get(0).getContainerPort());
         assertEquals(TopicController.HEALTHCHECK_PORT_NAME, dep.getSpec().getTemplate().getSpec().getContainers().get(0).getPorts().get(0).getName());
         assertEquals("TCP", dep.getSpec().getTemplate().getSpec().getContainers().get(0).getPorts().get(0).getProtocol());
+        assertEquals("Recreate", dep.getSpec().getStrategy().getType());
     }
 
     @Test

--- a/examples/install/cluster-controller/04-deployment.yaml
+++ b/examples/install/cluster-controller/04-deployment.yaml
@@ -32,3 +32,5 @@ spec:
               port: 8080
             initialDelaySeconds: 10
             periodSeconds: 30
+  strategy:
+    type: Recreate

--- a/examples/install/topic-controller/04-deployment.yaml
+++ b/examples/install/topic-controller/04-deployment.yaml
@@ -40,3 +40,5 @@ spec:
               port: 8080
             initialDelaySeconds: 10
             periodSeconds: 30
+  strategy:
+    type: Recreate


### PR DESCRIPTION
### Type of change

- ~~Bugfix~~
- Enhancement / new feature
- ~~Refactoring~~

### Description

Controllers should run only in one instance to avoid them overwriting each others resources etc. In order to do that, they should use the Recreate deployment strategy which will make sure that when the Pod is being updated the old one will be deleted first before creating the new one.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally

