### PR TITLE
Added events creation rights to the cluster controller role

### DIFF
--- a/examples/install/cluster-controller/02-role.yaml
+++ b/examples/install/cluster-controller/02-role.yaml
@@ -75,6 +75,12 @@ rules:
   - delete
   - patch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
 # OpenShift S2I requirements
 - apiGroups:
   - "extensions"


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When the topic controller is deployed by the cluster controller, at RBAC level it uses the same service account as cluster controller `strimzi-cluster-controller` with same rights. The topic controller need the events creation as well. This trivial PR adds this rights that will be used by the cluster controller in the future as well.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging

