### PR TITLE
Metrics cm labels

### DIFF
--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterController.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterController.java
@@ -25,7 +25,6 @@ import io.vertx.core.Handler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 public class ClusterController extends AbstractVerticle {

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterController.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterController.java
@@ -50,7 +50,6 @@ public class ClusterController extends AbstractVerticle {
     private boolean stopping;
 
     public ClusterController(String namespace,
-                             Labels labels,
                              long reconciliationInterval,
                              KubernetesClient client,
                              KafkaClusterOperations kafkaClusterOperations,
@@ -58,7 +57,7 @@ public class ClusterController extends AbstractVerticle {
                              KafkaConnectS2IClusterOperations kafkaConnectS2IClusterOperations) {
         log.info("Creating ClusterController for namespace {}", namespace);
         this.namespace = namespace;
-        this.labels = labels;
+        this.labels = Labels.forKind("cluster");
         this.reconciliationInterval = reconciliationInterval;
         this.client = client;
         this.kafkaClusterOperations = kafkaClusterOperations;

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterControllerConfig.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterControllerConfig.java
@@ -4,9 +4,6 @@
  */
 package io.strimzi.controller.cluster;
 
-import io.strimzi.controller.cluster.resources.Labels;
-
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -27,7 +24,6 @@ public class ClusterControllerConfig {
     public static final long DEFAULT_FULL_RECONCILIATION_INTERVAL_MS = 120_000;
     public static final long DEFAULT_OPERATION_TIMEOUT_MS = 60_000;
 
-    private final Labels labels;
     private final Set<String> namespaces;
     private final long reconciliationIntervalMs;
     private final long operationTimeoutMs;
@@ -36,25 +32,13 @@ public class ClusterControllerConfig {
      * Constructor
      *
      * @param namespaces namespace in which the controller will run and create resources
-     * @param labels    labels used for watching the cluster ConfigMap
      * @param reconciliationIntervalMs    specify every how many milliseconds the reconciliation runs
      * @param operationTimeoutMs    timeout for internal operations specified in milliseconds
      */
-    public ClusterControllerConfig(Set<String> namespaces, Labels labels, long reconciliationIntervalMs, long operationTimeoutMs) {
+    public ClusterControllerConfig(Set<String> namespaces, long reconciliationIntervalMs, long operationTimeoutMs) {
         this.namespaces = unmodifiableSet(new HashSet<>(namespaces));
-        this.labels = labels;
         this.reconciliationIntervalMs = reconciliationIntervalMs;
         this.operationTimeoutMs = operationTimeoutMs;
-    }
-
-    /**
-     * Constructor which provide a configuration with a default (120000 ms) reconciliation interval
-     *
-     * @param namespaces namespace in which the controller will run and create resources
-     * @param labels    labels used for watching the cluster ConfigMap
-     */
-    public ClusterControllerConfig(Set<String> namespaces, Labels labels) {
-        this(namespaces, labels, DEFAULT_FULL_RECONCILIATION_INTERVAL_MS, DEFAULT_OPERATION_TIMEOUT_MS);
     }
 
     /**
@@ -72,10 +56,6 @@ public class ClusterControllerConfig {
         } else {
             namespaces = new HashSet(asList(namespacesList.trim().split("\\s*,+\\s*")));
         }
-        String stringLabels = map.get(ClusterControllerConfig.STRIMZI_CONFIGMAP_LABELS);
-        if (stringLabels == null || stringLabels.isEmpty()) {
-            throw new IllegalArgumentException(ClusterControllerConfig.STRIMZI_CONFIGMAP_LABELS + " cannot be null");
-        }
 
         long reconciliationInterval = DEFAULT_FULL_RECONCILIATION_INTERVAL_MS;
         String reconciliationIntervalEnvVar = map.get(ClusterControllerConfig.STRIMZI_FULL_RECONCILIATION_INTERVAL_MS);
@@ -89,23 +69,9 @@ public class ClusterControllerConfig {
             operationTimeout = Long.parseLong(operationTimeoutEnvVar);
         }
 
-        Map<String, String> labelsMap = new HashMap<>();
-
-        String[] labels = stringLabels.split(",");
-        for (String label : labels) {
-            String[] fields = label.split("=");
-            labelsMap.put(fields[0].trim(), fields[1].trim());
-        }
-
-        return new ClusterControllerConfig(namespaces, Labels.userLabels(labelsMap), reconciliationInterval, operationTimeout);
+        return new ClusterControllerConfig(namespaces, reconciliationInterval, operationTimeout);
     }
 
-    /**
-     * @return  labels used for watching the cluster ConfigMap
-     */
-    public Labels getLabels() {
-        return labels;
-    }
 
     /**
      * @return  namespaces in which the controller runs and creates resources
@@ -132,7 +98,6 @@ public class ClusterControllerConfig {
     public String toString() {
         return "ClusterControllerConfig(" +
                 "namespaces=" + namespaces +
-                ",labels=" + labels +
                 ",reconciliationIntervalMs=" + reconciliationIntervalMs +
                 ")";
     }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterControllerConfig.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterControllerConfig.java
@@ -4,6 +4,8 @@
  */
 package io.strimzi.controller.cluster;
 
+import io.strimzi.controller.cluster.resources.Labels;
+
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -25,10 +27,10 @@ public class ClusterControllerConfig {
     public static final long DEFAULT_FULL_RECONCILIATION_INTERVAL_MS = 120_000;
     public static final long DEFAULT_OPERATION_TIMEOUT_MS = 60_000;
 
-    private Map<String, String> labels;
-    private Set<String> namespaces;
-    private long reconciliationIntervalMs;
-    private long operationTimeoutMs;
+    private final Labels labels;
+    private final Set<String> namespaces;
+    private final long reconciliationIntervalMs;
+    private final long operationTimeoutMs;
 
     /**
      * Constructor
@@ -38,7 +40,7 @@ public class ClusterControllerConfig {
      * @param reconciliationIntervalMs    specify every how many milliseconds the reconciliation runs
      * @param operationTimeoutMs    timeout for internal operations specified in milliseconds
      */
-    public ClusterControllerConfig(Set<String> namespaces, Map<String, String> labels, long reconciliationIntervalMs, long operationTimeoutMs) {
+    public ClusterControllerConfig(Set<String> namespaces, Labels labels, long reconciliationIntervalMs, long operationTimeoutMs) {
         this.namespaces = unmodifiableSet(new HashSet<>(namespaces));
         this.labels = labels;
         this.reconciliationIntervalMs = reconciliationIntervalMs;
@@ -51,7 +53,7 @@ public class ClusterControllerConfig {
      * @param namespaces namespace in which the controller will run and create resources
      * @param labels    labels used for watching the cluster ConfigMap
      */
-    public ClusterControllerConfig(Set<String> namespaces, Map<String, String> labels) {
+    public ClusterControllerConfig(Set<String> namespaces, Labels labels) {
         this(namespaces, labels, DEFAULT_FULL_RECONCILIATION_INTERVAL_MS, DEFAULT_OPERATION_TIMEOUT_MS);
     }
 
@@ -95,23 +97,14 @@ public class ClusterControllerConfig {
             labelsMap.put(fields[0].trim(), fields[1].trim());
         }
 
-        return new ClusterControllerConfig(namespaces, labelsMap, reconciliationInterval, operationTimeout);
+        return new ClusterControllerConfig(namespaces, Labels.userLabels(labelsMap), reconciliationInterval, operationTimeout);
     }
 
     /**
      * @return  labels used for watching the cluster ConfigMap
      */
-    public Map<String, String> getLabels() {
+    public Labels getLabels() {
         return labels;
-    }
-
-    /**
-     * Set the labels used for watching the cluster ConfigMap
-     *
-     * @param labels    labels used for watching the cluster ConfigMap
-     */
-    public void setLabels(Map<String, String> labels) {
-        this.labels = labels;
     }
 
     /**

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/Main.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/Main.java
@@ -88,7 +88,6 @@ public class Main {
             Future<String> fut = Future.future();
             futures.add(fut);
             ClusterController controller = new ClusterController(namespace,
-                    config.getLabels(),
                     config.getReconciliationIntervalMs(),
                     client,
                     kafkaClusterOperations,

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/AbstractClusterOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/AbstractClusterOperations.java
@@ -204,7 +204,7 @@ public abstract class AbstractClusterOperations<C extends AbstractCluster,
      * @param resource The resource
      */
     protected String nameFromLabels(R resource) {
-        return Labels.clusterLabel(resource);
+        return Labels.cluster(resource);
     }
 
     /**
@@ -239,7 +239,7 @@ public abstract class AbstractClusterOperations<C extends AbstractCluster,
                     // get ConfigMap and related resources for the specific cluster
                     ConfigMap cm = configMapOperations.get(namespace, name);
 
-                    Labels labels = Labels.cluster(name);
+                    Labels labels = Labels.forCluster(name);
                     List<R> resources = getResources(namespace, labels);
 
                     if (cm != null) {
@@ -327,7 +327,7 @@ public abstract class AbstractClusterOperations<C extends AbstractCluster,
 
         // get resources for the corresponding cluster name (they are part of)
         List<R> resources = getResources(namespace, newLabels);
-        Set<String> resourceNames = resources.stream().map(Labels::clusterLabel).collect(Collectors.toSet());
+        Set<String> resourceNames = resources.stream().map(Labels::cluster).collect(Collectors.toSet());
 
         cmsNames.addAll(resourceNames);
 

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/AbstractClusterOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/AbstractClusterOperations.java
@@ -6,7 +6,6 @@ package io.strimzi.controller.cluster.operations.cluster;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.strimzi.controller.cluster.ClusterController;
 import io.strimzi.controller.cluster.operations.resource.ConfigMapOperations;
 import io.strimzi.controller.cluster.resources.AbstractCluster;
 import io.strimzi.controller.cluster.resources.ClusterDiffResult;
@@ -21,9 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/AbstractClusterOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/AbstractClusterOperations.java
@@ -239,8 +239,7 @@ public abstract class AbstractClusterOperations<C extends AbstractCluster,
                     // get ConfigMap and related resources for the specific cluster
                     ConfigMap cm = configMapOperations.get(namespace, name);
 
-                    Labels labels = Labels.forCluster(name);
-                    List<R> resources = getResources(namespace, labels);
+                    List<R> resources = getResources(namespace, Labels.forCluster(name));
 
                     if (cm != null) {
                         String nameFromCm = name(cm);
@@ -306,8 +305,8 @@ public abstract class AbstractClusterOperations<C extends AbstractCluster,
     }
 
     /**
-     * Reconcile cluster resources in the given namespace having the given labels.
-     * Reconciliation works by getting the cluster ConfigMaps in the given namespace with the given labels and
+     * Reconcile cluster resources in the given namespace having the given selector.
+     * Reconciliation works by getting the cluster ConfigMaps in the given namespace with the given selector and
      * comparing with the corresponding {@linkplain #getResources(String, Labels) resource}.
      * <ul>
      * <li>A cluster will be {@linkplain #create(String, String, Handler) created} for all ConfigMaps without same-named resources</li>
@@ -315,18 +314,18 @@ public abstract class AbstractClusterOperations<C extends AbstractCluster,
      * <li>A cluster will be {@linkplain #update(String, String, Handler) updated} if it has a cluster ConfigMap and a resource with the same name.</li>
      * </ul>
      * @param namespace The namespace
-     * @param labels The labels
+     * @param selector The selector
      */
-    public final void reconcileAll(String namespace, Labels labels) {
+    public final void reconcileAll(String namespace, Labels selector) {
         String clusterType = clusterType();
-        Labels newLabels = labels.withType(clusterType);
+        Labels selectorWithCluster = selector.withType(clusterType);
 
         // get ConfigMap for the corresponding cluster type
-        List<ConfigMap> cms = configMapOperations.list(namespace, newLabels);
+        List<ConfigMap> cms = configMapOperations.list(namespace, selectorWithCluster);
         Set<String> cmsNames = cms.stream().map(cm -> cm.getMetadata().getName()).collect(Collectors.toSet());
 
         // get resources for the corresponding cluster name (they are part of)
-        List<R> resources = getResources(namespace, newLabels);
+        List<R> resources = getResources(namespace, selectorWithCluster);
         Set<String> resourceNames = resources.stream().map(Labels::cluster).collect(Collectors.toSet());
 
         cmsNames.addAll(resourceNames);
@@ -340,9 +339,9 @@ public abstract class AbstractClusterOperations<C extends AbstractCluster,
      * Gets the resources in the given namespace and with the given labels
      * from which an AbstractCluster representing the current state of the cluster can be obtained.
      * @param namespace The namespace
-     * @param kafkaLabels The labels
+     * @param selector The labels
      * @return The matching resources.
      */
-    protected abstract List<R> getResources(String namespace, Labels kafkaLabels);
+    protected abstract List<R> getResources(String namespace, Labels selector);
 
 }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperations.java
@@ -16,6 +16,7 @@ import io.strimzi.controller.cluster.operations.resource.ServiceOperations;
 import io.strimzi.controller.cluster.operations.resource.StatefulSetOperations;
 import io.strimzi.controller.cluster.resources.ClusterDiffResult;
 import io.strimzi.controller.cluster.resources.KafkaCluster;
+import io.strimzi.controller.cluster.resources.Labels;
 import io.strimzi.controller.cluster.resources.Storage;
 import io.strimzi.controller.cluster.resources.TopicController;
 import io.strimzi.controller.cluster.resources.ZookeeperCluster;
@@ -711,7 +712,7 @@ public class KafkaClusterOperations extends AbstractClusterOperations<KafkaClust
     }
 
     @Override
-    protected List<StatefulSet> getResources(String namespace, Map<String, String> kafkaLabels) {
+    protected List<StatefulSet> getResources(String namespace, Labels kafkaLabels) {
         return statefulSetOperations.list(namespace, kafkaLabels);
     }
 

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperations.java
@@ -711,8 +711,8 @@ public class KafkaClusterOperations extends AbstractClusterOperations<KafkaClust
     }
 
     @Override
-    protected List<StatefulSet> getResources(String namespace, Labels kafkaLabels) {
-        return statefulSetOperations.list(namespace, kafkaLabels);
+    protected List<StatefulSet> getResources(String namespace, Labels selector) {
+        return statefulSetOperations.list(namespace, selector);
     }
 
 

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperations.java
@@ -30,7 +30,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 /**
  * <p>Cluster operations for a "Kafka" cluster. A KafkaClusterOperations is

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectClusterOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectClusterOperations.java
@@ -11,6 +11,7 @@ import io.strimzi.controller.cluster.operations.resource.DeploymentOperations;
 import io.strimzi.controller.cluster.operations.resource.ServiceOperations;
 import io.strimzi.controller.cluster.resources.ClusterDiffResult;
 import io.strimzi.controller.cluster.resources.KafkaConnectCluster;
+import io.strimzi.controller.cluster.resources.Labels;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
@@ -207,7 +208,7 @@ public class KafkaConnectClusterOperations extends AbstractClusterOperations<Kaf
     }
 
     @Override
-    protected List<Deployment> getResources(String namespace, Map<String, String> kafkaLabels) {
+    protected List<Deployment> getResources(String namespace, Labels kafkaLabels) {
         return deploymentOperations.list(namespace, kafkaLabels);
     }
 }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectClusterOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectClusterOperations.java
@@ -207,7 +207,7 @@ public class KafkaConnectClusterOperations extends AbstractClusterOperations<Kaf
     }
 
     @Override
-    protected List<Deployment> getResources(String namespace, Labels kafkaLabels) {
-        return deploymentOperations.list(namespace, kafkaLabels);
+    protected List<Deployment> getResources(String namespace, Labels selector) {
+        return deploymentOperations.list(namespace, selector);
     }
 }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectClusterOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectClusterOperations.java
@@ -22,7 +22,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Cluster operations for a Kafka Connect cluster

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectS2IClusterOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectS2IClusterOperations.java
@@ -271,8 +271,8 @@ public class KafkaConnectS2IClusterOperations extends AbstractClusterOperations<
     }
 
     @Override
-    protected List<DeploymentConfig> getResources(String namespace, Labels kafkaLabels) {
-        return deploymentConfigOperations.list(namespace, kafkaLabels);
+    protected List<DeploymentConfig> getResources(String namespace, Labels selector) {
+        return deploymentConfigOperations.list(namespace, selector);
     }
 
 }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectS2IClusterOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectS2IClusterOperations.java
@@ -15,6 +15,7 @@ import io.strimzi.controller.cluster.operations.resource.ImageStreamOperations;
 import io.strimzi.controller.cluster.operations.resource.ServiceOperations;
 import io.strimzi.controller.cluster.resources.ClusterDiffResult;
 import io.strimzi.controller.cluster.resources.KafkaConnectS2ICluster;
+import io.strimzi.controller.cluster.resources.Labels;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
@@ -271,7 +272,7 @@ public class KafkaConnectS2IClusterOperations extends AbstractClusterOperations<
     }
 
     @Override
-    protected List<DeploymentConfig> getResources(String namespace, Map<String, String> kafkaLabels) {
+    protected List<DeploymentConfig> getResources(String namespace, Labels kafkaLabels) {
         return deploymentConfigOperations.list(namespace, kafkaLabels);
     }
 

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectS2IClusterOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectS2IClusterOperations.java
@@ -26,7 +26,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Cluster operations for a Kafka Connect cluster

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/resource/AbstractOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/resource/AbstractOperations.java
@@ -6,9 +6,11 @@ package io.strimzi.controller.cluster.operations.resource;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.internal.readiness.Readiness;
+import io.strimzi.controller.cluster.resources.Labels;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
@@ -171,8 +173,8 @@ public abstract class AbstractOperations<C, T extends HasMetadata, L extends Kub
      * @return A list of matching resources.
      */
     @SuppressWarnings("unchecked")
-    public List<T> list(String namespace, Map<String, String> labels) {
-        return operation().inNamespace(namespace).withLabels(labels).list().getItems();
+    public List<T> list(String namespace, Labels labels) {
+        return operation().inNamespace(namespace).withLabels(labels.toMap()).list().getItems();
     }
 
     /**

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/resource/AbstractOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/resource/AbstractOperations.java
@@ -6,7 +6,6 @@ package io.strimzi.controller.cluster.operations.resource;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
-import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.internal.readiness.Readiness;
@@ -18,7 +17,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * Abstract resource creation, for a generic resource type {@code R}.

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/resource/AbstractOperations.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operations/resource/AbstractOperations.java
@@ -165,14 +165,14 @@ public abstract class AbstractOperations<C, T extends HasMetadata, L extends Kub
     }
 
     /**
-     * Synchronously list the resources in the given {@code namespace} with the given {@code labels}.
+     * Synchronously list the resources in the given {@code namespace} with the given {@code selector}.
      * @param namespace The namespace.
-     * @param labels The labels.
+     * @param selector The selector.
      * @return A list of matching resources.
      */
     @SuppressWarnings("unchecked")
-    public List<T> list(String namespace, Labels labels) {
-        return operation().inNamespace(namespace).withLabels(labels.toMap()).list().getItems();
+    public List<T> list(String namespace, Labels selector) {
+        return operation().inNamespace(namespace).withLabels(selector.toMap()).list().getItems();
     }
 
     /**

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/AbstractCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/AbstractCluster.java
@@ -96,7 +96,7 @@ public abstract class AbstractCluster {
     protected AbstractCluster(String namespace, String cluster, Labels labels) {
         this.cluster = cluster;
         this.namespace = namespace;
-        this.labels = labels.withCluster(cluster);
+        this.labels = labels.withoutKind().withCluster(cluster);
     }
 
     public Labels getLabels() {

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/AbstractCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/AbstractCluster.java
@@ -58,7 +58,7 @@ public abstract class AbstractCluster {
 
     protected final String cluster;
     protected final String namespace;
-    protected Map<String, String> labels = new HashMap<>();
+    protected final Labels labels;
 
     // Docker image configuration
     protected String image;
@@ -93,18 +93,14 @@ public abstract class AbstractCluster {
      * @param namespace Kubernetes/OpenShift namespace where cluster resources are going to be created
      * @param cluster   overall cluster name
      */
-    protected AbstractCluster(String namespace, String cluster) {
+    protected AbstractCluster(String namespace, String cluster, Labels labels) {
         this.cluster = cluster;
         this.namespace = namespace;
+        this.labels = labels.withCluster(cluster);
     }
 
-    public Map<String, String> getLabels() {
+    public Labels getLabels() {
         return labels;
-    }
-
-    protected void setLabels(Map<String, String> newLabels) {
-        newLabels.put(ClusterController.STRIMZI_CLUSTER_LABEL, cluster);
-        this.labels = new HashMap<>(newLabels);
     }
 
     public int getReplicas() {
@@ -145,9 +141,7 @@ public abstract class AbstractCluster {
     }
 
     protected Map<String, String> getLabelsWithName(String name) {
-        Map<String, String> labelsWithName = new HashMap<>(labels);
-        labelsWithName.put(ClusterController.STRIMZI_NAME_LABEL, name);
-        return labelsWithName;
+        return labels.withName(name).toMap();
     }
 
     /**
@@ -317,8 +311,9 @@ public abstract class AbstractCluster {
 
         ConfigMap cm = new ConfigMapBuilder()
                 .withNewMetadata()
-                .withName(name)
-                .withNamespace(namespace)
+                    .withName(name)
+                    .withNamespace(namespace)
+                    .withLabels(labels.toMap())
                 .endMetadata()
                 .withData(data)
                 .build();

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/KafkaConnectCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/KafkaConnectCluster.java
@@ -86,8 +86,8 @@ public class KafkaConnectCluster extends AbstractCluster {
      * @param namespace Kubernetes/OpenShift namespace where Kafka Connect cluster resources are going to be created
      * @param cluster   overall cluster name
      */
-    protected KafkaConnectCluster(String namespace, String cluster) {
-        super(namespace, cluster);
+    protected KafkaConnectCluster(String namespace, String cluster, Labels labels) {
+        super(namespace, cluster, labels);
         this.name = kafkaConnectClusterName(cluster);
         this.image = DEFAULT_IMAGE;
         this.replicas = DEFAULT_REPLICAS;
@@ -103,9 +103,9 @@ public class KafkaConnectCluster extends AbstractCluster {
      * @return Kafka Connect cluster instance
      */
     public static KafkaConnectCluster fromConfigMap(ConfigMap cm) {
-        KafkaConnectCluster kafkaConnect = new KafkaConnectCluster(cm.getMetadata().getNamespace(), cm.getMetadata().getName());
-
-        kafkaConnect.setLabels(cm.getMetadata().getLabels());
+        KafkaConnectCluster kafkaConnect = new KafkaConnectCluster(cm.getMetadata().getNamespace(),
+                cm.getMetadata().getName(),
+                Labels.fromResource(cm));
 
         kafkaConnect.setReplicas(Integer.parseInt(cm.getData().getOrDefault(KEY_REPLICAS, String.valueOf(DEFAULT_REPLICAS))));
         kafkaConnect.setImage(cm.getData().getOrDefault(KEY_IMAGE, DEFAULT_IMAGE));
@@ -137,9 +137,8 @@ public class KafkaConnectCluster extends AbstractCluster {
             String namespace, String cluster,
             Deployment dep) {
 
-        KafkaConnectCluster kafkaConnect =  new KafkaConnectCluster(namespace, cluster);
+        KafkaConnectCluster kafkaConnect =  new KafkaConnectCluster(namespace, cluster, Labels.fromResource(dep));
 
-        kafkaConnect.setLabels(dep.getMetadata().getLabels());
         kafkaConnect.setReplicas(dep.getSpec().getReplicas());
         Container container = dep.getSpec().getTemplate().getSpec().getContainers().get(0);
         kafkaConnect.setImage(container.getImage());

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/KafkaConnectS2ICluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/KafkaConnectS2ICluster.java
@@ -48,8 +48,8 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
      * @param namespace Kubernetes/OpenShift namespace where Kafka Connect cluster resources are going to be created
      * @param cluster   overall cluster name
      */
-    private KafkaConnectS2ICluster(String namespace, String cluster) {
-        super(namespace, cluster);
+    private KafkaConnectS2ICluster(String namespace, String cluster, Labels labels) {
+        super(namespace, cluster, labels);
         setImage(DEFAULT_IMAGE);
     }
 
@@ -60,9 +60,7 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
      * @return Kafka Connect cluster instance
      */
     public static KafkaConnectS2ICluster fromConfigMap(ConfigMap cm) {
-        KafkaConnectS2ICluster kafkaConnect = new KafkaConnectS2ICluster(cm.getMetadata().getNamespace(), cm.getMetadata().getName());
-
-        kafkaConnect.setLabels(cm.getMetadata().getLabels());
+        KafkaConnectS2ICluster kafkaConnect = new KafkaConnectS2ICluster(cm.getMetadata().getNamespace(), cm.getMetadata().getName(), Labels.fromResource(cm));
 
         kafkaConnect.setReplicas(Integer.parseInt(cm.getData().getOrDefault(KEY_REPLICAS, String.valueOf(DEFAULT_REPLICAS))));
         kafkaConnect.setImage(cm.getData().getOrDefault(KEY_IMAGE, DEFAULT_IMAGE));
@@ -96,9 +94,8 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
             DeploymentConfig dep,
             ImageStream sis) {
 
-        KafkaConnectS2ICluster kafkaConnect =  new KafkaConnectS2ICluster(namespace, cluster);
+        KafkaConnectS2ICluster kafkaConnect =  new KafkaConnectS2ICluster(namespace, cluster, Labels.fromResource(dep));
 
-        kafkaConnect.setLabels(dep.getMetadata().getLabels());
         kafkaConnect.setReplicas(dep.getSpec().getReplicas());
         kafkaConnect.setHealthCheckInitialDelay(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getReadinessProbe().getInitialDelaySeconds());
         kafkaConnect.setHealthCheckTimeout(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getReadinessProbe().getTimeoutSeconds());

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/Labels.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/Labels.java
@@ -7,12 +7,9 @@ package io.strimzi.controller.cluster.resources;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 
-import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static java.util.Collections.unmodifiableMap;
@@ -115,7 +112,7 @@ public class Labels {
     }
 
     private Labels with(String label, String value) {
-        Map<String, String> newLabels = new HashMap<>(labels.size()+1);
+        Map<String, String> newLabels = new HashMap<>(labels.size() + 1);
         newLabels.putAll(labels);
         newLabels.put(label, value);
         return new Labels(newLabels);

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/Labels.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/Labels.java
@@ -149,6 +149,13 @@ public class Labels {
     }
 
     /**
+     * The same labels as this instance, but without any {@code strimzi.io/kind} key.
+     */
+    public Labels withoutKind() {
+        return without(STRIMZI_KIND_LABEL);
+    }
+
+    /**
      * The same labels as this instance, but with the given {@code cluster} for the {@code strimzi.io/cluster} key.
      */
     public Labels withCluster(String cluster) {

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/Labels.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/Labels.java
@@ -64,28 +64,28 @@ public class Labels {
     /**
      * Returns the value of the {@code strimzi.io/cluster} label of the given {@code resource}.
      */
-    public static String clusterLabel(HasMetadata resource) {
+    public static String cluster(HasMetadata resource) {
         return resource.getMetadata().getLabels().get(Labels.STRIMZI_CLUSTER_LABEL);
     }
 
     /**
      * Returns the value of the {@code strimzi.io/type} label of the given {@code resource}.
      */
-    public static String typeLabel(HasMetadata resource) {
+    public static String type(HasMetadata resource) {
         return resource.getMetadata().getLabels().get(Labels.STRIMZI_TYPE_LABEL);
     }
 
     /**
      * Returns the value of the {@code strimzi.io/name} label of the given {@code resource}.
      */
-    public static String nameLabel(HasMetadata resource) {
+    public static String name(HasMetadata resource) {
         return resource.getMetadata().getLabels().get(Labels.STRIMZI_NAME_LABEL);
     }
 
     /**
      * Returns the value of the {@code strimzi.io/kind} label of the given {@code resource}.
      */
-    public static String kindLabel(HasMetadata resource) {
+    public static String kind(HasMetadata resource) {
         return resource.getMetadata().getLabels().get(Labels.STRIMZI_KIND_LABEL);
     }
 
@@ -176,21 +176,21 @@ public class Labels {
     /**
      * A singleton instance with the given {@code cluster} for the {@code strimzi.io/cluster} key.
      */
-    public static Labels cluster(String cluster) {
+    public static Labels forCluster(String cluster) {
         return new Labels(singletonMap(STRIMZI_CLUSTER_LABEL, cluster));
     }
 
     /**
      * A singleton instance with the given {@code type} for the {@code strimzi.io/type} key.
      */
-    public static Labels type(String type) {
+    public static Labels forType(String type) {
         return new Labels(singletonMap(STRIMZI_TYPE_LABEL, type));
     }
 
     /**
      * A singleton instance with the given {@code kind} for the {@code strimzi.io/kind} key.
      */
-    public static Labels kind(String kind) {
+    public static Labels forKind(String kind) {
         return new Labels(singletonMap(STRIMZI_KIND_LABEL, kind));
     }
 

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/Labels.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/Labels.java
@@ -23,9 +23,38 @@ import static java.util.Collections.unmodifiableMap;
 public class Labels {
 
     public static final String STRIMZI_DOMAIN = "strimzi.io";
+
+    /**
+     * The kind of a ConfigMap:
+     * <ul>
+     *     <li>{@code strimzi.io/kind=cluster}
+     *         identifies a ConfigMap that is intended to be consumed by
+     *         the cluster controller.</li>
+     *     <li>{@code strimzi.io/kind=topic}
+     *         identifies a ConfigMap that is intended to be consumed
+     *         by the topic controller.</li>
+     * </ul>
+     */
     public static final String STRIMZI_KIND_LABEL = STRIMZI_DOMAIN + "/kind";
+    /**
+     * The type of Strimzi component:
+     * E.g: {@code kafka}, {@code zookeeper}, {@code topic-controller},
+     *      {@code connect}, {@code connect-s2i}
+     */
     public static final String STRIMZI_TYPE_LABEL = STRIMZI_DOMAIN + "/type";
+
+    /**
+     * The Strimzi cluster the resource is part of.
+     * The value is the cluster name (i.e. the name of the cluster CM)
+     */
     public static final String STRIMZI_CLUSTER_LABEL = STRIMZI_DOMAIN + "/cluster";
+
+    /**
+     * The name of the K8S resource.
+     * This is often the same name as the cluster
+     * (i.e. the same as {@code strimzi.io/cluster})
+     * but is different in some cases (e.g. headful and headless services)
+     */
     public static final String STRIMZI_NAME_LABEL = STRIMZI_DOMAIN + "/name";
 
     private static final Set<String> STRIMZI_LABELS = new HashSet(asList(STRIMZI_KIND_LABEL, STRIMZI_TYPE_LABEL, STRIMZI_CLUSTER_LABEL, STRIMZI_NAME_LABEL));

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/Labels.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/Labels.java
@@ -22,7 +22,7 @@ import static java.util.Collections.unmodifiableMap;
  */
 public class Labels {
 
-    public static final String STRIMZI_DOMAIN = "strimzi.io";
+    public static final String STRIMZI_DOMAIN = "strimzi.io/";
 
     /**
      * The kind of a ConfigMap:
@@ -35,19 +35,19 @@ public class Labels {
      *         by the topic controller.</li>
      * </ul>
      */
-    public static final String STRIMZI_KIND_LABEL = STRIMZI_DOMAIN + "/kind";
+    public static final String STRIMZI_KIND_LABEL = STRIMZI_DOMAIN + "kind";
     /**
      * The type of Strimzi component:
      * E.g: {@code kafka}, {@code zookeeper}, {@code topic-controller},
      *      {@code connect}, {@code connect-s2i}
      */
-    public static final String STRIMZI_TYPE_LABEL = STRIMZI_DOMAIN + "/type";
+    public static final String STRIMZI_TYPE_LABEL = STRIMZI_DOMAIN + "type";
 
     /**
      * The Strimzi cluster the resource is part of.
      * The value is the cluster name (i.e. the name of the cluster CM)
      */
-    public static final String STRIMZI_CLUSTER_LABEL = STRIMZI_DOMAIN + "/cluster";
+    public static final String STRIMZI_CLUSTER_LABEL = STRIMZI_DOMAIN + "cluster";
 
     /**
      * The name of the K8S resource.
@@ -55,9 +55,7 @@ public class Labels {
      * (i.e. the same as {@code strimzi.io/cluster})
      * but is different in some cases (e.g. headful and headless services)
      */
-    public static final String STRIMZI_NAME_LABEL = STRIMZI_DOMAIN + "/name";
-
-    private static final Set<String> STRIMZI_LABELS = new HashSet(asList(STRIMZI_KIND_LABEL, STRIMZI_TYPE_LABEL, STRIMZI_CLUSTER_LABEL, STRIMZI_NAME_LABEL));
+    public static final String STRIMZI_NAME_LABEL = STRIMZI_DOMAIN + "name";
 
     /**
      * The empty set of labels.
@@ -96,8 +94,10 @@ public class Labels {
 
     public static Labels userLabels(Map<String, String> userLabels) {
         for (String key : userLabels.keySet()) {
-            if (STRIMZI_LABELS.contains(key)) {
-                //throw new IllegalArgumentException("User labels includes a Strimzi label: " + key);
+            if (key.startsWith(STRIMZI_DOMAIN)
+                    && !key.equals(STRIMZI_KIND_LABEL)) {
+                throw new IllegalArgumentException("User labels includes a Strimzi label that is not "
+                        + STRIMZI_KIND_LABEL + ": " + key);
             }
         }
         return new Labels(userLabels);

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/Labels.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/Labels.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.controller.cluster.resources;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+import static java.util.Collections.unmodifiableMap;
+
+/**
+ * An immutable set of labels
+ */
+public class Labels {
+
+    public static final String STRIMZI_DOMAIN = "strimzi.io";
+    public static final String STRIMZI_KIND_LABEL = STRIMZI_DOMAIN + "/kind";
+    public static final String STRIMZI_TYPE_LABEL = STRIMZI_DOMAIN + "/type";
+    public static final String STRIMZI_CLUSTER_LABEL = STRIMZI_DOMAIN + "/cluster";
+    public static final String STRIMZI_NAME_LABEL = STRIMZI_DOMAIN + "/name";
+
+    private static final Set<String> STRIMZI_LABELS = new HashSet(asList(STRIMZI_KIND_LABEL, STRIMZI_TYPE_LABEL, STRIMZI_CLUSTER_LABEL, STRIMZI_NAME_LABEL));
+
+    /**
+     * The empty set of labels.
+     */
+    public static final Labels EMPTY = new Labels(emptyMap());
+
+    private final Map<String, String> labels;
+
+    /**
+     * Returns the value of the {@code strimzi.io/cluster} label of the given {@code resource}.
+     */
+    public static String clusterLabel(HasMetadata resource) {
+        return resource.getMetadata().getLabels().get(Labels.STRIMZI_CLUSTER_LABEL);
+    }
+
+    /**
+     * Returns the value of the {@code strimzi.io/type} label of the given {@code resource}.
+     */
+    public static String typeLabel(HasMetadata resource) {
+        return resource.getMetadata().getLabels().get(Labels.STRIMZI_TYPE_LABEL);
+    }
+
+    /**
+     * Returns the value of the {@code strimzi.io/name} label of the given {@code resource}.
+     */
+    public static String nameLabel(HasMetadata resource) {
+        return resource.getMetadata().getLabels().get(Labels.STRIMZI_NAME_LABEL);
+    }
+
+    /**
+     * Returns the value of the {@code strimzi.io/kind} label of the given {@code resource}.
+     */
+    public static String kindLabel(HasMetadata resource) {
+        return resource.getMetadata().getLabels().get(Labels.STRIMZI_KIND_LABEL);
+    }
+
+    public static Labels userLabels(Map<String, String> userLabels) {
+        for (String key : userLabels.keySet()) {
+            if (STRIMZI_LABELS.contains(key)) {
+                //throw new IllegalArgumentException("User labels includes a Strimzi label: " + key);
+            }
+        }
+        return new Labels(userLabels);
+    }
+
+    /**
+     * Returns the labels of the given {@code resource}.
+     */
+    public static Labels fromResource(HasMetadata resource) {
+        return new Labels(resource.getMetadata().getLabels());
+    }
+
+    private Labels(Map<String, String> labels) {
+        this.labels = unmodifiableMap(new HashMap(labels));
+    }
+
+    private Labels with(String label, String value) {
+        Map<String, String> newLabels = new HashMap<>(labels.size()+1);
+        newLabels.putAll(labels);
+        newLabels.put(label, value);
+        return new Labels(newLabels);
+    }
+
+    private Labels without(String label) {
+        Map<String, String> newLabels = new HashMap<>(labels);
+        newLabels.remove(label);
+        return new Labels(newLabels);
+    }
+
+    /**
+     * The same labels as this instance, but with the given {@code type} for the {@code strimzi.io/type} key.
+     */
+    public Labels withType(String type) {
+        return with(STRIMZI_TYPE_LABEL, type);
+    }
+
+    /**
+     * The same labels as this instance, but without any {@code strimzi.io/type} key.
+     */
+    public Labels withoutType() {
+        return without(STRIMZI_TYPE_LABEL);
+    }
+
+    /**
+     * The same labels as this instance, but with the given {@code kind} for the {@code strimzi.io/kind} key.
+     */
+    public Labels withKind(String kind) {
+        return with(STRIMZI_KIND_LABEL, kind);
+    }
+
+    /**
+     * The same labels as this instance, but with the given {@code cluster} for the {@code strimzi.io/cluster} key.
+     */
+    public Labels withCluster(String cluster) {
+        return with(STRIMZI_CLUSTER_LABEL, cluster);
+    }
+
+    /**
+     * The same labels as this instance, but with the given {@code name} for the {@code strimzi.io/name} key.
+     */
+    public Labels withName(String name) {
+        return with(STRIMZI_NAME_LABEL, name);
+    }
+
+    /**
+     * An unmodifiable map of the labels.
+     */
+    public Map<String, String> toMap() {
+        return labels;
+    }
+
+    /**
+     * A singleton instance with the given {@code cluster} for the {@code strimzi.io/cluster} key.
+     */
+    public static Labels cluster(String cluster) {
+        return new Labels(singletonMap(STRIMZI_CLUSTER_LABEL, cluster));
+    }
+
+    /**
+     * A singleton instance with the given {@code type} for the {@code strimzi.io/type} key.
+     */
+    public static Labels type(String type) {
+        return new Labels(singletonMap(STRIMZI_TYPE_LABEL, type));
+    }
+
+    /**
+     * A singleton instance with the given {@code kind} for the {@code strimzi.io/kind} key.
+     */
+    public static Labels kind(String kind) {
+        return new Labels(singletonMap(STRIMZI_KIND_LABEL, kind));
+    }
+
+    /**
+     * Return the value of the {@code strimzi.io/type}.
+     */
+    public String type() {
+        return labels.get(STRIMZI_TYPE_LABEL);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Labels labels1 = (Labels) o;
+        return Objects.equals(labels, labels1.labels);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(labels);
+    }
+
+    @Override
+    public String toString() {
+        return "Labels" + labels;
+    }
+}

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/Labels.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/Labels.java
@@ -35,8 +35,11 @@ public class Labels {
     public static final String STRIMZI_KIND_LABEL = STRIMZI_DOMAIN + "kind";
     /**
      * The type of Strimzi component:
-     * E.g: {@code kafka}, {@code zookeeper}, {@code topic-controller},
-     *      {@code connect}, {@code connect-s2i}
+     * E.g: {@link io.strimzi.controller.cluster.operations.cluster.KafkaClusterOperations#CLUSTER_TYPE_KAFKA kafka},
+     * {@link io.strimzi.controller.cluster.operations.cluster.KafkaClusterOperations#CLUSTER_TYPE_ZOOKEEPER zookeeper},
+     * {@link io.strimzi.controller.cluster.operations.cluster.KafkaClusterOperations#CLUSTER_TYPE_TOPIC_CONTROLLER topic-controller},
+     * {@link io.strimzi.controller.cluster.operations.cluster.KafkaConnectClusterOperations#CLUSTER_TYPE_CONNECT kafka-connect},
+     * {@link io.strimzi.controller.cluster.operations.cluster.KafkaConnectS2IClusterOperations#CLUSTER_TYPE_CONNECT_S2I kafka-connect-s2i}
      */
     public static final String STRIMZI_TYPE_LABEL = STRIMZI_DOMAIN + "type";
 

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/TopicController.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/TopicController.java
@@ -78,7 +78,7 @@ public class TopicController extends AbstractCluster {
      */
     protected TopicController(String namespace, String cluster, Labels labels) {
 
-        super(namespace, cluster, labels.withType(TopicController.TYPE).withoutType());
+        super(namespace, cluster, labels.withType(TopicController.TYPE));
         this.name = topicControllerName(cluster);
         this.image = DEFAULT_IMAGE;
         this.replicas = DEFAULT_REPLICAS;

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/TopicController.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/TopicController.java
@@ -25,7 +25,11 @@ import java.util.stream.Collectors;
  */
 public class TopicController extends AbstractCluster {
 
-    public static final String KIND = "topic";
+    /**
+     * The default kind of CMs that the Topic Controller will be configured to watch for
+     */
+    public static final String TOPIC_CM_KIND = "topic";
+    private static final String TYPE = "topic";
 
     private static final String NAME_SUFFIX = "-topic-controller";
 
@@ -74,7 +78,7 @@ public class TopicController extends AbstractCluster {
      */
     protected TopicController(String namespace, String cluster, Labels labels) {
 
-        super(namespace, cluster, labels.withKind(TopicController.KIND).withoutType());
+        super(namespace, cluster, labels.withType(TopicController.TYPE).withoutType());
         this.name = topicControllerName(cluster);
         this.image = DEFAULT_IMAGE;
         this.replicas = DEFAULT_REPLICAS;
@@ -154,7 +158,7 @@ public class TopicController extends AbstractCluster {
     protected static String defaultTopicConfigMapLabels(String cluster) {
         return String.format("%s=%s,%s=%s",
                 Labels.STRIMZI_CLUSTER_LABEL, cluster,
-                Labels.STRIMZI_KIND_LABEL, TopicController.KIND);
+                Labels.STRIMZI_KIND_LABEL, TopicController.TOPIC_CM_KIND);
     }
 
     /**

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/ZookeeperCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/ZookeeperCluster.java
@@ -84,7 +84,7 @@ public class ZookeeperCluster extends AbstractCluster {
      */
     private ZookeeperCluster(String namespace, String cluster, Labels labels) {
 
-        super(namespace, cluster, KafkaCluster.TYPE.equals(labels.type()) ? labels.withType(ZookeeperCluster.TYPE) : labels);
+        super(namespace, cluster, labels.withType(ZookeeperCluster.TYPE));
         this.name = zookeeperClusterName(cluster);
         this.headlessName = zookeeperHeadlessName(cluster);
         this.metricsConfigName = zookeeperMetricsName(cluster);

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/ZookeeperCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/ZookeeperCluster.java
@@ -8,6 +8,7 @@ import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ContainerPort;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.EnvVarBuilder;
+import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServicePort;
@@ -82,9 +83,9 @@ public class ZookeeperCluster extends AbstractCluster {
      * @param namespace Kubernetes/OpenShift namespace where Zookeeper cluster resources are going to be created
      * @param cluster   overall cluster name
      */
-    private ZookeeperCluster(String namespace, String cluster) {
+    private ZookeeperCluster(String namespace, String cluster, Labels labels) {
 
-        super(namespace, cluster);
+        super(namespace, cluster, KafkaCluster.TYPE.equals(labels.type()) ? labels.withType(ZookeeperCluster.TYPE) : labels);
         this.name = zookeeperClusterName(cluster);
         this.headlessName = zookeeperHeadlessName(cluster);
         this.metricsConfigName = zookeeperMetricsName(cluster);
@@ -109,10 +110,8 @@ public class ZookeeperCluster extends AbstractCluster {
      * @return Zookeeper cluster instance
      */
     public static ZookeeperCluster fromConfigMap(ConfigMap kafkaClusterCm) {
-
-        ZookeeperCluster zk = new ZookeeperCluster(kafkaClusterCm.getMetadata().getNamespace(), kafkaClusterCm.getMetadata().getName());
-
-        zk.setLabels(kafkaClusterCm.getMetadata().getLabels());
+        ZookeeperCluster zk = new ZookeeperCluster(kafkaClusterCm.getMetadata().getNamespace(), kafkaClusterCm.getMetadata().getName(),
+                Labels.fromResource(kafkaClusterCm));
 
         zk.setReplicas(Integer.parseInt(kafkaClusterCm.getData().getOrDefault(KEY_REPLICAS, String.valueOf(DEFAULT_REPLICAS))));
         zk.setImage(kafkaClusterCm.getData().getOrDefault(KEY_IMAGE, DEFAULT_IMAGE));
@@ -140,10 +139,9 @@ public class ZookeeperCluster extends AbstractCluster {
      */
     public static ZookeeperCluster fromStatefulSet(StatefulSet ss,
                                                    String namespace, String cluster) {
+        ZookeeperCluster zk =  new ZookeeperCluster(namespace, cluster,
+                Labels.fromResource(ss));
 
-        ZookeeperCluster zk =  new ZookeeperCluster(namespace, cluster);
-
-        zk.setLabels(ss.getMetadata().getLabels());
         zk.setReplicas(ss.getSpec().getReplicas());
         zk.setImage(ss.getSpec().getTemplate().getSpec().getContainers().get(0).getImage());
         zk.setHealthCheckInitialDelay(ss.getSpec().getTemplate().getSpec().getContainers().get(0).getReadinessProbe().getInitialDelaySeconds());
@@ -380,14 +378,4 @@ public class ZookeeperCluster extends AbstractCluster {
         return volumeMountList;
     }
 
-    @Override
-    protected void setLabels(Map<String, String> labels) {
-        Map<String, String> newLabels = new HashMap<>(labels);
-
-        if (KafkaCluster.TYPE.equals(newLabels.get(ClusterController.STRIMZI_TYPE_LABEL))) {
-            newLabels.put(ClusterController.STRIMZI_TYPE_LABEL, ZookeeperCluster.TYPE);
-        }
-
-        super.setLabels(newLabels);
-    }
 }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/ZookeeperCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/ZookeeperCluster.java
@@ -8,7 +8,6 @@ import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ContainerPort;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.EnvVarBuilder;
-import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServicePort;

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/ClusterControllerConfigTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/ClusterControllerConfigTest.java
@@ -22,7 +22,7 @@ public class ClusterControllerConfigTest {
     private static Map<String, String> envVars = new HashMap<>(4);
 
     static {
-        labels = Labels.kind("cluster");
+        labels = Labels.forKind("cluster");
 
         envVars.put(ClusterControllerConfig.STRIMZI_NAMESPACE, "namespace");
         envVars.put(ClusterControllerConfig.STRIMZI_CONFIGMAP_LABELS, "strimzi.io/kind=cluster");

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/ClusterControllerConfigTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/ClusterControllerConfigTest.java
@@ -33,10 +33,13 @@ public class ClusterControllerConfigTest {
     @Test
     public void testDefaultConfig() {
 
-        ClusterControllerConfig config = new ClusterControllerConfig(singleton("namespace"), labels);
+        Map<String, String> envVars = new HashMap<>(ClusterControllerConfigTest.envVars);
+        envVars.remove(ClusterControllerConfig.STRIMZI_FULL_RECONCILIATION_INTERVAL_MS);
+        envVars.remove(ClusterControllerConfig.STRIMZI_OPERATION_TIMEOUT_MS);
+
+        ClusterControllerConfig config = ClusterControllerConfig.fromMap(envVars);
 
         assertEquals(singleton("namespace"), config.getNamespaces());
-        assertEquals(labels, config.getLabels());
         assertEquals(ClusterControllerConfig.DEFAULT_FULL_RECONCILIATION_INTERVAL_MS, config.getReconciliationIntervalMs());
         assertEquals(ClusterControllerConfig.DEFAULT_OPERATION_TIMEOUT_MS, config.getOperationTimeoutMs());
     }
@@ -44,10 +47,9 @@ public class ClusterControllerConfigTest {
     @Test
     public void testReconciliationInterval() {
 
-        ClusterControllerConfig config = new ClusterControllerConfig(singleton("namespace"), labels, 60_000, 30_000);
+        ClusterControllerConfig config = new ClusterControllerConfig(singleton("namespace"), 60_000, 30_000);
 
         assertEquals(singleton("namespace"), config.getNamespaces());
-        assertEquals(labels, config.getLabels());
         assertEquals(60_000, config.getReconciliationIntervalMs());
         assertEquals(30_000, config.getOperationTimeoutMs());
     }
@@ -58,7 +60,6 @@ public class ClusterControllerConfigTest {
         ClusterControllerConfig config = ClusterControllerConfig.fromMap(envVars);
 
         assertEquals(singleton("namespace"), config.getNamespaces());
-        assertEquals(labels, config.getLabels());
         assertEquals(30_000, config.getReconciliationIntervalMs());
         assertEquals(30_000, config.getOperationTimeoutMs());
     }
@@ -73,7 +74,6 @@ public class ClusterControllerConfigTest {
         ClusterControllerConfig config = ClusterControllerConfig.fromMap(envVars);
 
         assertEquals(singleton("namespace"), config.getNamespaces());
-        assertEquals(labels, config.getLabels());
         assertEquals(ClusterControllerConfig.DEFAULT_FULL_RECONCILIATION_INTERVAL_MS, config.getReconciliationIntervalMs());
         assertEquals(ClusterControllerConfig.DEFAULT_OPERATION_TIMEOUT_MS, config.getOperationTimeoutMs());
     }
@@ -86,7 +86,6 @@ public class ClusterControllerConfigTest {
 
         ClusterControllerConfig config = ClusterControllerConfig.fromMap(envVars);
         assertEquals(new HashSet<>(asList("foo", "bar", "baz")), config.getNamespaces());
-        assertEquals(labels, config.getLabels());
         assertEquals(30_000, config.getReconciliationIntervalMs());
         assertEquals(30_000, config.getOperationTimeoutMs());
     }
@@ -96,15 +95,6 @@ public class ClusterControllerConfigTest {
 
         Map<String, String> envVars = new HashMap<>(ClusterControllerConfigTest.envVars);
         envVars.remove(ClusterControllerConfig.STRIMZI_NAMESPACE);
-
-        ClusterControllerConfig.fromMap(envVars);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testNoLabels() {
-
-        Map<String, String> envVars = new HashMap<>(ClusterControllerConfigTest.envVars);
-        envVars.remove(ClusterControllerConfig.STRIMZI_CONFIGMAP_LABELS);
 
         ClusterControllerConfig.fromMap(envVars);
     }

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/ClusterControllerConfigTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/ClusterControllerConfigTest.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.controller.cluster;
 
+import io.strimzi.controller.cluster.resources.Labels;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -17,11 +18,11 @@ import static org.junit.Assert.assertEquals;
 
 public class ClusterControllerConfigTest {
 
-    private static Map<String, String> labels = new HashMap<>(1);
+    private static Labels labels;
     private static Map<String, String> envVars = new HashMap<>(4);
 
     static {
-        labels.put("strimzi.io/kind", "cluster");
+        labels = Labels.kind("cluster");
 
         envVars.put(ClusterControllerConfig.STRIMZI_NAMESPACE, "namespace");
         envVars.put(ClusterControllerConfig.STRIMZI_CONFIGMAP_LABELS, "strimzi.io/kind=cluster");

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/ResourceUtils.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/ResourceUtils.java
@@ -13,7 +13,6 @@ import io.strimzi.controller.cluster.resources.Labels;
 import io.strimzi.controller.cluster.resources.TopicController;
 import io.strimzi.controller.cluster.resources.ZookeeperCluster;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/ResourceUtils.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/ResourceUtils.java
@@ -9,6 +9,7 @@ import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.strimzi.controller.cluster.resources.KafkaCluster;
 import io.strimzi.controller.cluster.resources.KafkaConnectCluster;
 import io.strimzi.controller.cluster.resources.KafkaConnectS2ICluster;
+import io.strimzi.controller.cluster.resources.Labels;
 import io.strimzi.controller.cluster.resources.TopicController;
 import io.strimzi.controller.cluster.resources.ZookeeperCluster;
 
@@ -81,7 +82,7 @@ public class ResourceUtils {
                 .withNewMetadata()
                 .withName(clusterCmName)
                 .withNamespace(clusterCmNamespace)
-                .withLabels(labels(ClusterController.STRIMZI_KIND_LABEL, "cluster", ClusterController.STRIMZI_TYPE_LABEL, "kafka"))
+                .withLabels(Labels.EMPTY.withKind("cluster").withType("kafka").toMap())
                 .endMetadata()
                 .withData(cmData)
                 .build();
@@ -127,7 +128,7 @@ public class ResourceUtils {
                 .withNewMetadata()
                 .withName(clusterCmName)
                 .withNamespace(clusterCmNamespace)
-                .withLabels(labels(ClusterController.STRIMZI_KIND_LABEL, "cluster", ClusterController.STRIMZI_TYPE_LABEL, "kafka-connect-s2i"))
+                .withLabels(labels(Labels.STRIMZI_KIND_LABEL, "cluster", Labels.STRIMZI_TYPE_LABEL, "kafka-connect-s2i"))
                 .endMetadata()
                 .withData(cmData)
                 .build();
@@ -172,7 +173,7 @@ public class ResourceUtils {
                 .withNewMetadata()
                 .withName(clusterCmName)
                 .withNamespace(clusterCmNamespace)
-                .withLabels(labels(ClusterController.STRIMZI_KIND_LABEL, "cluster", ClusterController.STRIMZI_TYPE_LABEL, "kafka-connect"))
+                .withLabels(labels(Labels.STRIMZI_KIND_LABEL, "cluster", Labels.STRIMZI_TYPE_LABEL, "kafka-connect"))
                 .endMetadata()
                 .withData(cmData)
                 .build();

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/ResourceUtils.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/ResourceUtils.java
@@ -13,8 +13,11 @@ import io.strimzi.controller.cluster.resources.Labels;
 import io.strimzi.controller.cluster.resources.TopicController;
 import io.strimzi.controller.cluster.resources.ZookeeperCluster;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+
+import static java.util.Collections.singletonMap;
 
 public class ResourceUtils {
 
@@ -80,9 +83,9 @@ public class ResourceUtils {
         }
         return new ConfigMapBuilder()
                 .withNewMetadata()
-                .withName(clusterCmName)
-                .withNamespace(clusterCmNamespace)
-                .withLabels(Labels.EMPTY.withKind("cluster").withType("kafka").toMap())
+                    .withName(clusterCmName)
+                    .withNamespace(clusterCmNamespace)
+                    .withLabels(Labels.userLabels(singletonMap("my-user-label", "cromulent")).withKind("cluster").withType("kafka").toMap())
                 .endMetadata()
                 .withData(cmData)
                 .build();
@@ -128,7 +131,9 @@ public class ResourceUtils {
                 .withNewMetadata()
                 .withName(clusterCmName)
                 .withNamespace(clusterCmNamespace)
-                .withLabels(labels(Labels.STRIMZI_KIND_LABEL, "cluster", Labels.STRIMZI_TYPE_LABEL, "kafka-connect-s2i"))
+                .withLabels(labels(Labels.STRIMZI_KIND_LABEL, "cluster",
+                        Labels.STRIMZI_TYPE_LABEL, "kafka-connect-s2i",
+                        "my-user-label", "cromulent"))
                 .endMetadata()
                 .withData(cmData)
                 .build();
@@ -173,7 +178,9 @@ public class ResourceUtils {
                 .withNewMetadata()
                 .withName(clusterCmName)
                 .withNamespace(clusterCmNamespace)
-                .withLabels(labels(Labels.STRIMZI_KIND_LABEL, "cluster", Labels.STRIMZI_TYPE_LABEL, "kafka-connect"))
+                .withLabels(labels(Labels.STRIMZI_KIND_LABEL, "cluster",
+                        Labels.STRIMZI_TYPE_LABEL, "kafka-connect",
+                        "my-user-label", "cromulent"))
                 .endMetadata()
                 .withData(cmData)
                 .build();

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperationsTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperationsTest.java
@@ -9,7 +9,6 @@ import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.extensions.Deployment;
 import io.fabric8.kubernetes.api.model.extensions.StatefulSet;
-import io.strimzi.controller.cluster.ClusterController;
 import io.strimzi.controller.cluster.ClusterControllerConfig;
 import io.strimzi.controller.cluster.ResourceUtils;
 import io.strimzi.controller.cluster.operations.resource.ConfigMapOperations;
@@ -43,7 +42,6 @@ import org.mockito.ArgumentCaptor;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperationsTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperationsTest.java
@@ -660,19 +660,19 @@ public class KafkaClusterOperationsTest {
 
 
         // providing the list of ALL StatefulSets for all the Kafka clusters
-        Labels newLabels = Labels.type("kafka");
+        Labels newLabels = Labels.forType("kafka");
         when(mockSsOps.list(eq(clusterCmNamespace), eq(newLabels))).thenReturn(
                 asList(KafkaCluster.fromConfigMap(bar).generateStatefulSet(openShift),
                         KafkaCluster.fromConfigMap(baz).generateStatefulSet(openShift))
         );
 
         // providing the list StatefulSets for already "existing" Kafka clusters
-        Labels barLabels = Labels.cluster("bar");
+        Labels barLabels = Labels.forCluster("bar");
         when(mockSsOps.list(eq(clusterCmNamespace), eq(barLabels))).thenReturn(
                 asList(KafkaCluster.fromConfigMap(bar).generateStatefulSet(openShift))
         );
 
-        Labels bazLabels = Labels.cluster("baz");
+        Labels bazLabels = Labels.forCluster("baz");
         when(mockSsOps.list(eq(clusterCmNamespace), eq(bazLabels))).thenReturn(
                 asList(KafkaCluster.fromConfigMap(baz).generateStatefulSet(openShift))
         );

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperationsTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/cluster/KafkaClusterOperationsTest.java
@@ -22,6 +22,7 @@ import io.strimzi.controller.cluster.operations.resource.StatefulSetOperations;
 import io.strimzi.controller.cluster.resources.AbstractCluster;
 import io.strimzi.controller.cluster.resources.ClusterDiffResult;
 import io.strimzi.controller.cluster.resources.KafkaCluster;
+import io.strimzi.controller.cluster.resources.Labels;
 import io.strimzi.controller.cluster.resources.Storage;
 import io.strimzi.controller.cluster.resources.TopicController;
 import io.strimzi.controller.cluster.resources.ZookeeperCluster;
@@ -646,22 +647,19 @@ public class KafkaClusterOperationsTest {
 
 
         // providing the list of ALL StatefulSets for all the Kafka clusters
-        Map<String, String> newLabels = new HashMap<>();
-        newLabels.put(ClusterController.STRIMZI_TYPE_LABEL, "kafka");
+        Labels newLabels = Labels.type("kafka");
         when(mockSsOps.list(eq(clusterCmNamespace), eq(newLabels))).thenReturn(
                 asList(KafkaCluster.fromConfigMap(bar).generateStatefulSet(openShift),
                         KafkaCluster.fromConfigMap(baz).generateStatefulSet(openShift))
         );
 
         // providing the list StatefulSets for already "existing" Kafka clusters
-        Map<String, String> barLabels = new HashMap<>();
-        barLabels.put(ClusterController.STRIMZI_CLUSTER_LABEL, "bar");
+        Labels barLabels = Labels.cluster("bar");
         when(mockSsOps.list(eq(clusterCmNamespace), eq(barLabels))).thenReturn(
                 asList(KafkaCluster.fromConfigMap(bar).generateStatefulSet(openShift))
         );
 
-        Map<String, String> bazLabels = new HashMap<>();
-        bazLabels.put(ClusterController.STRIMZI_CLUSTER_LABEL, "baz");
+        Labels bazLabels = Labels.cluster("baz");
         when(mockSsOps.list(eq(clusterCmNamespace), eq(bazLabels))).thenReturn(
                 asList(KafkaCluster.fromConfigMap(baz).generateStatefulSet(openShift))
         );
@@ -697,7 +695,7 @@ public class KafkaClusterOperationsTest {
         };
 
         // Now try to reconcile all the Kafka clusters
-        ops.reconcileAll(clusterCmNamespace, Collections.emptyMap());
+        ops.reconcileAll(clusterCmNamespace, Labels.EMPTY);
 
         async.await();
 

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectClusterOperationsTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectClusterOperationsTest.java
@@ -464,18 +464,18 @@ public class KafkaConnectClusterOperationsTest {
         when(mockCmOps.get(eq(clusterCmNamespace), eq("bar"))).thenReturn(bar);
 
         // providing the list of ALL Deployments for all the Kafka Connect clusters
-        Labels newLabels = Labels.type("kafka-connect");
+        Labels newLabels = Labels.forType("kafka-connect");
         when(mockDcOps.list(eq(clusterCmNamespace), eq(newLabels))).thenReturn(
                 asList(KafkaConnectCluster.fromConfigMap(bar).generateDeployment(),
                         KafkaConnectCluster.fromConfigMap(baz).generateDeployment()));
 
         // providing the list Deployments for already "existing" Kafka Connect clusters
-        Labels barLabels = Labels.cluster("bar");
+        Labels barLabels = Labels.forCluster("bar");
         when(mockDcOps.list(eq(clusterCmNamespace), eq(barLabels))).thenReturn(
                 asList(KafkaConnectCluster.fromConfigMap(bar).generateDeployment())
         );
 
-        Labels bazLabels = Labels.cluster("baz");
+        Labels bazLabels = Labels.forCluster("baz");
         when(mockDcOps.list(eq(clusterCmNamespace), eq(bazLabels))).thenReturn(
                 asList(KafkaConnectCluster.fromConfigMap(baz).generateDeployment())
         );

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectClusterOperationsTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectClusterOperationsTest.java
@@ -13,6 +13,7 @@ import io.strimzi.controller.cluster.operations.resource.ConfigMapOperations;
 import io.strimzi.controller.cluster.operations.resource.DeploymentOperations;
 import io.strimzi.controller.cluster.operations.resource.ServiceOperations;
 import io.strimzi.controller.cluster.resources.KafkaConnectCluster;
+import io.strimzi.controller.cluster.resources.Labels;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
@@ -467,21 +468,18 @@ public class KafkaConnectClusterOperationsTest {
         when(mockCmOps.get(eq(clusterCmNamespace), eq("bar"))).thenReturn(bar);
 
         // providing the list of ALL Deployments for all the Kafka Connect clusters
-        Map<String, String> newLabels = new HashMap<>();
-        newLabels.put(ClusterController.STRIMZI_TYPE_LABEL, "kafka-connect");
+        Labels newLabels = Labels.type("kafka-connect");
         when(mockDcOps.list(eq(clusterCmNamespace), eq(newLabels))).thenReturn(
                 asList(KafkaConnectCluster.fromConfigMap(bar).generateDeployment(),
                         KafkaConnectCluster.fromConfigMap(baz).generateDeployment()));
 
         // providing the list Deployments for already "existing" Kafka Connect clusters
-        Map<String, String> barLabels = new HashMap<>();
-        barLabels.put(ClusterController.STRIMZI_CLUSTER_LABEL, "bar");
+        Labels barLabels = Labels.cluster("bar");
         when(mockDcOps.list(eq(clusterCmNamespace), eq(barLabels))).thenReturn(
                 asList(KafkaConnectCluster.fromConfigMap(bar).generateDeployment())
         );
 
-        Map<String, String> bazLabels = new HashMap<>();
-        bazLabels.put(ClusterController.STRIMZI_CLUSTER_LABEL, "baz");
+        Labels bazLabels = Labels.cluster("baz");
         when(mockDcOps.list(eq(clusterCmNamespace), eq(bazLabels))).thenReturn(
                 asList(KafkaConnectCluster.fromConfigMap(baz).generateDeployment())
         );
@@ -516,7 +514,7 @@ public class KafkaConnectClusterOperationsTest {
         };
 
         // Now try to reconcile all the Kafka Connect clusters
-        ops.reconcileAll(clusterCmNamespace, Collections.emptyMap());
+        ops.reconcileAll(clusterCmNamespace, Labels.EMPTY);
 
         async.await();
 

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectClusterOperationsTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectClusterOperationsTest.java
@@ -7,7 +7,6 @@ package io.strimzi.controller.cluster.operations.cluster;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.extensions.Deployment;
-import io.strimzi.controller.cluster.ClusterController;
 import io.strimzi.controller.cluster.ResourceUtils;
 import io.strimzi.controller.cluster.operations.resource.ConfigMapOperations;
 import io.strimzi.controller.cluster.operations.resource.DeploymentOperations;
@@ -26,11 +25,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import static java.util.Arrays.asList;

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectS2IClusterOperationsTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectS2IClusterOperationsTest.java
@@ -9,7 +9,6 @@ import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.openshift.api.model.BuildConfig;
 import io.fabric8.openshift.api.model.DeploymentConfig;
 import io.fabric8.openshift.api.model.ImageStream;
-import io.strimzi.controller.cluster.ClusterController;
 import io.strimzi.controller.cluster.ResourceUtils;
 import io.strimzi.controller.cluster.operations.resource.BuildConfigOperations;
 import io.strimzi.controller.cluster.operations.resource.ConfigMapOperations;
@@ -31,11 +30,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import static java.util.Arrays.asList;

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectS2IClusterOperationsTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectS2IClusterOperationsTest.java
@@ -18,6 +18,7 @@ import io.strimzi.controller.cluster.operations.resource.ImageStreamOperations;
 import io.strimzi.controller.cluster.operations.resource.ServiceOperations;
 import io.strimzi.controller.cluster.resources.KafkaConnectCluster;
 import io.strimzi.controller.cluster.resources.KafkaConnectS2ICluster;
+import io.strimzi.controller.cluster.resources.Labels;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
@@ -649,21 +650,18 @@ public class KafkaConnectS2IClusterOperationsTest {
         when(mockCmOps.get(eq(clusterCmNamespace), eq("bar"))).thenReturn(bar);
 
         // providing the list of ALL DeploymentConfigs for all the Kafka Connect S2I clusters
-        Map<String, String> newLabels = new HashMap<>();
-        newLabels.put(ClusterController.STRIMZI_TYPE_LABEL, "kafka-connect-s2i");
+        Labels newLabels = Labels.type("kafka-connect-s2i");
         when(mockDcOps.list(eq(clusterCmNamespace), eq(newLabels))).thenReturn(
                 asList(KafkaConnectS2ICluster.fromConfigMap(bar).generateDeploymentConfig(),
                         KafkaConnectS2ICluster.fromConfigMap(baz).generateDeploymentConfig()));
 
         // providing the list DeploymentConfigs for already "existing" Kafka Connect S2I clusters
-        Map<String, String> barLabels = new HashMap<>();
-        barLabels.put(ClusterController.STRIMZI_CLUSTER_LABEL, "bar");
+        Labels barLabels = Labels.cluster("bar");
         when(mockDcOps.list(eq(clusterCmNamespace), eq(barLabels))).thenReturn(
                 asList(KafkaConnectS2ICluster.fromConfigMap(bar).generateDeploymentConfig())
         );
 
-        Map<String, String> bazLabels = new HashMap<>();
-        bazLabels.put(ClusterController.STRIMZI_CLUSTER_LABEL, "baz");
+        Labels bazLabels = Labels.cluster("baz");
         when(mockDcOps.list(eq(clusterCmNamespace), eq(bazLabels))).thenReturn(
                 asList(KafkaConnectS2ICluster.fromConfigMap(baz).generateDeploymentConfig())
         );
@@ -698,7 +696,7 @@ public class KafkaConnectS2IClusterOperationsTest {
         };
 
         // Now try to reconcile all the Kafka Connect S2I clusters
-        ops.reconcileAll(clusterCmNamespace, Collections.emptyMap());
+        ops.reconcileAll(clusterCmNamespace, Labels.EMPTY);
 
         async.await();
 

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectS2IClusterOperationsTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/cluster/KafkaConnectS2IClusterOperationsTest.java
@@ -646,18 +646,18 @@ public class KafkaConnectS2IClusterOperationsTest {
         when(mockCmOps.get(eq(clusterCmNamespace), eq("bar"))).thenReturn(bar);
 
         // providing the list of ALL DeploymentConfigs for all the Kafka Connect S2I clusters
-        Labels newLabels = Labels.type("kafka-connect-s2i");
+        Labels newLabels = Labels.forType("kafka-connect-s2i");
         when(mockDcOps.list(eq(clusterCmNamespace), eq(newLabels))).thenReturn(
                 asList(KafkaConnectS2ICluster.fromConfigMap(bar).generateDeploymentConfig(),
                         KafkaConnectS2ICluster.fromConfigMap(baz).generateDeploymentConfig()));
 
         // providing the list DeploymentConfigs for already "existing" Kafka Connect S2I clusters
-        Labels barLabels = Labels.cluster("bar");
+        Labels barLabels = Labels.forCluster("bar");
         when(mockDcOps.list(eq(clusterCmNamespace), eq(barLabels))).thenReturn(
                 asList(KafkaConnectS2ICluster.fromConfigMap(bar).generateDeploymentConfig())
         );
 
-        Labels bazLabels = Labels.cluster("baz");
+        Labels bazLabels = Labels.forCluster("baz");
         when(mockDcOps.list(eq(clusterCmNamespace), eq(bazLabels))).thenReturn(
                 asList(KafkaConnectS2ICluster.fromConfigMap(baz).generateDeploymentConfig())
         );

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/resource/PodOperationsMockTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/resource/PodOperationsMockTest.java
@@ -13,6 +13,7 @@ import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.openshift.client.server.mock.OpenShiftServer;
+import io.strimzi.controller.cluster.resources.Labels;
 import io.vertx.core.Vertx;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
@@ -37,12 +38,12 @@ public class PodOperationsMockTest extends ResourceOperationsMockTest<Kubernetes
         KubernetesClient client = server.getKubernetesClient();
         PodOperations pr = new PodOperations(vertx, client);
 
-        context.assertEquals(emptyList(), pr.list(NAMESPACE, emptyMap()));
+        context.assertEquals(emptyList(), pr.list(NAMESPACE, Labels.EMPTY));
 
         Async async = context.async(1);
         pr.create(resource()).setHandler(createResult -> {
             context.assertTrue(createResult.succeeded());
-            context.assertEquals(singletonList(RESOURCE_NAME), pr.list(NAMESPACE, emptyMap()).stream()
+            context.assertEquals(singletonList(RESOURCE_NAME), pr.list(NAMESPACE, Labels.EMPTY).stream()
                         .map(p -> p.getMetadata().getName())
                         .collect(Collectors.toList()));
             //Pod got = pr.get(NAMESPACE, RESOURCE_NAME);

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/resource/PodOperationsMockTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/operations/resource/PodOperationsMockTest.java
@@ -23,7 +23,6 @@ import org.junit.Test;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
-import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static org.mockito.Mockito.when;
 

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/resources/KafkaClusterTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/resources/KafkaClusterTest.java
@@ -45,7 +45,10 @@ public class KafkaClusterTest {
 
     private void checkService(Service headful) {
         assertEquals("ClusterIP", headful.getSpec().getType());
-        assertEquals(ResourceUtils.labels("strimzi.io/cluster", cluster, "strimzi.io/type", "kafka", "strimzi.io/kind", "cluster", "strimzi.io/name", cluster + "-kafka"), headful.getSpec().getSelector());
+        assertEquals(ResourceUtils.labels(Labels.STRIMZI_CLUSTER_LABEL, cluster,
+                Labels.STRIMZI_TYPE_LABEL, "kafka",
+                "my-user-label", "cromulent",
+                Labels.STRIMZI_NAME_LABEL, KafkaCluster.kafkaClusterName(cluster)), headful.getSpec().getSelector());
         assertEquals(2, headful.getSpec().getPorts().size());
         assertEquals(KafkaCluster.CLIENT_PORT_NAME, headful.getSpec().getPorts().get(0).getName());
         assertEquals(new Integer(KafkaCluster.CLIENT_PORT), headful.getSpec().getPorts().get(0).getPort());
@@ -64,7 +67,10 @@ public class KafkaClusterTest {
         assertEquals(KafkaCluster.headlessName(cluster), headless.getMetadata().getName());
         assertEquals("ClusterIP", headless.getSpec().getType());
         assertEquals("None", headless.getSpec().getClusterIP());
-        assertEquals(labels("strimzi.io/cluster", cluster, "strimzi.io/type", "kafka", "strimzi.io/kind", "cluster", "strimzi.io/name", KafkaCluster.kafkaClusterName(cluster)), headless.getSpec().getSelector());
+        assertEquals(labels(Labels.STRIMZI_CLUSTER_LABEL, cluster,
+                Labels.STRIMZI_TYPE_LABEL, "kafka",
+                "my-user-label", "cromulent",
+                Labels.STRIMZI_NAME_LABEL, KafkaCluster.kafkaClusterName(cluster)), headless.getSpec().getSelector());
         assertEquals(2, headless.getSpec().getPorts().size());
         assertEquals(KafkaCluster.CLIENT_PORT_NAME, headless.getSpec().getPorts().get(0).getName());
         assertEquals(new Integer(KafkaCluster.CLIENT_PORT), headless.getSpec().getPorts().get(0).getPort());
@@ -87,7 +93,7 @@ public class KafkaClusterTest {
         // ... with these labels
         assertEquals(labels("strimzi.io/cluster", cluster,
                 "strimzi.io/type", "kafka",
-                "strimzi.io/kind", "cluster",
+                "my-user-label", "cromulent",
                 "strimzi.io/name", KafkaCluster.kafkaClusterName(cluster)),
                 ss.getMetadata().getLabels());
 

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/resources/KafkaConnectClusterTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/resources/KafkaConnectClusterTest.java
@@ -17,6 +17,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -312,8 +313,12 @@ public class KafkaConnectClusterTest {
         Service svc = kc.generateService();
 
         assertEquals("ClusterIP", svc.getSpec().getType());
-        assertEquals(ResourceUtils.labels(Labels.STRIMZI_CLUSTER_LABEL, cluster, Labels.STRIMZI_TYPE_LABEL, "kafka-connect", Labels.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), svc.getMetadata().getLabels());
-        assertEquals(ResourceUtils.labels(Labels.STRIMZI_CLUSTER_LABEL, cluster, Labels.STRIMZI_TYPE_LABEL, "kafka-connect", Labels.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), svc.getSpec().getSelector());
+        Map<String, String> expectedLabels = ResourceUtils.labels(Labels.STRIMZI_CLUSTER_LABEL, this.cluster,
+                Labels.STRIMZI_TYPE_LABEL, "kafka-connect",
+                "my-user-label", "cromulent",
+                Labels.STRIMZI_NAME_LABEL, kc.kafkaConnectClusterName(cluster));
+        assertEquals(expectedLabels, svc.getMetadata().getLabels());
+        assertEquals(expectedLabels, svc.getSpec().getSelector());
         assertEquals(1, svc.getSpec().getPorts().size());
         assertEquals(new Integer(KafkaConnectCluster.REST_API_PORT), svc.getSpec().getPorts().get(0).getPort());
         assertEquals(KafkaConnectCluster.REST_API_PORT_NAME, svc.getSpec().getPorts().get(0).getName());
@@ -334,8 +339,12 @@ public class KafkaConnectClusterTest {
 
         Service svc = kc.patchService(orig);
 
-        assertEquals(ResourceUtils.labels(Labels.STRIMZI_CLUSTER_LABEL, cluster, Labels.STRIMZI_TYPE_LABEL, "kafka-connect", Labels.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), svc.getMetadata().getLabels());
-        assertEquals(ResourceUtils.labels(Labels.STRIMZI_CLUSTER_LABEL, cluster, Labels.STRIMZI_TYPE_LABEL, "kafka-connect", Labels.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), svc.getSpec().getSelector());
+        Map<String, String> expectedLabels = ResourceUtils.labels(Labels.STRIMZI_CLUSTER_LABEL, this.cluster,
+                Labels.STRIMZI_TYPE_LABEL, "kafka-connect",
+                "my-user-label", "cromulent",
+                Labels.STRIMZI_NAME_LABEL, kc.kafkaConnectClusterName(cluster));
+        assertEquals(expectedLabels, svc.getMetadata().getLabels());
+        assertEquals(expectedLabels, svc.getSpec().getSelector());
     }
 
     @Test
@@ -344,11 +353,15 @@ public class KafkaConnectClusterTest {
 
         assertEquals(kc.kafkaConnectClusterName(cluster), dep.getMetadata().getName());
         assertEquals(namespace, dep.getMetadata().getNamespace());
-        assertEquals(ResourceUtils.labels(Labels.STRIMZI_CLUSTER_LABEL, cluster, Labels.STRIMZI_TYPE_LABEL, "kafka-connect", Labels.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), dep.getMetadata().getLabels());
+        Map<String, String> expectedLabels = ResourceUtils.labels(Labels.STRIMZI_CLUSTER_LABEL, this.cluster,
+                Labels.STRIMZI_TYPE_LABEL, "kafka-connect",
+                "my-user-label", "cromulent",
+                Labels.STRIMZI_NAME_LABEL, kc.kafkaConnectClusterName(cluster));
+        assertEquals(expectedLabels, dep.getMetadata().getLabels());
         assertEquals(new Integer(replicas), dep.getSpec().getReplicas());
-        assertEquals(ResourceUtils.labels(Labels.STRIMZI_CLUSTER_LABEL, cluster, Labels.STRIMZI_TYPE_LABEL, "kafka-connect", Labels.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), dep.getSpec().getTemplate().getMetadata().getLabels());
+        assertEquals(expectedLabels, dep.getSpec().getTemplate().getMetadata().getLabels());
         assertEquals(1, dep.getSpec().getTemplate().getSpec().getContainers().size());
-        assertEquals(kc.kafkaConnectClusterName(cluster), dep.getSpec().getTemplate().getSpec().getContainers().get(0).getName());
+        assertEquals(kc.kafkaConnectClusterName(this.cluster), dep.getSpec().getTemplate().getSpec().getContainers().get(0).getName());
         assertEquals(kc.image, dep.getSpec().getTemplate().getSpec().getContainers().get(0).getImage());
         assertEquals(getExpectedEnvVars(), dep.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv());
         assertEquals(new Integer(healthDelay), dep.getSpec().getTemplate().getSpec().getContainers().get(0).getLivenessProbe().getInitialDelaySeconds());
@@ -370,12 +383,15 @@ public class KafkaConnectClusterTest {
         orig.getMetadata().setLabels(Collections.EMPTY_MAP);
         orig.getSpec().getTemplate().getMetadata().setLabels(Collections.EMPTY_MAP);
 
-
         Deployment dep = kc.patchDeployment(orig);
 
-        assertEquals(ResourceUtils.labels(Labels.STRIMZI_CLUSTER_LABEL, cluster, Labels.STRIMZI_TYPE_LABEL, "kafka-connect", Labels.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), dep.getMetadata().getLabels());
+        Map<String, String> expectedLabels = ResourceUtils.labels(Labels.STRIMZI_CLUSTER_LABEL, this.cluster,
+                Labels.STRIMZI_TYPE_LABEL, "kafka-connect",
+                "my-user-label", "cromulent",
+                Labels.STRIMZI_NAME_LABEL, kc.kafkaConnectClusterName(cluster));
+        assertEquals(expectedLabels, dep.getMetadata().getLabels());
         assertEquals(new Integer(KafkaConnectCluster.DEFAULT_REPLICAS), dep.getSpec().getReplicas());
-        assertEquals(ResourceUtils.labels(Labels.STRIMZI_CLUSTER_LABEL, cluster, Labels.STRIMZI_TYPE_LABEL, "kafka-connect", Labels.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), dep.getSpec().getTemplate().getMetadata().getLabels());
+        assertEquals(expectedLabels, dep.getSpec().getTemplate().getMetadata().getLabels());
         assertEquals(new Integer(healthDelay), dep.getSpec().getTemplate().getSpec().getContainers().get(0).getLivenessProbe().getInitialDelaySeconds());
         assertEquals(new Integer(healthTimeout), dep.getSpec().getTemplate().getSpec().getContainers().get(0).getLivenessProbe().getTimeoutSeconds());
         assertEquals(new Integer(healthDelay), dep.getSpec().getTemplate().getSpec().getContainers().get(0).getReadinessProbe().getInitialDelaySeconds());

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/resources/KafkaConnectClusterTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/resources/KafkaConnectClusterTest.java
@@ -10,7 +10,6 @@ import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceBuilder;
 import io.fabric8.kubernetes.api.model.extensions.Deployment;
-import io.strimzi.controller.cluster.ClusterController;
 import io.strimzi.controller.cluster.ResourceUtils;
 import org.junit.Test;
 

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/resources/KafkaConnectClusterTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/resources/KafkaConnectClusterTest.java
@@ -312,8 +312,8 @@ public class KafkaConnectClusterTest {
         Service svc = kc.generateService();
 
         assertEquals("ClusterIP", svc.getSpec().getType());
-        assertEquals(ResourceUtils.labels(ClusterController.STRIMZI_CLUSTER_LABEL, cluster, ClusterController.STRIMZI_TYPE_LABEL, "kafka-connect", ClusterController.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), svc.getMetadata().getLabels());
-        assertEquals(ResourceUtils.labels(ClusterController.STRIMZI_CLUSTER_LABEL, cluster, ClusterController.STRIMZI_TYPE_LABEL, "kafka-connect", ClusterController.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), svc.getSpec().getSelector());
+        assertEquals(ResourceUtils.labels(Labels.STRIMZI_CLUSTER_LABEL, cluster, Labels.STRIMZI_TYPE_LABEL, "kafka-connect", Labels.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), svc.getMetadata().getLabels());
+        assertEquals(ResourceUtils.labels(Labels.STRIMZI_CLUSTER_LABEL, cluster, Labels.STRIMZI_TYPE_LABEL, "kafka-connect", Labels.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), svc.getSpec().getSelector());
         assertEquals(1, svc.getSpec().getPorts().size());
         assertEquals(new Integer(KafkaConnectCluster.REST_API_PORT), svc.getSpec().getPorts().get(0).getPort());
         assertEquals(KafkaConnectCluster.REST_API_PORT_NAME, svc.getSpec().getPorts().get(0).getName());
@@ -334,8 +334,8 @@ public class KafkaConnectClusterTest {
 
         Service svc = kc.patchService(orig);
 
-        assertEquals(ResourceUtils.labels(ClusterController.STRIMZI_CLUSTER_LABEL, cluster, ClusterController.STRIMZI_TYPE_LABEL, "kafka-connect", ClusterController.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), svc.getMetadata().getLabels());
-        assertEquals(ResourceUtils.labels(ClusterController.STRIMZI_CLUSTER_LABEL, cluster, ClusterController.STRIMZI_TYPE_LABEL, "kafka-connect", ClusterController.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), svc.getSpec().getSelector());
+        assertEquals(ResourceUtils.labels(Labels.STRIMZI_CLUSTER_LABEL, cluster, Labels.STRIMZI_TYPE_LABEL, "kafka-connect", Labels.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), svc.getMetadata().getLabels());
+        assertEquals(ResourceUtils.labels(Labels.STRIMZI_CLUSTER_LABEL, cluster, Labels.STRIMZI_TYPE_LABEL, "kafka-connect", Labels.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), svc.getSpec().getSelector());
     }
 
     @Test
@@ -344,9 +344,9 @@ public class KafkaConnectClusterTest {
 
         assertEquals(kc.kafkaConnectClusterName(cluster), dep.getMetadata().getName());
         assertEquals(namespace, dep.getMetadata().getNamespace());
-        assertEquals(ResourceUtils.labels(ClusterController.STRIMZI_CLUSTER_LABEL, cluster, ClusterController.STRIMZI_TYPE_LABEL, "kafka-connect", ClusterController.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), dep.getMetadata().getLabels());
+        assertEquals(ResourceUtils.labels(Labels.STRIMZI_CLUSTER_LABEL, cluster, Labels.STRIMZI_TYPE_LABEL, "kafka-connect", Labels.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), dep.getMetadata().getLabels());
         assertEquals(new Integer(replicas), dep.getSpec().getReplicas());
-        assertEquals(ResourceUtils.labels(ClusterController.STRIMZI_CLUSTER_LABEL, cluster, ClusterController.STRIMZI_TYPE_LABEL, "kafka-connect", ClusterController.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), dep.getSpec().getTemplate().getMetadata().getLabels());
+        assertEquals(ResourceUtils.labels(Labels.STRIMZI_CLUSTER_LABEL, cluster, Labels.STRIMZI_TYPE_LABEL, "kafka-connect", Labels.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), dep.getSpec().getTemplate().getMetadata().getLabels());
         assertEquals(1, dep.getSpec().getTemplate().getSpec().getContainers().size());
         assertEquals(kc.kafkaConnectClusterName(cluster), dep.getSpec().getTemplate().getSpec().getContainers().get(0).getName());
         assertEquals(kc.image, dep.getSpec().getTemplate().getSpec().getContainers().get(0).getImage());
@@ -373,9 +373,9 @@ public class KafkaConnectClusterTest {
 
         Deployment dep = kc.patchDeployment(orig);
 
-        assertEquals(ResourceUtils.labels(ClusterController.STRIMZI_CLUSTER_LABEL, cluster, ClusterController.STRIMZI_TYPE_LABEL, "kafka-connect", ClusterController.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), dep.getMetadata().getLabels());
+        assertEquals(ResourceUtils.labels(Labels.STRIMZI_CLUSTER_LABEL, cluster, Labels.STRIMZI_TYPE_LABEL, "kafka-connect", Labels.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), dep.getMetadata().getLabels());
         assertEquals(new Integer(KafkaConnectCluster.DEFAULT_REPLICAS), dep.getSpec().getReplicas());
-        assertEquals(ResourceUtils.labels(ClusterController.STRIMZI_CLUSTER_LABEL, cluster, ClusterController.STRIMZI_TYPE_LABEL, "kafka-connect", ClusterController.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), dep.getSpec().getTemplate().getMetadata().getLabels());
+        assertEquals(ResourceUtils.labels(Labels.STRIMZI_CLUSTER_LABEL, cluster, Labels.STRIMZI_TYPE_LABEL, "kafka-connect", Labels.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), dep.getSpec().getTemplate().getMetadata().getLabels());
         assertEquals(new Integer(healthDelay), dep.getSpec().getTemplate().getSpec().getContainers().get(0).getLivenessProbe().getInitialDelaySeconds());
         assertEquals(new Integer(healthTimeout), dep.getSpec().getTemplate().getSpec().getContainers().get(0).getLivenessProbe().getTimeoutSeconds());
         assertEquals(new Integer(healthDelay), dep.getSpec().getTemplate().getSpec().getContainers().get(0).getReadinessProbe().getInitialDelaySeconds());

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/resources/KafkaConnectS2IClusterTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/resources/KafkaConnectS2IClusterTest.java
@@ -377,8 +377,8 @@ public class KafkaConnectS2IClusterTest {
         Service svc = kc.generateService();
 
         assertEquals("ClusterIP", svc.getSpec().getType());
-        assertEquals(ResourceUtils.labels(ClusterController.STRIMZI_CLUSTER_LABEL, cluster, ClusterController.STRIMZI_TYPE_LABEL, "kafka-connect-s2i", ClusterController.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), svc.getMetadata().getLabels());
-        assertEquals(ResourceUtils.labels(ClusterController.STRIMZI_CLUSTER_LABEL, cluster, ClusterController.STRIMZI_TYPE_LABEL, "kafka-connect-s2i", ClusterController.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), svc.getSpec().getSelector());
+        assertEquals(ResourceUtils.labels(Labels.STRIMZI_CLUSTER_LABEL, cluster, Labels.STRIMZI_TYPE_LABEL, "kafka-connect-s2i", Labels.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), svc.getMetadata().getLabels());
+        assertEquals(ResourceUtils.labels(Labels.STRIMZI_CLUSTER_LABEL, cluster, Labels.STRIMZI_TYPE_LABEL, "kafka-connect-s2i", Labels.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), svc.getSpec().getSelector());
         assertEquals(1, svc.getSpec().getPorts().size());
         assertEquals(new Integer(KafkaConnectCluster.REST_API_PORT), svc.getSpec().getPorts().get(0).getPort());
         assertEquals(KafkaConnectCluster.REST_API_PORT_NAME, svc.getSpec().getPorts().get(0).getName());
@@ -399,8 +399,8 @@ public class KafkaConnectS2IClusterTest {
 
         Service svc = kc.patchService(orig);
 
-        assertEquals(ResourceUtils.labels(ClusterController.STRIMZI_CLUSTER_LABEL, cluster, ClusterController.STRIMZI_TYPE_LABEL, "kafka-connect-s2i", ClusterController.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), svc.getMetadata().getLabels());
-        assertEquals(ResourceUtils.labels(ClusterController.STRIMZI_CLUSTER_LABEL, cluster, ClusterController.STRIMZI_TYPE_LABEL, "kafka-connect-s2i", ClusterController.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), svc.getSpec().getSelector());
+        assertEquals(ResourceUtils.labels(Labels.STRIMZI_CLUSTER_LABEL, cluster, Labels.STRIMZI_TYPE_LABEL, "kafka-connect-s2i", Labels.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), svc.getMetadata().getLabels());
+        assertEquals(ResourceUtils.labels(Labels.STRIMZI_CLUSTER_LABEL, cluster, Labels.STRIMZI_TYPE_LABEL, "kafka-connect-s2i", Labels.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), svc.getSpec().getSelector());
     }
 
     @Test
@@ -409,9 +409,9 @@ public class KafkaConnectS2IClusterTest {
 
         assertEquals(kc.kafkaConnectClusterName(cluster), dep.getMetadata().getName());
         assertEquals(namespace, dep.getMetadata().getNamespace());
-        assertEquals(ResourceUtils.labels(ClusterController.STRIMZI_CLUSTER_LABEL, cluster, ClusterController.STRIMZI_TYPE_LABEL, "kafka-connect-s2i", ClusterController.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), dep.getMetadata().getLabels());
+        assertEquals(ResourceUtils.labels(Labels.STRIMZI_CLUSTER_LABEL, cluster, Labels.STRIMZI_TYPE_LABEL, "kafka-connect-s2i", Labels.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), dep.getMetadata().getLabels());
         assertEquals(new Integer(replicas), dep.getSpec().getReplicas());
-        assertEquals(ResourceUtils.labels(ClusterController.STRIMZI_CLUSTER_LABEL, cluster, ClusterController.STRIMZI_TYPE_LABEL, "kafka-connect-s2i", ClusterController.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), dep.getSpec().getTemplate().getMetadata().getLabels());
+        assertEquals(ResourceUtils.labels(Labels.STRIMZI_CLUSTER_LABEL, cluster, Labels.STRIMZI_TYPE_LABEL, "kafka-connect-s2i", Labels.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), dep.getSpec().getTemplate().getMetadata().getLabels());
         assertEquals(1, dep.getSpec().getTemplate().getSpec().getContainers().size());
         assertEquals(kc.kafkaConnectClusterName(cluster), dep.getSpec().getTemplate().getSpec().getContainers().get(0).getName());
         assertEquals(kc.kafkaConnectClusterName(cluster) + ":latest", dep.getSpec().getTemplate().getSpec().getContainers().get(0).getImage());
@@ -446,9 +446,9 @@ public class KafkaConnectS2IClusterTest {
 
         DeploymentConfig dep = kc.patchDeploymentConfig(orig);
 
-        assertEquals(ResourceUtils.labels(ClusterController.STRIMZI_CLUSTER_LABEL, cluster, ClusterController.STRIMZI_TYPE_LABEL, "kafka-connect-s2i", ClusterController.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), dep.getMetadata().getLabels());
+        assertEquals(ResourceUtils.labels(Labels.STRIMZI_CLUSTER_LABEL, cluster, Labels.STRIMZI_TYPE_LABEL, "kafka-connect-s2i", Labels.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), dep.getMetadata().getLabels());
         assertEquals(new Integer(KafkaConnectS2ICluster.DEFAULT_REPLICAS), dep.getSpec().getReplicas());
-        assertEquals(ResourceUtils.labels(ClusterController.STRIMZI_CLUSTER_LABEL, cluster, ClusterController.STRIMZI_TYPE_LABEL, "kafka-connect-s2i", ClusterController.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), dep.getSpec().getTemplate().getMetadata().getLabels());
+        assertEquals(ResourceUtils.labels(Labels.STRIMZI_CLUSTER_LABEL, cluster, Labels.STRIMZI_TYPE_LABEL, "kafka-connect-s2i", Labels.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), dep.getSpec().getTemplate().getMetadata().getLabels());
         assertEquals(new Integer(healthDelay), dep.getSpec().getTemplate().getSpec().getContainers().get(0).getLivenessProbe().getInitialDelaySeconds());
         assertEquals(new Integer(healthTimeout), dep.getSpec().getTemplate().getSpec().getContainers().get(0).getLivenessProbe().getTimeoutSeconds());
         assertEquals(new Integer(healthDelay), dep.getSpec().getTemplate().getSpec().getContainers().get(0).getReadinessProbe().getInitialDelaySeconds());
@@ -462,7 +462,7 @@ public class KafkaConnectS2IClusterTest {
 
         assertEquals(kc.kafkaConnectClusterName(cluster), bc.getMetadata().getName());
         assertEquals(namespace, bc.getMetadata().getNamespace());
-        assertEquals(ResourceUtils.labels(ClusterController.STRIMZI_CLUSTER_LABEL, cluster, ClusterController.STRIMZI_TYPE_LABEL, "kafka-connect-s2i", ClusterController.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), bc.getMetadata().getLabels());
+        assertEquals(ResourceUtils.labels(Labels.STRIMZI_CLUSTER_LABEL, cluster, Labels.STRIMZI_TYPE_LABEL, "kafka-connect-s2i", Labels.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), bc.getMetadata().getLabels());
         assertEquals("ImageStreamTag", bc.getSpec().getOutput().getTo().getKind());
         assertEquals(kc.image, bc.getSpec().getOutput().getTo().getName());
         assertEquals("Serial", bc.getSpec().getRunPolicy());
@@ -519,7 +519,7 @@ public class KafkaConnectS2IClusterTest {
 
         BuildConfig bc = kc.patchBuildConfig(orig);
 
-        assertEquals(ResourceUtils.labels(ClusterController.STRIMZI_CLUSTER_LABEL, cluster, ClusterController.STRIMZI_TYPE_LABEL, "kafka-connect-s2i", ClusterController.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), bc.getMetadata().getLabels());
+        assertEquals(ResourceUtils.labels(Labels.STRIMZI_CLUSTER_LABEL, cluster, Labels.STRIMZI_TYPE_LABEL, "kafka-connect-s2i", Labels.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), bc.getMetadata().getLabels());
         assertEquals(kc.getSourceImageStreamName() + ":" + kc.sourceImageTag, bc.getSpec().getStrategy().getSourceStrategy().getFrom().getName());
     }
 
@@ -529,7 +529,7 @@ public class KafkaConnectS2IClusterTest {
 
         assertEquals(kc.getSourceImageStreamName(), is.getMetadata().getName());
         assertEquals(namespace, is.getMetadata().getNamespace());
-        assertEquals(ResourceUtils.labels(ClusterController.STRIMZI_CLUSTER_LABEL, cluster, ClusterController.STRIMZI_TYPE_LABEL, "kafka-connect-s2i", ClusterController.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.getSourceImageStreamName()), is.getMetadata().getLabels());
+        assertEquals(ResourceUtils.labels(Labels.STRIMZI_CLUSTER_LABEL, cluster, Labels.STRIMZI_TYPE_LABEL, "kafka-connect-s2i", Labels.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.getSourceImageStreamName()), is.getMetadata().getLabels());
         assertEquals(false, is.getSpec().getLookupPolicy().getLocal());
         assertEquals(1, is.getSpec().getTags().size());
         assertEquals(image.substring(image.lastIndexOf(":") + 1), is.getSpec().getTags().get(0).getName());
@@ -543,7 +543,7 @@ public class KafkaConnectS2IClusterTest {
 
         assertEquals(kc.kafkaConnectClusterName(cluster), is.getMetadata().getName());
         assertEquals(namespace, is.getMetadata().getNamespace());
-        assertEquals(ResourceUtils.labels(ClusterController.STRIMZI_CLUSTER_LABEL, cluster, ClusterController.STRIMZI_TYPE_LABEL, "kafka-connect-s2i", ClusterController.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), is.getMetadata().getLabels());
+        assertEquals(ResourceUtils.labels(Labels.STRIMZI_CLUSTER_LABEL, cluster, Labels.STRIMZI_TYPE_LABEL, "kafka-connect-s2i", Labels.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), is.getMetadata().getLabels());
         assertEquals(true, is.getSpec().getLookupPolicy().getLocal());
     }
 
@@ -570,7 +570,7 @@ public class KafkaConnectS2IClusterTest {
 
         ImageStream is = kc.patchSourceImageStream(orig);
 
-        assertEquals(ResourceUtils.labels(ClusterController.STRIMZI_CLUSTER_LABEL, cluster, ClusterController.STRIMZI_TYPE_LABEL, "kafka-connect-s2i", ClusterController.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.getSourceImageStreamName()), is.getMetadata().getLabels());
+        assertEquals(ResourceUtils.labels(Labels.STRIMZI_CLUSTER_LABEL, cluster, Labels.STRIMZI_TYPE_LABEL, "kafka-connect-s2i", Labels.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.getSourceImageStreamName()), is.getMetadata().getLabels());
         assertEquals(image.substring(image.lastIndexOf(":") + 1), is.getSpec().getTags().get(0).getName());
         assertEquals(image, is.getSpec().getTags().get(0).getFrom().getName());
     }
@@ -589,6 +589,6 @@ public class KafkaConnectS2IClusterTest {
 
         ImageStream is = kc.patchTargetImageStream(orig);
 
-        assertEquals(ResourceUtils.labels(ClusterController.STRIMZI_CLUSTER_LABEL, cluster, ClusterController.STRIMZI_TYPE_LABEL, "kafka-connect-s2i", ClusterController.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), is.getMetadata().getLabels());
+        assertEquals(ResourceUtils.labels(Labels.STRIMZI_CLUSTER_LABEL, cluster, Labels.STRIMZI_TYPE_LABEL, "kafka-connect-s2i", Labels.STRIMZI_KIND_LABEL, "cluster", "strimzi.io/name", kc.kafkaConnectClusterName(cluster)), is.getMetadata().getLabels());
     }
 }

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/resources/KafkaConnectS2IClusterTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/resources/KafkaConnectS2IClusterTest.java
@@ -20,7 +20,6 @@ import io.fabric8.openshift.api.model.ImageLookupPolicyBuilder;
 import io.fabric8.openshift.api.model.ImageStream;
 import io.fabric8.openshift.api.model.ImageStreamBuilder;
 import io.fabric8.openshift.api.model.TagReference;
-import io.strimzi.controller.cluster.ClusterController;
 import io.strimzi.controller.cluster.ResourceUtils;
 import org.junit.Test;
 

--- a/documentation/adoc/cluster-controller.adoc
+++ b/documentation/adoc/cluster-controller.adoc
@@ -36,9 +36,8 @@ a consistent state across all of them.
 [[config_map_details]]
 === Format of the cluster ConfigMap
 
-By default, the controller watches for ConfigMaps having the label `strimzi.io/kind=cluster` in order to find and get
-configuration for a Kafka or Kafka Connect cluster to deploy. The label is configurable through the `STRIMZI_CONFIGMAP_LABELS` 
-environment variable.
+The controller watches for ConfigMaps having the label `strimzi.io/kind=cluster` in order to find and get
+configuration for a Kafka or Kafka Connect cluster to deploy.
 
 In order to distinguish which "type" of cluster to deploy, Kafka or Kafka Connect, the controller checks the
 `strimzi.io/type` label which can have one of the the following values :
@@ -47,6 +46,10 @@ In order to distinguish which "type" of cluster to deploy, Kafka or Kafka Connec
 * `kafka-connect`: the ConfigMap provides configuration for a Kafka Connect cluster deployment
 * `kafka-connect-s2i`: the ConfigMap provides configuration for a Kafka Connect cluster deployment using Build and Source2Image
 features (works only with OpenShift)
+
+Whatever other labels are applied to the ConfigMap will also be applied to the Kubernetes/OpenShift resources making
+up the Kafka or Kafka Connect cluster. This provides a convenient mechanism for those resource to be labelled
+in whatever way the user requires.
 
 The `data` section of such ConfigMaps contains different keys depending on the "type" of deployment as described in the 
 following sections.
@@ -381,9 +384,6 @@ include::../../examples/install/cluster-controller/03-role-binding.yaml[]
 === Controller configuration
 
 The controller itself can be configured through the following environment variables.
-
-`STRIMZI_CONFIGMAP_LABELS`:: Required. The Kubernetes/OpenShift label selector used to identify ConfigMaps to be managed by the
-controller.
 
 `STRIMZI_NAMESPACE`:: Required. A comma-separated list of namespaces that the controller should operate in. The Cluster Controller deployment might use the https://kubernetes.io/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/#the-downward-api[Kubernetes Downward API]
 to set this automatically to the namespace the Cluster Controller is deployed in. See the example below:

--- a/documentation/adoc/getting-started.adoc
+++ b/documentation/adoc/getting-started.adoc
@@ -83,7 +83,7 @@ acquired using a PersistentVolumeClaim – that makes it independent of the actu
 example, it can use HostPath volumes on Minikube or Amazon EBS volumes in Amazon AWS deployments without any
 changes in the YAML files. The PersistentVolumeClaim can use a StorageClass to trigger automatic volume provisioning.
 
-To deploy a Kafka cluster, a ConfigMap with the cluster configuration has to be created. By default, the ConfigMap
+To deploy a Kafka cluster, a ConfigMap with the cluster configuration has to be created. The ConfigMap
 should have the following labels:
 
 [source,yaml]


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The change:

* Adds the appropriate labels to the kafka and zookeeper metrics CMs (fixes  #161)
* Changes the label added to the TC Deployment from `kind=topic` to `type=topic-controller`
* Removes `kind=cluster` from the resources created by the cluster. This means that both in CC and TC the `kind` label us used consistently for resources which are watched-for by a controller.
* Adds (hopefully) clear Javadoc for the the labels. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging

