### PR TITLE
System Tests: New cluster with custom parameters

### DIFF
--- a/common-test/src/main/java/io/strimzi/test/CmData.java
+++ b/common-test/src/main/java/io/strimzi/test/CmData.java
@@ -4,16 +4,25 @@
  */
 package io.strimzi.test;
 
-import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotation for test classes or methods run via {@code @RunWith(StrimziRunner.class)}
- * which causes that runner to update config map before tests
+ * Annotation is used in ({@link ClusterController}, {@link KafkaCluster})
+ * to configure a cluster with custom parameters and values.
+ * <p>
+ * An example would be:
+ * <pre>
+ * &#064;Test
+ * &#064;KafkaCluster(config = {
+ * &#064;CmData(key = "foo", value = "bar")
+ * })
+ * public void test() {
+ * }
+ * </pre>
  */
-@Target({ElementType.METHOD, ElementType.TYPE})
+@Target({})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface CmData {
 

--- a/common-test/src/main/java/io/strimzi/test/CmData.java
+++ b/common-test/src/main/java/io/strimzi/test/CmData.java
@@ -5,7 +5,6 @@
 package io.strimzi.test;
 
 import java.lang.annotation.ElementType;
-import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -16,15 +15,8 @@ import java.lang.annotation.Target;
  */
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
-@Repeatable(CmData.Container.class)
 public @interface CmData {
 
     String key();
     String value();
-
-    @Target({ElementType.METHOD, ElementType.TYPE})
-    @Retention(RetentionPolicy.RUNTIME)
-    @interface Container {
-        CmData[] value();
-    }
 }

--- a/common-test/src/main/java/io/strimzi/test/CmData.java
+++ b/common-test/src/main/java/io/strimzi/test/CmData.java
@@ -12,21 +12,19 @@ import java.lang.annotation.Target;
 
 /**
  * Annotation for test classes or methods run via {@code @RunWith(StrimziRunner.class)}
- * which causes that runner to create kafka clusters before, and delete kafka clusters after,
- * the tests.
+ * which causes that runner to update config map before tests
  */
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
-@Repeatable(KafkaCluster.Container.class)
-public @interface KafkaCluster {
+@Repeatable(CmData.Container.class)
+public @interface CmData {
 
-    String name();
-    int kafkaNodes() default 3;
-    int zkNodes() default 1;
+    String key();
+    String value();
 
     @Target({ElementType.METHOD, ElementType.TYPE})
     @Retention(RetentionPolicy.RUNTIME)
     @interface Container {
-        KafkaCluster[] value();
+        CmData[] value();
     }
 }

--- a/common-test/src/main/java/io/strimzi/test/ConnectCluster.java
+++ b/common-test/src/main/java/io/strimzi/test/ConnectCluster.java
@@ -22,6 +22,7 @@ public @interface ConnectCluster {
     String name();
     String bootstrapServers();
     int nodes() default 1;
+    CmData[] config() default {};
 
     @Target({ElementType.METHOD, ElementType.TYPE})
     @Retention(RetentionPolicy.RUNTIME)

--- a/common-test/src/main/java/io/strimzi/test/KafkaCluster.java
+++ b/common-test/src/main/java/io/strimzi/test/KafkaCluster.java
@@ -23,11 +23,17 @@ public @interface KafkaCluster {
     String name();
     int kafkaNodes() default 3;
     int zkNodes() default 1;
+    CmConfiguration[] cmConfiguration() default {};
 
 
     @Target({ElementType.METHOD, ElementType.TYPE})
     @Retention(RetentionPolicy.RUNTIME)
     @interface Container {
         KafkaCluster[] value();
+    }
+
+    @interface CmConfiguration{
+        String key();
+        String value();
     }
 }

--- a/common-test/src/main/java/io/strimzi/test/KafkaCluster.java
+++ b/common-test/src/main/java/io/strimzi/test/KafkaCluster.java
@@ -32,7 +32,7 @@ public @interface KafkaCluster {
         KafkaCluster[] value();
     }
 
-    @interface CmConfiguration{
+    @interface CmConfiguration {
         String key();
         String value();
     }

--- a/common-test/src/main/java/io/strimzi/test/KafkaCluster.java
+++ b/common-test/src/main/java/io/strimzi/test/KafkaCluster.java
@@ -23,6 +23,7 @@ public @interface KafkaCluster {
     String name();
     int kafkaNodes() default 3;
     int zkNodes() default 1;
+    CmData[] config() default {};
 
     @Target({ElementType.METHOD, ElementType.TYPE})
     @Retention(RetentionPolicy.RUNTIME)

--- a/common-test/src/main/java/io/strimzi/test/StrimziRunner.java
+++ b/common-test/src/main/java/io/strimzi/test/StrimziRunner.java
@@ -216,6 +216,10 @@ public class StrimziRunner extends BlockJUnit4ClassRunner {
                 ((ObjectNode) data).put("nodes", String.valueOf(cluster.nodes()));
                 ((ObjectNode) data).put("KAFKA_CONNECT_BOOTSTRAP_SERVERS", cluster.bootstrapServers());
                 yaml = mapper.writeValueAsString(node);
+                // updates values for config map
+                for (CmData cmData : annotations(element, CmData.class)) {
+                    ((ObjectNode) data).put(cmData.key(), cmData.value());
+                }
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
@@ -258,10 +262,9 @@ public class StrimziRunner extends BlockJUnit4ClassRunner {
                 ((ObjectNode) data).put("kafka-nodes", String.valueOf(cluster.kafkaNodes()));
                 ((ObjectNode) data).put("zookeeper-nodes", String.valueOf(cluster.zkNodes()));
                 // updates values for config map
-                Arrays.stream(cluster.cmConfiguration())
-                        .forEach(config ->
-                            ((ObjectNode) data).put(config.key(), String.valueOf(config.value()))
-                    );
+                for (CmData cmData : annotations(element, CmData.class)) {
+                    ((ObjectNode) data).put(cmData.key(), cmData.value());
+                }
                 yaml = mapper.writeValueAsString(node);
             } catch (IOException e) {
                 throw new RuntimeException(e);

--- a/common-test/src/main/java/io/strimzi/test/StrimziRunner.java
+++ b/common-test/src/main/java/io/strimzi/test/StrimziRunner.java
@@ -261,7 +261,7 @@ public class StrimziRunner extends BlockJUnit4ClassRunner {
                 Arrays.stream(cluster.cmConfiguration())
                         .forEach(config ->
                             ((ObjectNode) data).put(config.key(), String.valueOf(config.value()))
-                        );
+                    );
                 yaml = mapper.writeValueAsString(node);
             } catch (IOException e) {
                 throw new RuntimeException(e);

--- a/common-test/src/main/java/io/strimzi/test/StrimziRunner.java
+++ b/common-test/src/main/java/io/strimzi/test/StrimziRunner.java
@@ -257,6 +257,11 @@ public class StrimziRunner extends BlockJUnit4ClassRunner {
                 JsonNode data = node.get("data");
                 ((ObjectNode) data).put("kafka-nodes", String.valueOf(cluster.kafkaNodes()));
                 ((ObjectNode) data).put("zookeeper-nodes", String.valueOf(cluster.zkNodes()));
+                // updates values for config map
+                Arrays.stream(cluster.cmConfiguration())
+                        .forEach(config ->
+                            ((ObjectNode) data).put(config.key(), String.valueOf(config.value()))
+                        );
                 yaml = mapper.writeValueAsString(node);
             } catch (IOException e) {
                 throw new RuntimeException(e);

--- a/common-test/src/main/java/io/strimzi/test/StrimziRunner.java
+++ b/common-test/src/main/java/io/strimzi/test/StrimziRunner.java
@@ -217,7 +217,7 @@ public class StrimziRunner extends BlockJUnit4ClassRunner {
                 ((ObjectNode) data).put("KAFKA_CONNECT_BOOTSTRAP_SERVERS", cluster.bootstrapServers());
                 yaml = mapper.writeValueAsString(node);
                 // updates values for config map
-                for (CmData cmData : annotations(element, CmData.class)) {
+                for (CmData cmData : cluster.config()) {
                     ((ObjectNode) data).put(cmData.key(), cmData.value());
                 }
             } catch (IOException e) {
@@ -262,7 +262,7 @@ public class StrimziRunner extends BlockJUnit4ClassRunner {
                 ((ObjectNode) data).put("kafka-nodes", String.valueOf(cluster.kafkaNodes()));
                 ((ObjectNode) data).put("zookeeper-nodes", String.valueOf(cluster.zkNodes()));
                 // updates values for config map
-                for (CmData cmData : annotations(element, CmData.class)) {
+                for (CmData cmData : cluster.config()) {
                     ((ObjectNode) data).put(cmData.key(), cmData.value());
                 }
                 yaml = mapper.writeValueAsString(node);

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -9,6 +9,10 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <properties>
+        <hamcrest.version>1.3</hamcrest.version>
+    </properties>
+
     <artifactId>systemtest</artifactId>
     <dependencies>
         <dependency>
@@ -32,6 +36,11 @@
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client</artifactId>
             <version>${fabric8.kubernetes-client.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <version>${hamcrest.version}</version>
         </dependency>
     </dependencies>
 

--- a/systemtest/src/main/java/matchers/CmMatcher.java
+++ b/systemtest/src/main/java/matchers/CmMatcher.java
@@ -20,7 +20,7 @@ public class CmMatcher extends BaseMatcher<String> {
     private String key;
     private String value;
 
-    public CmMatcher(String key, String value){
+    public CmMatcher(String key, String value) {
         this.key = key;
         this.value = value;
     }

--- a/systemtest/src/main/java/matchers/CmMatcher.java
+++ b/systemtest/src/main/java/matchers/CmMatcher.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package matchers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import org.hamcrest.BaseMatcher;
+
+import java.io.IOException;
+
+/**
+ * <p>A CmMatcher is custom matcher to check values for parameters
+ * in the config map of tested cluster.</p>
+ */
+public class CmMatcher extends BaseMatcher<String> {
+
+    private YAMLMapper mapper = new YAMLMapper();
+    private String key;
+    private String value;
+
+    public CmMatcher(String key, String value){
+        this.key = key;
+        this.value = value;
+    }
+
+    @Override
+    public boolean matches(Object actualValue) {
+        try {
+            JsonNode node = mapper.readTree(String.valueOf(actualValue));
+            return node.get("data").get(key).asText().equals(value);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void describeTo(org.hamcrest.Description description) {
+        description.appendText("key: " + key + " with value :" + value);
+    }
+}

--- a/systemtest/src/main/java/matchers/Matchers.java
+++ b/systemtest/src/main/java/matchers/Matchers.java
@@ -16,7 +16,7 @@ public class Matchers {
      * @param key - key of config map
      * @param value - expected value for the key
      */
-    public static Matcher<String> valueOfCmEqualsTo(String key, String value) {
+    public static Matcher<String> valueOfCmEquals(String key, String value) {
         return new CmMatcher(key, value);
     }
 }

--- a/systemtest/src/main/java/matchers/Matchers.java
+++ b/systemtest/src/main/java/matchers/Matchers.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package matchers;
+
+import org.hamcrest.Matcher;
+
+public class Matchers {
+
+    private Matchers() {
+    }
+
+    /**
+     * Matcher to check value by key in config map
+     * @param key - key of config map
+     * @param value - expected value for the key
+     */
+    public static Matcher<String> valueOfCmEqualsTo(String key, String value) {
+        return new CmMatcher(key, value);
+    }
+}

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterTest.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterTest.java
@@ -14,6 +14,7 @@ import io.strimzi.test.KafkaCluster;
 import io.strimzi.test.Namespace;
 import io.strimzi.test.OpenShiftOnly;
 import io.strimzi.test.Resources;
+import io.strimzi.test.CmData;
 import io.strimzi.test.StrimziRunner;
 import io.strimzi.test.TestUtils;
 import io.strimzi.test.k8s.KubeClient;
@@ -34,7 +35,7 @@ import java.util.regex.Pattern;
 import static io.strimzi.test.TestUtils.indent;
 import static io.strimzi.test.TestUtils.map;
 import static junit.framework.TestCase.assertTrue;
-import static matchers.Matchers.valueOfCmEqualsTo;
+import static matchers.Matchers.valueOfCmEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
@@ -228,15 +229,14 @@ public class KafkaClusterTest {
     }
 
     @Test
-    @KafkaCluster(name = "my-cluster",
-            cmConfiguration = {@KafkaCluster.CmConfiguration(key = "zookeeper-healthcheck-delay", value = "30"),
-                    @KafkaCluster.CmConfiguration(key = "zookeeper-healthcheck-timeout", value = "10"),
-                    @KafkaCluster.CmConfiguration(key = "kafka-healthcheck-delay", value = "30"),
-                    @KafkaCluster.CmConfiguration(key = "kafka-healthcheck-timeout", value = "10"),
-                    @KafkaCluster.CmConfiguration(key = "KAFKA_DEFAULT_REPLICATION_FACTOR", value = "2"),
-                    @KafkaCluster.CmConfiguration(key = "KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR", value = "5"),
-                    @KafkaCluster.CmConfiguration(key = "KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR", value = "5")
-            })
+    @KafkaCluster(name = "my-cluster", kafkaNodes = 1)
+    @CmData(key = "zookeeper-healthcheck-delay", value = "30")
+    @CmData(key = "zookeeper-healthcheck-timeout", value = "10")
+    @CmData(key = "kafka-healthcheck-delay", value = "30")
+    @CmData(key = "kafka-healthcheck-timeout", value = "10")
+    @CmData(key = "KAFKA_DEFAULT_REPLICATION_FACTOR", value = "2")
+    @CmData(key = "KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR", value = "5")
+    @CmData(key = "KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR", value = "5")
     public void testClusterWithCustomParameters() {
         // kafka cluster already deployed via annotation
         String clusterName = "my-cluster";
@@ -244,13 +244,13 @@ public class KafkaClusterTest {
 
         String jsonString = kubeClient.get("cm", clusterName);
 
-        assertThat(jsonString, valueOfCmEqualsTo("zookeeper-healthcheck-delay", "30"));
-        assertThat(jsonString, valueOfCmEqualsTo("zookeeper-healthcheck-timeout", "10"));
-        assertThat(jsonString, valueOfCmEqualsTo("kafka-healthcheck-delay", "30"));
-        assertThat(jsonString, valueOfCmEqualsTo("kafka-healthcheck-timeout", "30"));
-        assertThat(jsonString, valueOfCmEqualsTo("KAFKA_DEFAULT_REPLICATION_FACTOR", "2"));
-        assertThat(jsonString, valueOfCmEqualsTo("KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR", "5"));
-        assertThat(jsonString, valueOfCmEqualsTo("KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR", "5"));
+        assertThat(jsonString, valueOfCmEquals("zookeeper-healthcheck-delay", "30"));
+        assertThat(jsonString, valueOfCmEquals("zookeeper-healthcheck-timeout", "10"));
+        assertThat(jsonString, valueOfCmEquals("kafka-healthcheck-delay", "30"));
+        assertThat(jsonString, valueOfCmEquals("kafka-healthcheck-timeout", "10"));
+        assertThat(jsonString, valueOfCmEquals("KAFKA_DEFAULT_REPLICATION_FACTOR", "2"));
+        assertThat(jsonString, valueOfCmEquals("KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR", "5"));
+        assertThat(jsonString, valueOfCmEquals("KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR", "5"));
 
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterTest.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterTest.java
@@ -34,7 +34,9 @@ import java.util.regex.Pattern;
 import static io.strimzi.test.TestUtils.indent;
 import static io.strimzi.test.TestUtils.map;
 import static junit.framework.TestCase.assertTrue;
+import static matchers.Matchers.valueOfCmEqualsTo;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 @RunWith(StrimziRunner.class)
 @Namespace(KafkaClusterTest.NAMESPACE)
@@ -225,4 +227,30 @@ public class KafkaClusterTest {
         );
     }
 
+    @Test
+    @KafkaCluster(name = "my-cluster",
+            cmConfiguration = {@KafkaCluster.CmConfiguration(key = "zookeeper-healthcheck-delay", value = "30"),
+                    @KafkaCluster.CmConfiguration(key = "zookeeper-healthcheck-timeout", value = "10"),
+                    @KafkaCluster.CmConfiguration(key = "kafka-healthcheck-delay", value = "30"),
+                    @KafkaCluster.CmConfiguration(key = "kafka-healthcheck-timeout", value = "10"),
+                    @KafkaCluster.CmConfiguration(key = "KAFKA_DEFAULT_REPLICATION_FACTOR", value = "2"),
+                    @KafkaCluster.CmConfiguration(key = "KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR", value = "5"),
+                    @KafkaCluster.CmConfiguration(key = "KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR", value = "5")
+            })
+    public void testClusterWithCustomParameters() {
+        // kafka cluster already deployed via annotation
+        String clusterName = "my-cluster";
+        LOGGER.info("Running clusterWithCustomParameters with cluster {}", clusterName);
+
+        String jsonString = kubeClient.get("cm", clusterName);
+
+        assertThat(jsonString, valueOfCmEqualsTo("zookeeper-healthcheck-delay", "30"));
+        assertThat(jsonString, valueOfCmEqualsTo("zookeeper-healthcheck-timeout", "10"));
+        assertThat(jsonString, valueOfCmEqualsTo("kafka-healthcheck-delay", "30"));
+        assertThat(jsonString, valueOfCmEqualsTo("kafka-healthcheck-timeout", "30"));
+        assertThat(jsonString, valueOfCmEqualsTo("KAFKA_DEFAULT_REPLICATION_FACTOR", "2"));
+        assertThat(jsonString, valueOfCmEqualsTo("KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR", "5"));
+        assertThat(jsonString, valueOfCmEqualsTo("KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR", "5"));
+
+    }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterTest.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterTest.java
@@ -229,21 +229,22 @@ public class KafkaClusterTest {
     }
 
     @Test
-    @KafkaCluster(name = "my-cluster", kafkaNodes = 1)
-    @CmData(key = "zookeeper-healthcheck-delay", value = "30")
-    @CmData(key = "zookeeper-healthcheck-timeout", value = "10")
-    @CmData(key = "kafka-healthcheck-delay", value = "30")
-    @CmData(key = "kafka-healthcheck-timeout", value = "10")
-    @CmData(key = "KAFKA_DEFAULT_REPLICATION_FACTOR", value = "2")
-    @CmData(key = "KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR", value = "5")
-    @CmData(key = "KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR", value = "5")
+    @KafkaCluster(name = "my-cluster", kafkaNodes = 1, config = {
+        @CmData(key = "zookeeper-healthcheck-delay", value = "30"),
+        @CmData(key = "zookeeper-healthcheck-timeout", value = "10"),
+        @CmData(key = "kafka-healthcheck-delay", value = "30"),
+        @CmData(key = "kafka-healthcheck-timeout", value = "10"),
+        @CmData(key = "KAFKA_DEFAULT_REPLICATION_FACTOR", value = "2"),
+        @CmData(key = "KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR", value = "5"),
+        @CmData(key = "KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR", value = "5")
+    })
     public void testClusterWithCustomParameters() {
         // kafka cluster already deployed via annotation
         String clusterName = "my-cluster";
         LOGGER.info("Running clusterWithCustomParameters with cluster {}", clusterName);
 
+        //TODO Add assertions to check that Kafka brokers have a custom configuration
         String jsonString = kubeClient.get("cm", clusterName);
-
         assertThat(jsonString, valueOfCmEquals("zookeeper-healthcheck-delay", "30"));
         assertThat(jsonString, valueOfCmEquals("zookeeper-healthcheck-timeout", "10"));
         assertThat(jsonString, valueOfCmEquals("kafka-healthcheck-delay", "30"));
@@ -251,6 +252,5 @@ public class KafkaClusterTest {
         assertThat(jsonString, valueOfCmEquals("KAFKA_DEFAULT_REPLICATION_FACTOR", "2"));
         assertThat(jsonString, valueOfCmEquals("KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR", "5"));
         assertThat(jsonString, valueOfCmEquals("KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR", "5"));
-
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/OpenShiftTemplatesTest.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/OpenShiftTemplatesTest.java
@@ -71,13 +71,43 @@ public class OpenShiftTemplatesTest {
                 "KAFKA_NODE_COUNT", "1"));
 
         KubernetesClient client = new DefaultKubernetesClient();
-        ConfigMap cm = client.configMaps().inNamespace("template-test").withName(clusterName).get();
+        ConfigMap cm = client.configMaps().inNamespace(NAMESPACE).withName(clusterName).get();
         assertNotNull(cm);
         Map<String, String> cmData = cm.getData();
         assertEquals("1", cmData.get("kafka-nodes"));
         assertEquals("1", cmData.get("zookeeper-nodes"));
         assertEquals("persistent-claim", mapper.readTree(cmData.get("kafka-storage")).get("type").asText());
         assertEquals("persistent-claim", mapper.readTree(cmData.get("zookeeper-storage")).get("type").asText());
+    }
+
+    @Test
+    public void testStrimziPersistentWithCustomParameters() throws IOException {
+        Oc oc = (Oc) cluster.client();
+        String clusterName = "baz";
+        oc.newApp("strimzi-persistent", map("CLUSTER_NAME", clusterName,
+                "ZOOKEEPER_HEALTHCHECK_DELAY", "30",
+                "ZOOKEEPER_HEALTHCHECK_TIMEOUT", "10",
+                "KAFKA_HEALTHCHECK_DELAY", "30",
+                "KAFKA_HEALTHCHECK_TIMEOUT", "10",
+                "KAFKA_DEFAULT_REPLICATION_FACTOR", "2",
+                "KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR", "5",
+                "KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR", "5",
+                "ZOOKEEPER_VOLUME_CAPACITY", "2Gi",
+                "KAFKA_VOLUME_CAPACITY", "2Gi"));
+
+        KubernetesClient client = new DefaultKubernetesClient();
+        ConfigMap cm = client.configMaps().inNamespace(NAMESPACE).withName(clusterName).get();
+        assertNotNull(cm);
+        Map<String, String> cmData = cm.getData();
+        assertEquals("30", cmData.get("zookeeper-healthcheck-delay"));
+        assertEquals("10", cmData.get("zookeeper-healthcheck-timeout"));
+        assertEquals("30", cmData.get("kafka-healthcheck-delay"));
+        assertEquals("10", cmData.get("kafka-healthcheck-timeout"));
+        assertEquals("2", cmData.get("KAFKA_DEFAULT_REPLICATION_FACTOR"));
+        assertEquals("5", cmData.get("KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR"));
+        assertEquals("5", cmData.get("KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR"));
+        assertEquals("2Gi", mapper.readTree(cmData.get("kafka-storage")).get("size").asText());
+        assertEquals("2Gi", mapper.readTree(cmData.get("zookeeper-storage")).get("size").asText());
     }
 
     @Test
@@ -88,7 +118,7 @@ public class OpenShiftTemplatesTest {
                 "INSTANCES", "1"));
 
         KubernetesClient client = new DefaultKubernetesClient();
-        ConfigMap cm = client.configMaps().inNamespace("template-test").withName(clusterName).get();
+        ConfigMap cm = client.configMaps().inNamespace(NAMESPACE).withName(clusterName).get();
         assertNotNull(cm);
         Map<String, String> cmData = cm.getData();
         assertEquals("1", cmData.get("nodes"));
@@ -102,7 +132,7 @@ public class OpenShiftTemplatesTest {
                 "INSTANCES", "1"));
 
         KubernetesClient client = new DefaultKubernetesClient();
-        ConfigMap cm = client.configMaps().inNamespace("template-test").withName(clusterName).get();
+        ConfigMap cm = client.configMaps().inNamespace(NAMESPACE).withName(clusterName).get();
         assertNotNull(cm);
         Map<String, String> cmData = cm.getData();
         assertEquals("1", cmData.get("nodes"));
@@ -120,7 +150,7 @@ public class OpenShiftTemplatesTest {
                 "TOPIC_REPLICAS", "2"));
 
         KubernetesClient client = new DefaultKubernetesClient();
-        ConfigMap cm = client.configMaps().inNamespace("template-test").withName(mapName).get();
+        ConfigMap cm = client.configMaps().inNamespace(NAMESPACE).withName(mapName).get();
         assertNotNull(cm);
         Map<String, String> cmData = cm.getData();
         assertEquals(topicName, cmData.get("name"));

--- a/systemtest/src/test/java/io/strimzi/systemtest/OpenShiftTemplatesTest.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/OpenShiftTemplatesTest.java
@@ -90,6 +90,7 @@ public class OpenShiftTemplatesTest {
                 "KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR", "5",
                 "KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR", "5"));
 
+        //TODO Add assertions to check that Kafka brokers have a custom configuration
         ConfigMap cm = client.configMaps().inNamespace(NAMESPACE).withName(clusterName).get();
         assertNotNull(cm);
         Map<String, String> cmData = cm.getData();
@@ -116,6 +117,7 @@ public class OpenShiftTemplatesTest {
                 "ZOOKEEPER_VOLUME_CAPACITY", "2Gi",
                 "KAFKA_VOLUME_CAPACITY", "2Gi"));
 
+        //TODO Add assertions to check that Kafka brokers have a custom configuration
         ConfigMap cm = client.configMaps().inNamespace(NAMESPACE).withName(clusterName).get();
         assertNotNull(cm);
         Map<String, String> cmData = cm.getData();

--- a/systemtest/src/test/java/io/strimzi/systemtest/OpenShiftTemplatesTest.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/OpenShiftTemplatesTest.java
@@ -79,7 +79,7 @@ public class OpenShiftTemplatesTest {
     }
 
     @Test
-    public void testStrimziEphemeralWithCustomParameters(){
+    public void testStrimziEphemeralWithCustomParameters() {
         String clusterName = "test-ephemeral-with-custom-parameters";
         oc.newApp("strimzi-ephemeral", map("CLUSTER_NAME", clusterName,
                 "ZOOKEEPER_HEALTHCHECK_DELAY", "30",


### PR DESCRIPTION
### Type of change
- New system tests

### Description
- Created system test for case when user create new cluster with custom parameters for cluster:
"ZOOKEEPER_HEALTHCHECK_DELAY" = "30"
"ZOOKEEPER_HEALTHCHECK_TIMEOUT" = "10"
"KAFKA_HEALTHCHECK_DELAY" = "30"
"KAFKA_HEALTHCHECK_TIMEOUT" = "10"
"KAFKA_DEFAULT_REPLICATION_FACTOR" = "2"
"KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR" = "5"
"KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR" = "5"
"ZOOKEEPER_VOLUME_CAPACITY" = "2Gi"
"KAFKA_VOLUME_CAPACITY" = "2Gi"

- Added the using of the constants "NAMESPACE" to other tests
- Added custom matcher to check values for CM in an easy way

### Checklist

- [x] Execute all system tests before merging PR
- [x] Make sure all tests pass
- [ ] Check all templates for cluster and topic controllers

