### PR TITLE
Implement workaround hack to avoid RBAC errors

### DIFF
--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/Main.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/Main.java
@@ -7,6 +7,7 @@ package io.strimzi.controller.cluster;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.openshift.client.OpenShiftClient;
+import io.netty.handler.codec.http.HttpResponseStatus;
 import io.strimzi.controller.cluster.operations.cluster.KafkaClusterOperations;
 import io.strimzi.controller.cluster.operations.cluster.KafkaConnectClusterOperations;
 import io.strimzi.controller.cluster.operations.cluster.KafkaConnectS2IClusterOperations;
@@ -128,8 +129,8 @@ public class Main {
         HttpClient httpClient = vertx.createHttpClient(httpClientOptions);
 
         httpClient.getNow("/oapi", res -> {
-            if (res.statusCode() == 200) {
-                log.info("{} returned 200. We should be in OpenShift. It is safe to check 'isAdaptable'", res.request().absoluteURI());
+            if (res.statusCode() == HttpResponseStatus.OK.code()) {
+                log.info("{} returned {}. We should be in OpenShift. It is safe to check 'isAdaptable'", res.request().absoluteURI(), res.statusCode());
                 Boolean isOpenShift = Boolean.TRUE.equals(client.isAdaptable(OpenShiftClient.class));
                 fut.complete(isOpenShift);
             } else {

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/Main.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/Main.java
@@ -23,9 +23,12 @@ import io.strimzi.controller.cluster.operations.resource.StatefulSetOperations;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -34,15 +37,25 @@ public class Main {
     private static final Logger log = LoggerFactory.getLogger(Main.class.getName());
 
     public static void main(String[] args) {
-        run(Vertx.vertx(), new DefaultKubernetesClient(), System.getenv()).setHandler(ar -> {
-            if (ar.failed()) {
-                log.error("Unable to start controller for 1 or more namespace", ar.cause());
+        Vertx vertx = Vertx.vertx();
+        KubernetesClient client = new DefaultKubernetesClient();
+
+        isOnOpenShift(vertx, client).setHandler(os -> {
+            if (os.succeeded()) {
+                run(vertx, client, os.result().booleanValue(), System.getenv()).setHandler(ar -> {
+                    if (ar.failed()) {
+                        log.error("Unable to start controller for 1 or more namespace", ar.cause());
+                        System.exit(1);
+                    }
+                });
+            } else {
+                log.error("Failed to distinguish between Kubernetes and OpenShift", os.cause());
                 System.exit(1);
             }
         });
     }
 
-    static CompositeFuture run(Vertx vertx, KubernetesClient client, Map<String, String> env) {
+    static CompositeFuture run(Vertx vertx, KubernetesClient client, boolean isOpenShift, Map<String, String> env) {
         ClusterControllerConfig config = ClusterControllerConfig.fromMap(env);
 
         ServiceOperations serviceOperations = new ServiceOperations(vertx, client);
@@ -53,7 +66,6 @@ public class Main {
         PodOperations podOperations = new PodOperations(vertx, client);
         EndpointOperations endpointOperations = new EndpointOperations(vertx, client);
 
-        boolean isOpenShift = Boolean.TRUE.equals(client.isAdaptable(OpenShiftClient.class));
         KafkaClusterOperations kafkaClusterOperations = new KafkaClusterOperations(vertx, isOpenShift, config.getOperationTimeoutMs(), configMapOperations, serviceOperations, statefulSetOperations, pvcOperations, podOperations, endpointOperations, deploymentOperations);
         KafkaConnectClusterOperations kafkaConnectClusterOperations = new KafkaConnectClusterOperations(vertx, isOpenShift, configMapOperations, deploymentOperations, serviceOperations);
 
@@ -93,5 +105,39 @@ public class Main {
                 });
         }
         return CompositeFuture.join(futures);
+    }
+
+    static Future<Boolean> isOnOpenShift(Vertx vertx, KubernetesClient client)  {
+        URL kubernetesApi = client.getMasterUrl();
+        Future<Boolean> fut = Future.future();
+
+        HttpClientOptions httpClientOptions = new HttpClientOptions();
+        httpClientOptions.setDefaultHost(kubernetesApi.getHost());
+
+        if (kubernetesApi.getPort() == -1) {
+            httpClientOptions.setDefaultPort(kubernetesApi.getDefaultPort());
+        } else {
+            httpClientOptions.setDefaultPort(kubernetesApi.getPort());
+        }
+
+        if (kubernetesApi.getProtocol().equals("https")) {
+            httpClientOptions.setSsl(true);
+            httpClientOptions.setTrustAll(true);
+        }
+
+        HttpClient httpClient = vertx.createHttpClient(httpClientOptions);
+
+        httpClient.getNow("/oapi", res -> {
+            if (res.statusCode() == 200) {
+                log.info("{} returned 200. We should be in OpenShift. It is safe to check 'isAdaptable'", res.request().absoluteURI());
+                Boolean isOpenShift = Boolean.TRUE.equals(client.isAdaptable(OpenShiftClient.class));
+                fut.complete(isOpenShift);
+            } else {
+                log.info("{} returned {}. We are not on OpenShift.", res.request().absoluteURI(), res.statusCode());
+                fut.complete(Boolean.FALSE);
+            }
+        });
+
+        return fut;
     }
 }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/Main.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/Main.java
@@ -130,11 +130,12 @@ public class Main {
 
         httpClient.getNow("/oapi", res -> {
             if (res.statusCode() == HttpResponseStatus.OK.code()) {
-                log.info("{} returned {}. We should be in OpenShift. It is safe to check 'isAdaptable'", res.request().absoluteURI(), res.statusCode());
+                log.debug("{} returned {}. We are on OpenShift.", res.request().absoluteURI(), res.statusCode());
+                // We should be on OpenShift based on the /oapi result. We can now safely try isAdaptable() to be 100% sure.
                 Boolean isOpenShift = Boolean.TRUE.equals(client.isAdaptable(OpenShiftClient.class));
                 fut.complete(isOpenShift);
             } else {
-                log.info("{} returned {}. We are not on OpenShift.", res.request().absoluteURI(), res.statusCode());
+                log.debug("{} returned {}. We are not on OpenShift.", res.request().absoluteURI(), res.statusCode());
                 fut.complete(Boolean.FALSE);
             }
         });

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/ClusterControllerTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/ClusterControllerTest.java
@@ -88,7 +88,7 @@ public class ClusterControllerTest {
         env.put(ClusterControllerConfig.STRIMZI_NAMESPACE, namespaces);
         env.put(ClusterControllerConfig.STRIMZI_CONFIGMAP_LABELS, STRIMZI_IO_KIND_CLUSTER);
         env.put(ClusterControllerConfig.STRIMZI_FULL_RECONCILIATION_INTERVAL_MS, "120000");
-        Main.run(vertx, client, env).setHandler(ar -> {
+        Main.run(vertx, client, true, env).setHandler(ar -> {
             context.assertNull(ar.cause(), "Expected all verticles to start OK");
             async.complete();
         });


### PR DESCRIPTION
### Type of change

- Bugfix
- ~~Enhancement / new feature~~
- ~~Refactoring~~

### Description

This PR implements a workaround for issue #286 . It uses Vert.x HTTP client to query the /oapi endpoint. On OpenShift it is expected that this returns 200 OK. On Kubernetes, this should return some error (usually with RBAC enabled this returns 403). This doesn't use anything special to authenticate against the API, since on OpenShift the endpoint seems to be available even to anonymous user. After it gets 200 OK, it additionally calls the `isAdaptable` method. Seems to work on Kubernetes as well as on OpenShfit - both from inside as well as from IDE.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Make sure all tests pass
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging

