### PR TITLE
Removing redundant size check on the resources to reconcile

### DIFF
--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/AbstractClusterOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/AbstractClusterOperations.java
@@ -272,7 +272,7 @@ public abstract class AbstractClusterOperations<C extends AbstractCluster,
                                 log.debug("Lock {} released", lockName);
                             });
                         }
-                    } else if (resources.size() > 0) {
+                    } else {
 
                         List<Future> result = new ArrayList<>(resources.size());
                         for (R resource : resources) {


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR should fixes #296. It seems that the `CompositFuture.join` calls the handler when the `Future` list is empty so the redundant check on `resources.size()` can be removed in order to release the lock in the scenario described by #296.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging

