### PR TITLE
Reconsile S2I clusters only on OpenShift - Closes #288

### DIFF
--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterController.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterController.java
@@ -130,7 +130,12 @@ public class ClusterController extends AbstractVerticle {
                         } else if (type.equals(KafkaConnectCluster.TYPE)) {
                             cluster = kafkaConnectClusterOperations;
                         } else if (type.equals(KafkaConnectS2ICluster.TYPE)) {
-                            cluster = kafkaConnectS2IClusterOperations;
+                            if (kafkaConnectS2IClusterOperations != null)   {
+                                cluster = kafkaConnectS2IClusterOperations;
+                            } else {
+                                log.warn("Cluster type {} cannot be used outside of OpenShift as requested by Config Map {} in namespace {}", type, cm.getMetadata().getName(), namespace);
+                                return;
+                            }
                         } else {
                             log.warn("Unknown type {} received in Config Map {} in namespace {}", labels.get(ClusterController.STRIMZI_TYPE_LABEL), cm.getMetadata().getName(), namespace);
                             return;
@@ -197,10 +202,12 @@ public class ClusterController extends AbstractVerticle {
       Periodical reconciliation (in case we lost some event)
      */
     private void reconcile() {
-
         kafkaClusterOperations.reconcileAll(namespace, labels);
         kafkaConnectClusterOperations.reconcileAll(namespace, labels);
-        kafkaConnectS2IClusterOperations.reconcileAll(namespace, labels);
+
+        if (kafkaConnectS2IClusterOperations != null) {
+            kafkaConnectS2IClusterOperations.reconcileAll(namespace, labels);
+        }
     }
 
     /**

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/Main.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/Main.java
@@ -60,14 +60,15 @@ public class Main {
         DeploymentConfigOperations deploymentConfigOperations = null;
         ImageStreamOperations imagesStreamOperations = null;
         BuildConfigOperations buildConfigOperations = null;
+        KafkaConnectS2IClusterOperations kafkaConnectS2IClusterOperations = null;
         if (isOpenShift) {
             imagesStreamOperations = new ImageStreamOperations(vertx, client.adapt(OpenShiftClient.class));
             buildConfigOperations = new BuildConfigOperations(vertx, client.adapt(OpenShiftClient.class));
             deploymentConfigOperations = new DeploymentConfigOperations(vertx, client.adapt(OpenShiftClient.class));
+            kafkaConnectS2IClusterOperations = new KafkaConnectS2IClusterOperations(vertx, isOpenShift,
+                    configMapOperations, deploymentConfigOperations,
+                    serviceOperations, imagesStreamOperations, buildConfigOperations);
         }
-        KafkaConnectS2IClusterOperations kafkaConnectS2IClusterOperations = new KafkaConnectS2IClusterOperations(vertx, isOpenShift,
-                configMapOperations, deploymentConfigOperations,
-                serviceOperations, imagesStreamOperations, buildConfigOperations);
 
         List<Future> futures = new ArrayList<>();
         for (String namespace : config.getNamespaces()) {


### PR DESCRIPTION
### Type of change

- Bugfix
- ~~Enhancement / new feature~~
- ~~Refactoring~~

### Description

Makes sure that any S2I operations are done only on OpenShift.

### Checklist

- [x] Make sure all tests pass
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging

