### PR TITLE
Ci failure info

### DIFF
--- a/common-test/src/main/java/io/strimzi/test/StrimziRunner.java
+++ b/common-test/src/main/java/io/strimzi/test/StrimziRunner.java
@@ -31,6 +31,7 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
 
+import static io.strimzi.test.TestUtils.indent;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -127,7 +128,7 @@ public class StrimziRunner extends BlockJUnit4ClassRunner {
         return list;
     }
 
-    static abstract class Bracket extends Statement implements Runnable {
+    abstract class Bracket extends Statement implements Runnable {
         private final Statement statement;
         private final Thread hook = new Thread(this);
         public Bracket(Statement statement) {
@@ -139,6 +140,12 @@ public class StrimziRunner extends BlockJUnit4ClassRunner {
                 Runtime.getRuntime().addShutdownHook(hook);
                 before();
                 statement.evaluate();
+            } catch (Throwable e) {
+                if (!(e instanceof VirtualMachineError)) {
+                    onError(e);
+                }
+                throw e;
+
             } finally {
                 Runtime.getRuntime().removeShutdownHook(hook);
                 runAfter();
@@ -147,6 +154,24 @@ public class StrimziRunner extends BlockJUnit4ClassRunner {
         }
         protected abstract void before();
         protected abstract void after();
+
+        protected void onError(Throwable t) {
+            LOGGER.info("The test is failing/erroring due to {}, here's some diagnostic output{}{}",
+                    t, System.lineSeparator(), "----------------------------------------------------------------------");
+            for (String resourceType : asList("pod", "deployment", "statefulset", "cm")) {
+                for (String resourceName : kubeClient().list(resourceType)) {
+                    LOGGER.info("Description of {} '{}':{}{}", resourceType, resourceName,
+                            System.lineSeparator(), indent(kubeClient().describe(resourceType, resourceName)));
+                }
+            }
+            for (String pod : kubeClient().list("pod")) {
+                LOGGER.info("Logs from pod {}:{}{}", pod, System.lineSeparator(), indent(kubeClient().logs(pod)));
+            }
+            LOGGER.info("That's all the diagnostic info, the exception {} will now propoagate and the test will fail{}{}",
+                    t,
+                    t, System.lineSeparator(), "----------------------------------------------------------------------");
+        }
+
         @Override
         public void run() {
             runAfter();
@@ -158,7 +183,7 @@ public class StrimziRunner extends BlockJUnit4ClassRunner {
         }
     }
 
-    protected KubeClient kubeClient() {
+    protected KubeClient<?> kubeClient() {
         return clusterResource().client();
     }
 

--- a/common-test/src/main/java/io/strimzi/test/TestUtils.java
+++ b/common-test/src/main/java/io/strimzi/test/TestUtils.java
@@ -38,6 +38,10 @@ public final class TestUtils {
      * (helpful if you have several calls which need to share a common timeout),
      * */
     public static long waitFor(String description, long pollIntervalMs, long timeoutMs, BooleanSupplier ready) {
+        return waitFor(description, pollIntervalMs, timeoutMs, ready, () -> { });
+    }
+
+    public static long waitFor(String description, long pollIntervalMs, long timeoutMs, BooleanSupplier ready, Runnable onTimeout) {
         LOGGER.debug("Waiting for {}", description);
         long deadline = System.currentTimeMillis() + timeoutMs;
         while (true) {
@@ -47,6 +51,7 @@ public final class TestUtils {
                 return timeLeft;
             }
             if (timeLeft <= 0) {
+                onTimeout.run();
                 throw new TimeoutException("Timeout after " + timeoutMs + " ms waiting for " + description + " to be ready");
             }
             long sleepTime = Math.min(pollIntervalMs, timeLeft);
@@ -59,5 +64,14 @@ public final class TestUtils {
                 return deadline - System.currentTimeMillis();
             }
         }
+    }
+
+    public static String indent(String s) {
+        StringBuilder sb = new StringBuilder();
+        String[] lines = s.split("[\n\r]");
+        for (String line : lines) {
+            sb.append("    ").append(line).append(System.lineSeparator());
+        }
+        return sb.toString();
     }
 }

--- a/common-test/src/main/java/io/strimzi/test/k8s/BaseKubeClient.java
+++ b/common-test/src/main/java/io/strimzi/test/k8s/BaseKubeClient.java
@@ -203,7 +203,7 @@ public abstract class BaseKubeClient<K extends BaseKubeClient<K>> implements Kub
     }
 
     private K waitFor(String resource, String name, Predicate<JsonNode> ready) {
-        long timeoutMs = 600_000L;
+        long timeoutMs = 570_000L;
         long pollMs = 1_000L;
         ObjectMapper mapper = new ObjectMapper();
         TestUtils.waitFor(resource + " " + name, pollMs, timeoutMs, () -> {

--- a/common-test/src/main/java/io/strimzi/test/k8s/BaseKubeClient.java
+++ b/common-test/src/main/java/io/strimzi/test/k8s/BaseKubeClient.java
@@ -240,7 +240,9 @@ public abstract class BaseKubeClient<K extends BaseKubeClient<K>> implements Kub
                 JsonNode containerStatuses = actualObj.get("status").get("containerStatuses");
                 if (containerStatuses != null && containerStatuses.isArray()) {
                     for (final JsonNode objNode : containerStatuses) {
-                        if (!objNode.get("ready").asBoolean()) return false;
+                        if (!objNode.get("ready").asBoolean()) {
+                            return false;
+                        }
                     }
                     return true;
                 }

--- a/common-test/src/main/java/io/strimzi/test/k8s/BaseKubeClient.java
+++ b/common-test/src/main/java/io/strimzi/test/k8s/BaseKubeClient.java
@@ -292,7 +292,7 @@ public abstract class BaseKubeClient<K extends BaseKubeClient<K>> implements Kub
 
     @Override
     public List<String> list(String resourceType) {
-        return asList(Exec.exec(namespacedCommand("get", resourceType, "-o", "jsonpath={range .items[*]}{.metadata.name} ")).out().trim().split(" "));
+        return asList(Exec.exec(namespacedCommand("get", resourceType, "-o", "jsonpath={range .items[*]}{.metadata.name} ")).out().trim().split(" +"));
     }
 
     @Override

--- a/common-test/src/main/java/io/strimzi/test/k8s/BaseKubeClient.java
+++ b/common-test/src/main/java/io/strimzi/test/k8s/BaseKubeClient.java
@@ -289,4 +289,19 @@ public abstract class BaseKubeClient<K extends BaseKubeClient<K>> implements Kub
     public String toString() {
         return cmd();
     }
+
+    @Override
+    public List<String> list(String resourceType) {
+        return asList(Exec.exec(namespacedCommand("get", resourceType, "-o", "jsonpath={range .items[*]}{.metadata.name} ")).out().trim().split(" "));
+    }
+
+    @Override
+    public String describe(String resourceType, String resourceName) {
+        return Exec.exec(namespacedCommand("describe", resourceType, resourceName)).out();
+    }
+
+    @Override
+    public String logs(String pod) {
+        return Exec.exec(namespacedCommand("logs", pod)).out();
+    }
 }

--- a/common-test/src/main/java/io/strimzi/test/k8s/KubeClient.java
+++ b/common-test/src/main/java/io/strimzi/test/k8s/KubeClient.java
@@ -113,4 +113,10 @@ public interface KubeClient<K extends KubeClient<K>> {
     String get(String resource, String resourceName);
 
     K waitForResourceDeletion(String resourceType, String resourceName);
+
+    List<String> list(String resourceType);
+
+    String describe(String resourceType, String resourceName);
+
+    String logs(String pod);
 }

--- a/common-test/src/test/java/io/strimzi/test/StrimziRunnerTest.java
+++ b/common-test/src/test/java/io/strimzi/test/StrimziRunnerTest.java
@@ -6,6 +6,8 @@ package io.strimzi.test;
 
 import io.strimzi.test.k8s.KubeClient;
 import io.strimzi.test.k8s.KubeClusterResource;
+import org.junit.Assert;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.JUnitCore;
@@ -13,11 +15,16 @@ import org.junit.runner.Request;
 import org.junit.runner.Result;
 import org.junit.runner.RunWith;
 
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class StrimziRunnerTest {
 
@@ -63,9 +70,21 @@ public class StrimziRunnerTest {
         public void test1() {
             System.out.println("Hello");
         }
+
+        @Namespace("different")
+        @Resources("moreResources")
+        @Test
+        public void test2() {
+            Assert.fail("This test fails");
+        }
     }
 
     JUnitCore jUnitCore = new JUnitCore();
+
+    @Before
+    public void resetMock() {
+        reset(MOCK_KUBE_CLIENT);
+    }
 
     @Test
     public void test0() {
@@ -93,9 +112,34 @@ public class StrimziRunnerTest {
             r.getFailures().get(0).getException().printStackTrace();
         }
         assertTrue(r.wasSuccessful());
-        verify(MOCK_KUBE_CLIENT, times(2)).createNamespace(eq("test"));
-        verify(MOCK_KUBE_CLIENT, times(2)).create(eq("foo"));
-        verify(MOCK_KUBE_CLIENT, times(2)).deleteNamespace(eq("test"));
-        verify(MOCK_KUBE_CLIENT, times(2)).delete(eq("foo"));
+        verify(MOCK_KUBE_CLIENT, times(1)).createNamespace(eq("test"));
+        verify(MOCK_KUBE_CLIENT, times(1)).create(eq("foo"));
+        verify(MOCK_KUBE_CLIENT, times(1)).deleteNamespace(eq("test"));
+        verify(MOCK_KUBE_CLIENT, times(1)).delete(eq("foo"));
+    }
+
+    @Test
+    public void test2() {
+        if (System.getenv(StrimziRunner.NOTEARDOWN) != null) {
+            return;
+        }
+        for (String resourceType : asList("pod", "deployment", "statefulset", "cm")) {
+            when(MOCK_KUBE_CLIENT.list(resourceType)).thenReturn(asList(resourceType + "1", resourceType + "2"));
+            when(MOCK_KUBE_CLIENT.describe(resourceType, resourceType + "1")).thenReturn("Blah\nblah,\n" + resourceType + "1");
+            when(MOCK_KUBE_CLIENT.describe(resourceType, resourceType + "2")).thenReturn("Blah\nblah,\n" + resourceType + "2");
+        }
+        when(MOCK_KUBE_CLIENT.logs("pod1")).thenReturn("these\nare\nthe\nlogs\nfrom\npod\n1");
+        when(MOCK_KUBE_CLIENT.logs("pod2")).thenReturn("these\nare\nthe\nlogs\nfrom\npod\n2");
+
+        Result r =  jUnitCore.run(Request.method(ClsWithClusterResource.class, "test2"));
+        if (!r.wasSuccessful()) {
+            r.getFailures().get(0).getException().printStackTrace();
+        }
+        assertFalse(r.wasSuccessful());
+        assertEquals(1, r.getFailures().size());
+        verify(MOCK_KUBE_CLIENT, times(1)).createNamespace(eq("test"));
+        verify(MOCK_KUBE_CLIENT, times(1)).create(eq("foo"));
+        verify(MOCK_KUBE_CLIENT, times(1)).deleteNamespace(eq("test"));
+        verify(MOCK_KUBE_CLIENT, times(1)).delete(eq("foo"));
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterTest.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterTest.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 
+import static io.strimzi.test.TestUtils.indent;
 import static io.strimzi.test.TestUtils.map;
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
@@ -210,7 +211,12 @@ public class KafkaClusterTest {
                 LOGGER.trace("Exception while waiting for ZK to become leader/follower, ignoring", e);
             }
             return false;
-        });
+        },
+            () -> LOGGER.info("zookeeper `mntr` output at the point of timeout does not match {}:{}{}",
+                pattern.pattern(),
+                System.lineSeparator(),
+                indent(kubeClient.exec(pod, "/bin/bash", "-c", "echo mntr | nc localhost 2181").out()))
+        );
     }
 
 }


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature

### Description

Gets extra diagnostic info when system tests fail:

1. description of ss, deps, pods and cms
2. logs of pods

Fixes a minor bug.

Changes the ZK scale up/down tests to scale up to 3, in the hope this avoids failures with mntr (which is seems to have done so far, but only time will tell).

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging

