### PR TITLE
Use shorter PVC template name - Closes #294

### DIFF
--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/AbstractCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/AbstractCluster.java
@@ -82,7 +82,7 @@ public abstract class AbstractCluster {
 
     protected Storage storage;
 
-    protected String mounthPath;
+    protected String mountPath;
     protected String volumeName;
     protected String metricsConfigVolumeName;
     protected String metricsConfigMountPath;

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/KafkaCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/KafkaCluster.java
@@ -92,8 +92,8 @@ public class KafkaCluster extends AbstractCluster {
         this.healthCheckInitialDelay = DEFAULT_HEALTHCHECK_DELAY;
         this.isMetricsEnabled = DEFAULT_KAFKA_METRICS_ENABLED;
 
-        this.mounthPath = "/var/lib/kafka";
-        this.volumeName = "kafka-storage";
+        this.mountPath = "/var/lib/kafka";
+        this.volumeName = "data";
         this.metricsConfigVolumeName = "kafka-metrics-config";
         this.metricsConfigMountPath = "/opt/prometheus/config/";
     }
@@ -422,7 +422,7 @@ public class KafkaCluster extends AbstractCluster {
 
     private List<VolumeMount> getVolumeMounts() {
         List<VolumeMount> volumeMountList = new ArrayList<>();
-        volumeMountList.add(createVolumeMount(volumeName, mounthPath));
+        volumeMountList.add(createVolumeMount(volumeName, mountPath));
         if (isMetricsEnabled) {
             volumeMountList.add(createVolumeMount(metricsConfigVolumeName, metricsConfigMountPath));
         }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/ZookeeperCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/ZookeeperCluster.java
@@ -95,8 +95,8 @@ public class ZookeeperCluster extends AbstractCluster {
         this.healthCheckInitialDelay = DEFAULT_HEALTHCHECK_DELAY;
         this.isMetricsEnabled = DEFAULT_ZOOKEEPER_METRICS_ENABLED;
 
-        this.mounthPath = "/var/lib/zookeeper";
-        this.volumeName = "zookeeper-storage";
+        this.mountPath = "/var/lib/zookeeper";
+        this.volumeName = "data";
         this.metricsConfigVolumeName = "zookeeper-metrics-config";
         this.metricsConfigMountPath = "/opt/prometheus/config/";
     }
@@ -372,7 +372,7 @@ public class ZookeeperCluster extends AbstractCluster {
 
     private List<VolumeMount> getVolumeMounts() {
         List<VolumeMount> volumeMountList = new ArrayList<>();
-        volumeMountList.add(createVolumeMount(volumeName, mounthPath));
+        volumeMountList.add(createVolumeMount(volumeName, mountPath));
         if (isMetricsEnabled) {
             volumeMountList.add(createVolumeMount(metricsConfigVolumeName, metricsConfigMountPath));
         }

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperationsTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperationsTest.java
@@ -322,10 +322,10 @@ public class KafkaClusterOperationsTest {
             // PvcOperations only used for deletion
             Set<String> expectedPvcDeletions = new HashSet<>();
             for (int i = 0; deleteClaim && i < kafkaCluster.getReplicas(); i++) {
-                expectedPvcDeletions.add("kafka-storage-" + clusterCmName + "-kafka-" + i);
+                expectedPvcDeletions.add("data-" + clusterCmName + "-kafka-" + i);
             }
             for (int i = 0; deleteClaim && i < zookeeperCluster.getReplicas(); i++) {
-                expectedPvcDeletions.add("zookeeper-storage-" + clusterCmName + "-zookeeper-" + i);
+                expectedPvcDeletions.add("data-" + clusterCmName + "-zookeeper-" + i);
             }
             context.assertEquals(expectedPvcDeletions, captured(pvcCaptor));
 

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/resources/KafkaClusterTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/resources/KafkaClusterTest.java
@@ -208,7 +208,7 @@ public class KafkaClusterTest {
     public void testPvcNames() {
 
         for (int i = 0; i < replicas; i++) {
-            assertEquals("kafka-storage-" + KafkaCluster.kafkaClusterName(cluster) + "-" + i, kc.getPersistentVolumeClaimName(i));
+            assertEquals(kc.volumeName + "-" + KafkaCluster.kafkaClusterName(cluster) + "-" + i, kc.getPersistentVolumeClaimName(i));
         }
     }
 

--- a/documentation/adoc/cluster-controller.adoc
+++ b/documentation/adoc/cluster-controller.adoc
@@ -217,8 +217,8 @@ Finally, a selector can be used in order to select a specific labeled persistent
 When the "persistent-claim" is used, other than the resources already described in the <<Kafka>> section, the following resources
 are generated :
 
-* `kafka-storage-[cluster-name]-kafka-[idx]` Persistent Volume Claim for the volume used for storing data for the Kafka broker pod `[idx]`
-* `zookeeper-storage-[cluster-name]-zookeeper-[idx]` Persistent Volume Claim for the volume used for storing data for the
+* `data-[cluster-name]-kafka-[idx]` Persistent Volume Claim for the volume used for storing data for the Kafka broker pod `[idx]`
+* `data-[cluster-name]-zookeeper-[idx]` Persistent Volume Claim for the volume used for storing data for the
 Zookeeper node pod `[idx]`
 
 ===== Metrics


### PR DESCRIPTION
### Type of change

- ~~Bugfix~~
- Enhancement / new feature
- ~~Refactoring~~

### Description

The current names of the PVC templates are rather long: `zookeeper-storage` and `kafka-storage`. The volumes are used to store data (Zookeeper data, Kafka data). We sould use just the name `data`. The additional information that these are Kafka or Zookeeper data will come from the pod name which will be attached to the actual PVC name.

_PS: Please lets avoid discussion whether the new name should be `data`, `db`, `logs` or whatever else :-D._

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging

