### PR TITLE
Making max attempts configurable for backoff on topic metadata request

### DIFF
--- a/.checkstyle/checkstyle.xml
+++ b/.checkstyle/checkstyle.xml
@@ -92,7 +92,7 @@
         </module>
         <module name="ClassDataAbstractionCoupling">
             <!-- default is 7 -->
-            <property name="max" value="20"/>
+            <property name="max" value="21"/>
         </module>
         <module name="BooleanExpressionComplexity">
             <!-- default is 3 -->

--- a/.checkstyle/checkstyle.xml
+++ b/.checkstyle/checkstyle.xml
@@ -92,7 +92,7 @@
         </module>
         <module name="ClassDataAbstractionCoupling">
             <!-- default is 7 -->
-            <property name="max" value="21"/>
+            <property name="max" value="20"/>
         </module>
         <module name="BooleanExpressionComplexity">
             <!-- default is 3 -->

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/AbstractCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/AbstractCluster.java
@@ -574,7 +574,7 @@ public abstract class AbstractCluster {
      * @param value The value of the environment variable
      * @return The environment variable instance
      */
-    protected EnvVar buildEnvVar(String name, String value) {
+    protected static EnvVar buildEnvVar(String name, String value) {
         return new EnvVarBuilder().withName(name).withValue(value).build();
     }
 }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/AbstractCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/AbstractCluster.java
@@ -13,6 +13,7 @@ import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.ContainerPort;
 import io.fabric8.kubernetes.api.model.ContainerPortBuilder;
 import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaimBuilder;
@@ -564,5 +565,16 @@ public abstract class AbstractCluster {
         cm.setData(data);
 
         return cm;
+    }
+
+    /**
+     * Build an environment variable instance with the provided name and value
+     *
+     * @param name The name of the environment variable
+     * @param value The value of the environment variable
+     * @return The environment variable instance
+     */
+    protected EnvVar buildEnvVar(String name, String value) {
+        return new EnvVarBuilder().withName(name).withValue(value).build();
     }
 }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/TopicController.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/TopicController.java
@@ -186,38 +186,18 @@ public class TopicController extends AbstractCluster {
 
         String config = kafkaClusterCm.getData().get(KEY_CONFIG);
         if (config != null) {
-            topicController = new TopicController(kafkaClusterCm.getMetadata().getNamespace(),
+            String namespace = kafkaClusterCm.getMetadata().getNamespace();
+            topicController = new TopicController(namespace,
                     kafkaClusterCm.getMetadata().getName(),
                     Labels.fromResource(kafkaClusterCm));
 
             JsonObject json = new JsonObject(config);
 
-            String image = json.getString(TopicController.IMAGE_FIELD);
-            if (image != null) {
-                topicController.setImage(image);
-            }
-
-            String topicNamespace = json.getString(TopicController.NAMESPACE_FIELD);
-            if (topicNamespace != null) {
-                topicController.setTopicNamespace(topicNamespace);
-            }
-
-            String reconciliationIntervalMs = json.getString(TopicController.RECONCILIATION_INTERVAL_FIELD_MS);
-            if (reconciliationIntervalMs != null) {
-                // TODO : add parsing and validation
-                topicController.setReconciliationIntervalMs(reconciliationIntervalMs);
-            }
-
-            String zookeeperSessionTimeoutMs = json.getString(TopicController.ZOOKEEPER_SESSION_TIMEOUT_FIELD_MS);
-            if (zookeeperSessionTimeoutMs != null) {
-                // TODO : add parsing and validation
-                topicController.setZookeeperSessionTimeoutMs(zookeeperSessionTimeoutMs);
-            }
-
-            Integer topicMetadataMaxAttempts = json.getInteger(TopicController.TOPIC_METADATA_MAX_ATTEMPTS_FIELD);
-            if (topicMetadataMaxAttempts != null) {
-                topicController.setTopicMetadataMaxAttempts(topicMetadataMaxAttempts);
-            }
+            topicController.setImage(json.getString(TopicController.IMAGE_FIELD, DEFAULT_IMAGE));
+            topicController.setTopicNamespace(json.getString(TopicController.NAMESPACE_FIELD, namespace));
+            topicController.setReconciliationIntervalMs(json.getString(TopicController.RECONCILIATION_INTERVAL_FIELD_MS, DEFAULT_FULL_RECONCILIATION_INTERVAL_MS));
+            topicController.setZookeeperSessionTimeoutMs(json.getString(TopicController.ZOOKEEPER_SESSION_TIMEOUT_FIELD_MS, DEFAULT_ZOOKEEPER_SESSION_TIMEOUT_MS));
+            topicController.setTopicMetadataMaxAttempts(json.getInteger(TopicController.TOPIC_METADATA_MAX_ATTEMPTS_FIELD, DEFAULT_TOPIC_METADATA_MAX_ATTEMPTS));
         }
 
         return topicController;

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/TopicController.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/TopicController.java
@@ -7,7 +7,6 @@ package io.strimzi.controller.cluster.resources;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
-import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 import io.fabric8.kubernetes.api.model.extensions.Deployment;
 import io.fabric8.kubernetes.api.model.extensions.DeploymentStrategy;
 import io.fabric8.kubernetes.api.model.extensions.DeploymentStrategyBuilder;
@@ -325,13 +324,13 @@ public class TopicController extends AbstractCluster {
     @Override
     protected List<EnvVar> getEnvVars() {
         List<EnvVar> varList = new ArrayList<>();
-        varList.add(new EnvVarBuilder().withName(KEY_CONFIGMAP_LABELS).withValue(topicConfigMapLabels).build());
-        varList.add(new EnvVarBuilder().withName(KEY_KAFKA_BOOTSTRAP_SERVERS).withValue(kafkaBootstrapServers).build());
-        varList.add(new EnvVarBuilder().withName(KEY_ZOOKEEPER_CONNECT).withValue(zookeeperConnect).build());
-        varList.add(new EnvVarBuilder().withName(KEY_NAMESPACE).withValue(topicNamespace).build());
-        varList.add(new EnvVarBuilder().withName(KEY_FULL_RECONCILIATION_INTERVAL_MS).withValue(reconciliationIntervalMs).build());
-        varList.add(new EnvVarBuilder().withName(KEY_ZOOKEEPER_SESSION_TIMEOUT_MS).withValue(zookeeperSessionTimeoutMs).build());
-        varList.add(new EnvVarBuilder().withName(KEY_TOPIC_METADATA_MAX_ATTEMPTS).withValue(String.valueOf(topicMetadataMaxAttempts)).build());
+        varList.add(buildEnvVar(KEY_CONFIGMAP_LABELS, topicConfigMapLabels));
+        varList.add(buildEnvVar(KEY_KAFKA_BOOTSTRAP_SERVERS, kafkaBootstrapServers));
+        varList.add(buildEnvVar(KEY_ZOOKEEPER_CONNECT, zookeeperConnect));
+        varList.add(buildEnvVar(KEY_NAMESPACE, topicNamespace));
+        varList.add(buildEnvVar(KEY_FULL_RECONCILIATION_INTERVAL_MS, reconciliationIntervalMs));
+        varList.add(buildEnvVar(KEY_ZOOKEEPER_SESSION_TIMEOUT_MS, zookeeperSessionTimeoutMs));
+        varList.add(buildEnvVar(KEY_TOPIC_METADATA_MAX_ATTEMPTS, String.valueOf(topicMetadataMaxAttempts)));
 
         return varList;
     }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/TopicController.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/TopicController.java
@@ -52,7 +52,7 @@ public class TopicController extends AbstractCluster {
     protected static final int DEFAULT_BOOTSTRAP_SERVERS_PORT = 9092;
     protected static final String DEFAULT_FULL_RECONCILIATION_INTERVAL_MS = "900000";
     protected static final String DEFAULT_ZOOKEEPER_SESSION_TIMEOUT_MS = "20000";
-    protected static final int DEFAULT_TOPIC_METADATA_MAX_ATTEMPTS = 4;
+    protected static final int DEFAULT_TOPIC_METADATA_MAX_ATTEMPTS = 6;
 
     // Configuration keys
     public static final String KEY_CONFIG = "topic-controller-config";

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/TopicController.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/TopicController.java
@@ -32,7 +32,7 @@ public class TopicController extends AbstractCluster {
 
     private static final String NAME_SUFFIX = "-topic-controller";
 
-    private static final String NAMESPACE_FIELD = "namespace";
+    private static final String WATCHED_NAMESPACE_FIELD = "watchedNamespace";
     private static final String IMAGE_FIELD = "image";
     private static final String RECONCILIATION_INTERVAL_FIELD_MS = "reconciliationIntervalMs";
     private static final String ZOOKEEPER_SESSION_TIMEOUT_FIELD_MS = "zookeeperSessionTimeoutMs";
@@ -60,7 +60,7 @@ public class TopicController extends AbstractCluster {
     public static final String KEY_CONFIGMAP_LABELS = "STRIMZI_CONFIGMAP_LABELS";
     public static final String KEY_KAFKA_BOOTSTRAP_SERVERS = "STRIMZI_KAFKA_BOOTSTRAP_SERVERS";
     public static final String KEY_ZOOKEEPER_CONNECT = "STRIMZI_ZOOKEEPER_CONNECT";
-    public static final String KEY_NAMESPACE = "STRIMZI_NAMESPACE";
+    public static final String KEY_WATCHED_NAMESPACE = "STRIMZI_NAMESPACE";
     public static final String KEY_FULL_RECONCILIATION_INTERVAL_MS = "STRIMZI_FULL_RECONCILIATION_INTERVAL_MS";
     public static final String KEY_ZOOKEEPER_SESSION_TIMEOUT_MS = "STRIMZI_ZOOKEEPER_SESSION_TIMEOUT_MS";
     public static final String KEY_TOPIC_METADATA_MAX_ATTEMPTS = "STRIMZI_TOPIC_METADATA_MAX_ATTEMPTS";
@@ -69,7 +69,7 @@ public class TopicController extends AbstractCluster {
     private String kafkaBootstrapServers;
     private String zookeeperConnect;
 
-    private String topicNamespace;
+    private String watchedNamespace;
     private String reconciliationIntervalMs;
     private String zookeeperSessionTimeoutMs;
     private String topicConfigMapLabels;
@@ -92,19 +92,19 @@ public class TopicController extends AbstractCluster {
         // create a default configuration
         this.kafkaBootstrapServers = defaultBootstrapServers(cluster);
         this.zookeeperConnect = defaultZookeeperConnect(cluster);
-        this.topicNamespace = namespace;
+        this.watchedNamespace = namespace;
         this.reconciliationIntervalMs = DEFAULT_FULL_RECONCILIATION_INTERVAL_MS;
         this.zookeeperSessionTimeoutMs = DEFAULT_ZOOKEEPER_SESSION_TIMEOUT_MS;
         this.topicConfigMapLabels = defaultTopicConfigMapLabels(cluster);
         this.topicMetadataMaxAttempts = DEFAULT_TOPIC_METADATA_MAX_ATTEMPTS;
     }
 
-    public void setTopicNamespace(String topicNamespace) {
-        this.topicNamespace = topicNamespace;
+    public void setWatchedNamespace(String watchedNamespace) {
+        this.watchedNamespace = watchedNamespace;
     }
 
-    public String getTopicNamespace() {
-        return topicNamespace;
+    public String getWatchedNamespace() {
+        return watchedNamespace;
     }
 
     public void setTopicConfigMapLabels(String topicConfigMapLabels) {
@@ -193,7 +193,7 @@ public class TopicController extends AbstractCluster {
             JsonObject json = new JsonObject(config);
 
             topicController.setImage(json.getString(TopicController.IMAGE_FIELD, DEFAULT_IMAGE));
-            topicController.setTopicNamespace(json.getString(TopicController.NAMESPACE_FIELD, namespace));
+            topicController.setWatchedNamespace(json.getString(TopicController.WATCHED_NAMESPACE_FIELD, namespace));
             topicController.setReconciliationIntervalMs(json.getString(TopicController.RECONCILIATION_INTERVAL_FIELD_MS, DEFAULT_FULL_RECONCILIATION_INTERVAL_MS));
             topicController.setZookeeperSessionTimeoutMs(json.getString(TopicController.ZOOKEEPER_SESSION_TIMEOUT_FIELD_MS, DEFAULT_ZOOKEEPER_SESSION_TIMEOUT_MS));
             topicController.setTopicMetadataMaxAttempts(json.getInteger(TopicController.TOPIC_METADATA_MAX_ATTEMPTS_FIELD, DEFAULT_TOPIC_METADATA_MAX_ATTEMPTS));
@@ -229,7 +229,7 @@ public class TopicController extends AbstractCluster {
 
             topicController.setKafkaBootstrapServers(vars.getOrDefault(KEY_KAFKA_BOOTSTRAP_SERVERS, defaultBootstrapServers(cluster)));
             topicController.setZookeeperConnect(vars.getOrDefault(KEY_ZOOKEEPER_CONNECT, defaultZookeeperConnect(cluster)));
-            topicController.setTopicNamespace(vars.getOrDefault(KEY_NAMESPACE, namespace));
+            topicController.setWatchedNamespace(vars.getOrDefault(KEY_WATCHED_NAMESPACE, namespace));
             topicController.setReconciliationIntervalMs(vars.getOrDefault(KEY_FULL_RECONCILIATION_INTERVAL_MS, DEFAULT_FULL_RECONCILIATION_INTERVAL_MS));
             topicController.setZookeeperSessionTimeoutMs(vars.getOrDefault(KEY_ZOOKEEPER_SESSION_TIMEOUT_MS, DEFAULT_ZOOKEEPER_SESSION_TIMEOUT_MS));
             topicController.setTopicConfigMapLabels(vars.getOrDefault(KEY_CONFIGMAP_LABELS, defaultTopicConfigMapLabels(cluster)));
@@ -271,7 +271,7 @@ public class TopicController extends AbstractCluster {
                 isDifferent = true;
             }
 
-            if (!topicNamespace.equals(vars.getOrDefault(KEY_NAMESPACE, namespace))) {
+            if (!watchedNamespace.equals(vars.getOrDefault(KEY_WATCHED_NAMESPACE, namespace))) {
                 log.info("Diff: Namespace in which watching for topics changed");
                 isDifferent = true;
             }
@@ -327,7 +327,7 @@ public class TopicController extends AbstractCluster {
         varList.add(buildEnvVar(KEY_CONFIGMAP_LABELS, topicConfigMapLabels));
         varList.add(buildEnvVar(KEY_KAFKA_BOOTSTRAP_SERVERS, kafkaBootstrapServers));
         varList.add(buildEnvVar(KEY_ZOOKEEPER_CONNECT, zookeeperConnect));
-        varList.add(buildEnvVar(KEY_NAMESPACE, topicNamespace));
+        varList.add(buildEnvVar(KEY_WATCHED_NAMESPACE, watchedNamespace));
         varList.add(buildEnvVar(KEY_FULL_RECONCILIATION_INTERVAL_MS, reconciliationIntervalMs));
         varList.add(buildEnvVar(KEY_ZOOKEEPER_SESSION_TIMEOUT_MS, zookeeperSessionTimeoutMs));
         varList.add(buildEnvVar(KEY_TOPIC_METADATA_MAX_ATTEMPTS, String.valueOf(topicMetadataMaxAttempts)));

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/resources/TopicControllerTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/resources/TopicControllerTest.java
@@ -35,12 +35,14 @@ public class TopicControllerTest {
     private final String tcImage = "my-topic-controller-image";
     private final String tcReconciliationInterval = "900000";
     private final String tcZookeeperSessionTimeout = "20000";
+    private final int tcTopicMetadataMaxAttempts = 3;
 
     private final String topicControllerJson = "{ " +
             "\"namespace\":\"" + tcNamespace + "\", " +
             "\"image\":\"" + tcImage + "\", " +
             "\"reconciliationInterval\":\"" + tcReconciliationInterval + "\", " +
-            "\"zookeeperSessionTimeout\":\"" + tcZookeeperSessionTimeout + "\"" +
+            "\"zookeeperSessionTimeout\":\"" + tcZookeeperSessionTimeout + "\"," +
+            "\"topicMetadataMaxAttempts\":" + tcTopicMetadataMaxAttempts +
             " }";
 
     private final ConfigMap cm = ResourceUtils.createKafkaClusterConfigMap(namespace, cluster, replicas, image, healthDelay, healthTimeout, metricsCmJson, storageJson, topicControllerJson);
@@ -54,6 +56,7 @@ public class TopicControllerTest {
         expected.add(new EnvVarBuilder().withName(TopicController.KEY_NAMESPACE).withValue(tcNamespace).build());
         expected.add(new EnvVarBuilder().withName(TopicController.KEY_FULL_RECONCILIATION_INTERVAL_MS).withValue(tcReconciliationInterval).build());
         expected.add(new EnvVarBuilder().withName(TopicController.KEY_ZOOKEEPER_SESSION_TIMEOUT_MS).withValue(tcZookeeperSessionTimeout).build());
+        expected.add(new EnvVarBuilder().withName(TopicController.KEY_TOPIC_METADATA_MAX_ATTEMPTS).withValue(String.valueOf(tcTopicMetadataMaxAttempts)).build());
 
         return expected;
     }
@@ -80,6 +83,7 @@ public class TopicControllerTest {
         assertEquals(TopicController.defaultBootstrapServers(cluster), tc.getKafkaBootstrapServers());
         assertEquals(TopicController.defaultZookeeperConnect(cluster), tc.getZookeeperConnect());
         assertEquals(TopicController.defaultTopicConfigMapLabels(cluster), tc.getTopicConfigMapLabels());
+        assertEquals(TopicController.DEFAULT_TOPIC_METADATA_MAX_ATTEMPTS, tc.getTopicMetadataMaxAttempts());
     }
 
     @Test
@@ -98,6 +102,7 @@ public class TopicControllerTest {
         assertEquals(TopicController.defaultBootstrapServers(cluster), tc.getKafkaBootstrapServers());
         assertEquals(TopicController.defaultZookeeperConnect(cluster), tc.getZookeeperConnect());
         assertEquals(TopicController.defaultTopicConfigMapLabels(cluster), tc.getTopicConfigMapLabels());
+        assertEquals(tcTopicMetadataMaxAttempts, tc.getTopicMetadataMaxAttempts());
     }
 
     @Test
@@ -118,6 +123,7 @@ public class TopicControllerTest {
         assertEquals(tc.getKafkaBootstrapServers(), tcFromDep.getKafkaBootstrapServers());
         assertEquals(tc.getZookeeperConnect(), tcFromDep.getZookeeperConnect());
         assertEquals(tc.getTopicConfigMapLabels(), tcFromDep.getTopicConfigMapLabels());
+        assertEquals(tc.getTopicMetadataMaxAttempts(), tcFromDep.getTopicMetadataMaxAttempts());
     }
 
     @Test
@@ -183,6 +189,12 @@ public class TopicControllerTest {
     public void testDiffZookeeperSessionTimeout() {
 
         testDiffEnvVar(TopicController.KEY_ZOOKEEPER_SESSION_TIMEOUT_MS, "10000");
+    }
+
+    @Test
+    public void testDiffTopicMetadataMaxAttempts() {
+
+        testDiffEnvVar(TopicController.KEY_TOPIC_METADATA_MAX_ATTEMPTS, "5");
     }
 
     private void testDiffEnvVar(String name, String value) {

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/resources/TopicControllerTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/resources/TopicControllerTest.java
@@ -31,14 +31,14 @@ public class TopicControllerTest {
     private final String metricsCmJson = "{\"animal\":\"wombat\"}";
     private final String storageJson = "{\"type\": \"ephemeral\"}";
 
-    private final String tcNamespace = "my-topic-namespace";
+    private final String tcWatchedNamespace = "my-topic-namespace";
     private final String tcImage = "my-topic-controller-image";
     private final String tcReconciliationInterval = "900000";
     private final String tcZookeeperSessionTimeout = "20000";
     private final int tcTopicMetadataMaxAttempts = 3;
 
     private final String topicControllerJson = "{ " +
-            "\"namespace\":\"" + tcNamespace + "\", " +
+            "\"watchedNamespace\":\"" + tcWatchedNamespace + "\", " +
             "\"image\":\"" + tcImage + "\", " +
             "\"reconciliationInterval\":\"" + tcReconciliationInterval + "\", " +
             "\"zookeeperSessionTimeout\":\"" + tcZookeeperSessionTimeout + "\"," +
@@ -53,7 +53,7 @@ public class TopicControllerTest {
         expected.add(new EnvVarBuilder().withName(TopicController.KEY_CONFIGMAP_LABELS).withValue(TopicController.defaultTopicConfigMapLabels(cluster)).build());
         expected.add(new EnvVarBuilder().withName(TopicController.KEY_KAFKA_BOOTSTRAP_SERVERS).withValue(TopicController.defaultBootstrapServers(cluster)).build());
         expected.add(new EnvVarBuilder().withName(TopicController.KEY_ZOOKEEPER_CONNECT).withValue(TopicController.defaultZookeeperConnect(cluster)).build());
-        expected.add(new EnvVarBuilder().withName(TopicController.KEY_NAMESPACE).withValue(tcNamespace).build());
+        expected.add(new EnvVarBuilder().withName(TopicController.KEY_WATCHED_NAMESPACE).withValue(tcWatchedNamespace).build());
         expected.add(new EnvVarBuilder().withName(TopicController.KEY_FULL_RECONCILIATION_INTERVAL_MS).withValue(tcReconciliationInterval).build());
         expected.add(new EnvVarBuilder().withName(TopicController.KEY_ZOOKEEPER_SESSION_TIMEOUT_MS).withValue(tcZookeeperSessionTimeout).build());
         expected.add(new EnvVarBuilder().withName(TopicController.KEY_TOPIC_METADATA_MAX_ATTEMPTS).withValue(String.valueOf(tcTopicMetadataMaxAttempts)).build());
@@ -77,7 +77,7 @@ public class TopicControllerTest {
         TopicController tc = TopicController.fromConfigMap(cm);
 
         assertEquals(TopicController.DEFAULT_IMAGE, tc.getImage());
-        assertEquals(namespace, tc.getTopicNamespace());
+        assertEquals(namespace, tc.getWatchedNamespace());
         assertEquals(TopicController.DEFAULT_FULL_RECONCILIATION_INTERVAL_MS, tc.getReconciliationIntervalMs());
         assertEquals(TopicController.DEFAULT_ZOOKEEPER_SESSION_TIMEOUT_MS, tc.getZookeeperSessionTimeoutMs());
         assertEquals(TopicController.defaultBootstrapServers(cluster), tc.getKafkaBootstrapServers());
@@ -96,7 +96,7 @@ public class TopicControllerTest {
         assertEquals(TopicController.DEFAULT_HEALTHCHECK_DELAY, tc.healthCheckInitialDelay);
         assertEquals(TopicController.DEFAULT_HEALTHCHECK_TIMEOUT, tc.healthCheckTimeout);
         assertEquals(tcImage, tc.getImage());
-        assertEquals(tcNamespace, tc.getTopicNamespace());
+        assertEquals(tcWatchedNamespace, tc.getWatchedNamespace());
         assertEquals(tcReconciliationInterval, tc.getReconciliationIntervalMs());
         assertEquals(tcZookeeperSessionTimeout, tc.getZookeeperSessionTimeoutMs());
         assertEquals(TopicController.defaultBootstrapServers(cluster), tc.getKafkaBootstrapServers());
@@ -117,7 +117,7 @@ public class TopicControllerTest {
         assertEquals(tc.healthCheckInitialDelay, tcFromDep.healthCheckInitialDelay);
         assertEquals(tc.healthCheckTimeout, tcFromDep.healthCheckTimeout);
         assertEquals(tc.getImage(), tcFromDep.getImage());
-        assertEquals(tc.getTopicNamespace(), tcFromDep.getTopicNamespace());
+        assertEquals(tc.getWatchedNamespace(), tcFromDep.getWatchedNamespace());
         assertEquals(tc.getReconciliationIntervalMs(), tcFromDep.getReconciliationIntervalMs());
         assertEquals(tc.getZookeeperSessionTimeoutMs(), tcFromDep.getZookeeperSessionTimeoutMs());
         assertEquals(tc.getKafkaBootstrapServers(), tcFromDep.getKafkaBootstrapServers());
@@ -176,7 +176,7 @@ public class TopicControllerTest {
     @Test
     public void testDiffNamespace() {
 
-        testDiffEnvVar(TopicController.KEY_NAMESPACE, "diff-tc-namespace");
+        testDiffEnvVar(TopicController.KEY_WATCHED_NAMESPACE, "diff-tc-namespace");
     }
 
     @Test

--- a/documentation/adoc/cluster-controller.adoc
+++ b/documentation/adoc/cluster-controller.adoc
@@ -247,7 +247,7 @@ The JSON representation of the 'topic-controller-config` has no mandatory fields
 The configurable fields are the following :
 
 `image`:: Docker image to use for the topic controller. Default is `strimzi/topic-controller:latest`
-`namespace`:: The Kubernetes namespace (OpenShift project) in which the topic controller watches for topic ConfigMaps.
+`watchedNamespace`:: The Kubernetes namespace (OpenShift project) in which the topic controller watches for topic ConfigMaps.
 Default is the namespace where the topic controller is running
 `reconciliationIntervalMs`:: The interval between periodic reconciliations in milliseconds. Default is 900000 (15 minutes).
 `zookeeperSessionTimeoutMs`:: The Zookeeper session timeout in milliseconds. Default is 20000 milliseconds (20 seconds).

--- a/documentation/adoc/cluster-controller.adoc
+++ b/documentation/adoc/cluster-controller.adoc
@@ -251,6 +251,7 @@ The configurable fields are the following :
 Default is the namespace where the topic controller is running
 `reconciliationIntervalMs`:: The interval between periodic reconciliations in milliseconds. Default is 900000 (15 minutes).
 `zookeeperSessionTimeoutMs`:: The Zookeeper session timeout in milliseconds. Default is 20000 milliseconds (20 seconds).
+`topicMetadataMaxAttempts`:: The number of attempts for getting topics metadata. Default `4`.
 
 .Example Topic Controller JSON configuration
 [source,json]

--- a/documentation/adoc/cluster-controller.adoc
+++ b/documentation/adoc/cluster-controller.adoc
@@ -251,7 +251,7 @@ The configurable fields are the following :
 Default is the namespace where the topic controller is running
 `reconciliationIntervalMs`:: The interval between periodic reconciliations in milliseconds. Default is 900000 (15 minutes).
 `zookeeperSessionTimeoutMs`:: The Zookeeper session timeout in milliseconds. Default is 20000 milliseconds (20 seconds).
-`topicMetadataMaxAttempts`:: The number of attempts for getting topics metadata. Default `4`.
+`topicMetadataMaxAttempts`:: The number of attempts for getting topics metadata. Default `6`.
 
 .Example Topic Controller JSON configuration
 [source,json]

--- a/documentation/adoc/cluster-controller.adoc
+++ b/documentation/adoc/cluster-controller.adoc
@@ -251,7 +251,9 @@ The configurable fields are the following :
 Default is the namespace where the topic controller is running
 `reconciliationIntervalMs`:: The interval between periodic reconciliations in milliseconds. Default is 900000 (15 minutes).
 `zookeeperSessionTimeoutMs`:: The Zookeeper session timeout in milliseconds. Default is 20000 milliseconds (20 seconds).
-`topicMetadataMaxAttempts`:: The number of attempts for getting topics metadata. Default `6`.
+`topicMetadataMaxAttempts`:: The number of attempts for getting topics metadata from Kafka. The time between each attempt
+ is defined as an exponential back-off. You might want to increase this value when topic creation could take more time due
+ to its larger size (i.e. many partitions/replicas). Default `6`.
 
 .Example Topic Controller JSON configuration
 [source,json]

--- a/documentation/adoc/topic-controller.adoc
+++ b/documentation/adoc/topic-controller.adoc
@@ -180,6 +180,8 @@ The controller is configured from environment variables:
 – The Zookeeper connection information. This variable is mandatory.
 * `STRIMZI_FULL_RECONCILIATION_INTERVAL_MS`
 – The interval between periodic reconciliations, in milliseconds.
+* `STRIMZI_TOPIC_METADATA_MAX_ATTEMPTS`
+– The number of attempts for getting topic metedata. Default `4`.
 
 If the controller configuration needs to be changed the process must be killed and restarted.
 Since the controller is intended to execute within Kubernetes, this can be achieved

--- a/documentation/adoc/topic-controller.adoc
+++ b/documentation/adoc/topic-controller.adoc
@@ -181,7 +181,7 @@ The controller is configured from environment variables:
 * `STRIMZI_FULL_RECONCILIATION_INTERVAL_MS`
 – The interval between periodic reconciliations, in milliseconds.
 * `STRIMZI_TOPIC_METADATA_MAX_ATTEMPTS`
-– The number of attempts for getting topics metadata. Default `4`.
+– The number of attempts for getting topics metadata. Default `6`.
 
 If the controller configuration needs to be changed the process must be killed and restarted.
 Since the controller is intended to execute within Kubernetes, this can be achieved

--- a/documentation/adoc/topic-controller.adoc
+++ b/documentation/adoc/topic-controller.adoc
@@ -181,7 +181,7 @@ The controller is configured from environment variables:
 * `STRIMZI_FULL_RECONCILIATION_INTERVAL_MS`
 – The interval between periodic reconciliations, in milliseconds.
 * `STRIMZI_TOPIC_METADATA_MAX_ATTEMPTS`
-– The number of attempts for getting topic metedata. Default `4`.
+– The number of attempts for getting topics metadata. Default `4`.
 
 If the controller configuration needs to be changed the process must be killed and restarted.
 Since the controller is intended to execute within Kubernetes, this can be achieved

--- a/documentation/adoc/topic-controller.adoc
+++ b/documentation/adoc/topic-controller.adoc
@@ -181,7 +181,9 @@ The controller is configured from environment variables:
 * `STRIMZI_FULL_RECONCILIATION_INTERVAL_MS`
 – The interval between periodic reconciliations, in milliseconds.
 * `STRIMZI_TOPIC_METADATA_MAX_ATTEMPTS`
-– The number of attempts for getting topics metadata. Default `6`.
+– The number of attempts for getting topics metadata from Kafka. The time between each attempt is defined as an exponential
+back-off. You might want to increase this value when topic creation could take more time due to its larger size
+(i.e. many partitions/replicas). Default `6`.
 
 If the controller configuration needs to be changed the process must be killed and restarted.
 Since the controller is intended to execute within Kubernetes, this can be achieved

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/BackOff.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/BackOff.java
@@ -17,6 +17,10 @@ public class BackOff {
         this(200L, 2, 4);
     }
 
+    public BackOff(int maxAttempts) {
+        this(200L, 2, maxAttempts);
+    }
+
     public BackOff(long scaleMs, int base, int maxAttempts) {
         assert scaleMs > 0;
         assert base > 0;

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/BackOff.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/BackOff.java
@@ -8,17 +8,22 @@ package io.strimzi.controller.topic;
  * Encapsulates computing delays for an exponential back-off.
  */
 public class BackOff {
+
+    private static final long DEFAULT_SCALE_MS = 200L;
+    private static final int DEFAULT_BASE = 2;
+    private static final int DEFAULT_MAX_ATTEMPTS = 6;
+
     private final long scaleMs;
     private final int base;
     private final int maxAttempts;
     private int attempt = 0;
 
     public BackOff() {
-        this(200L, 2, 6);
+        this(DEFAULT_SCALE_MS, DEFAULT_BASE, DEFAULT_MAX_ATTEMPTS);
     }
 
     public BackOff(int maxAttempts) {
-        this(200L, 2, maxAttempts);
+        this(DEFAULT_SCALE_MS, DEFAULT_BASE, maxAttempts);
     }
 
     public BackOff(long scaleMs, int base, int maxAttempts) {

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/BackOff.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/BackOff.java
@@ -14,7 +14,7 @@ public class BackOff {
     private int attempt = 0;
 
     public BackOff() {
-        this(200L, 2, 4);
+        this(200L, 2, 6);
     }
 
     public BackOff(int maxAttempts) {

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/Config.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/Config.java
@@ -35,10 +35,14 @@ public class Config {
     };
 
     /** A Java Integer */
-    private static final Type<? extends Integer> INTEGER = new Type<Integer>() {
+    private static final Type<? extends Integer> POSITIVE_INTEGER = new Type<Integer>() {
         @Override
         Integer parse(String s) {
-            return Integer.parseInt(s);
+            int value = Integer.parseInt(s);
+            if (value <= 0) {
+                throw new IllegalArgumentException("The value must be greater than zero");
+            }
+            return value;
         }
     };
 
@@ -125,7 +129,7 @@ public class Config {
     public static final Value<Long> REASSIGN_VERIFY_INTERVAL_MS = new Value<>(TC_REASSIGN_VERIFY_INTERVAL_MS, DURATION, "120000");
 
     /** The maximum number of retries for getting topic metadata from the Kafka cluster */
-    public static final Value<Integer> TOPIC_METADATA_MAX_ATTEMPTS = new Value<>(TC_TOPIC_METADATA_MAX_ATTEMPTS, INTEGER, "6");
+    public static final Value<Integer> TOPIC_METADATA_MAX_ATTEMPTS = new Value<>(TC_TOPIC_METADATA_MAX_ATTEMPTS, POSITIVE_INTEGER, "6");
 
     static {
         Map<String, Value<?>> configValues = CONFIG_VALUES;

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/Config.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/Config.java
@@ -125,7 +125,7 @@ public class Config {
     public static final Value<Long> REASSIGN_VERIFY_INTERVAL_MS = new Value<>(TC_REASSIGN_VERIFY_INTERVAL_MS, DURATION, "120000");
 
     /** The maximum number of retries for getting topic metadata from the Kafka cluster */
-    public static final Value<Integer> TOPIC_METADATA_MAX_ATTEMPTS = new Value<>(TC_TOPIC_METADATA_MAX_ATTEMPTS, INTEGER, "4");
+    public static final Value<Integer> TOPIC_METADATA_MAX_ATTEMPTS = new Value<>(TC_TOPIC_METADATA_MAX_ATTEMPTS, INTEGER, "6");
 
     static {
         Map<String, Value<?>> configValues = CONFIG_VALUES;

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/Config.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/Config.java
@@ -34,6 +34,14 @@ public class Config {
         }
     };
 
+    /** A Java Integer */
+    private static final Type<? extends Integer> INTEGER = new Type<Integer>() {
+        @Override
+        Integer parse(String s) {
+            return Integer.parseInt(s);
+        }
+    };
+
     /**
      * A time duration.
      */
@@ -85,6 +93,7 @@ public class Config {
     public static final String TC_PERIODIC_INTERVAL_MS = "STRIMZI_FULL_RECONCILIATION_INTERVAL_MS";
     public static final String TC_REASSIGN_THROTTLE = "STRIMZI_REASSIGN_THROTTLE";
     public static final String TC_REASSIGN_VERIFY_INTERVAL_MS = "STRIMZI_REASSIGN_VERIFY_INTERVAL_MS";
+    public static final String TC_TOPIC_METADATA_MAX_ATTEMPTS = "STRIMZI_TOPIC_METADATA_MAX_ATTEMPTS";
 
     private static final Map<String, Value<?>> CONFIG_VALUES = new HashMap<>();
 
@@ -115,6 +124,8 @@ public class Config {
      */
     public static final Value<Long> REASSIGN_VERIFY_INTERVAL_MS = new Value<>(TC_REASSIGN_VERIFY_INTERVAL_MS, DURATION, "120000");
 
+    /** The maximum number of retries for getting topic metadata from the Kafka cluster */
+    public static final Value<Integer> TOPIC_METADATA_MAX_ATTEMPTS = new Value<>(TC_TOPIC_METADATA_MAX_ATTEMPTS, INTEGER, "4");
 
     static {
         Map<String, Value<?>> configValues = CONFIG_VALUES;
@@ -126,6 +137,7 @@ public class Config {
         addConfigValue(configValues, FULL_RECONCILIATION_INTERVAL_MS);
         addConfigValue(configValues, REASSIGN_THROTTLE);
         addConfigValue(configValues, REASSIGN_VERIFY_INTERVAL_MS);
+        addConfigValue(configValues, TOPIC_METADATA_MAX_ATTEMPTS);
     }
 
     static void addConfigValue(Map<String, Value<?>> configValues, Value<?> cv) {

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/Controller.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/Controller.java
@@ -614,7 +614,7 @@ public class Controller {
                 // getting topic information from the private store
                 topicStore.read(topicName, topicResult -> {
 
-                    TopicMetadataHandler handler = new TopicMetadataHandler(vertx, kafka, topicName, new BackOff(config.get(Config.TOPIC_METADATA_MAX_ATTEMPTS))) {
+                    TopicMetadataHandler handler = new TopicMetadataHandler(vertx, kafka, topicName, getBackOff()) {
                         @Override
                         public void handle(AsyncResult<TopicMetadata> metadataResult) {
 
@@ -710,7 +710,7 @@ public class Controller {
             @Override
             public void handle(Future<Void> fut) {
 
-                TopicMetadataHandler handler = new TopicMetadataHandler(vertx, kafka, topicName, new BackOff(config.get(Config.TOPIC_METADATA_MAX_ATTEMPTS))) {
+                TopicMetadataHandler handler = new TopicMetadataHandler(vertx, kafka, topicName, getBackOff()) {
 
                     @Override
                     public void handle(AsyncResult<TopicMetadata> metadataResult) {
@@ -931,6 +931,13 @@ public class Controller {
 
     public boolean isWorkInflight() {
         return inFlight.size() > 0;
+    }
+
+    /**
+     * @return an instance of BackOff with configured topic metadata max attempts
+     */
+    private BackOff getBackOff() {
+        return new BackOff(config.get(Config.TOPIC_METADATA_MAX_ATTEMPTS));
     }
 }
 

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/Controller.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/Controller.java
@@ -614,7 +614,7 @@ public class Controller {
                 // getting topic information from the private store
                 topicStore.read(topicName, topicResult -> {
 
-                    TopicMetadataHandler handler = new TopicMetadataHandler(vertx, kafka, topicName, getBackOff()) {
+                    TopicMetadataHandler handler = new TopicMetadataHandler(vertx, kafka, topicName, topicMetadataBackOff()) {
                         @Override
                         public void handle(AsyncResult<TopicMetadata> metadataResult) {
 
@@ -710,7 +710,7 @@ public class Controller {
             @Override
             public void handle(Future<Void> fut) {
 
-                TopicMetadataHandler handler = new TopicMetadataHandler(vertx, kafka, topicName, getBackOff()) {
+                TopicMetadataHandler handler = new TopicMetadataHandler(vertx, kafka, topicName, topicMetadataBackOff()) {
 
                     @Override
                     public void handle(AsyncResult<TopicMetadata> metadataResult) {
@@ -934,9 +934,9 @@ public class Controller {
     }
 
     /**
-     * @return an instance of BackOff with configured topic metadata max attempts
+     * @return a new instance of BackOff with configured topic metadata max attempts
      */
-    private BackOff getBackOff() {
+    private BackOff topicMetadataBackOff() {
         return new BackOff(config.get(Config.TOPIC_METADATA_MAX_ATTEMPTS));
     }
 }

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/Session.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/Session.java
@@ -117,7 +117,7 @@ public class Session extends AbstractVerticle {
         ZkTopicStore topicStore = new ZkTopicStore(zk);
         LOGGER.debug("Using TopicStore {}", topicStore);
 
-        this.controller = new Controller(vertx, kafka, k8s, topicStore, cmPredicate, namespace);
+        this.controller = new Controller(vertx, kafka, k8s, topicStore, cmPredicate, namespace, config);
         LOGGER.debug("Using Controller {}", controller);
 
         this.topicConfigsWatcher = new TopicConfigsWatcher(controller);

--- a/topic-controller/src/test/java/io/strimzi/controller/topic/BackOffTest.java
+++ b/topic-controller/src/test/java/io/strimzi/controller/topic/BackOffTest.java
@@ -45,4 +45,19 @@ public class BackOffTest {
 
         assertEquals(1111L, b.totalDelayMs());
     }
+
+    @Test
+    public void testMaxAttemptsOnlyBackOff() {
+        BackOff b = new BackOff(3);
+        assertEquals(0, b.delayMs());
+        assertEquals(200L, b.delayMs());
+        assertEquals(400L, b.delayMs());
+        try {
+            b.delayMs();
+            fail("Should throw");
+        } catch (MaxAttemptsExceededException e) {
+
+        }
+        assertEquals(600L, b.totalDelayMs());
+    }
 }

--- a/topic-controller/src/test/java/io/strimzi/controller/topic/BackOffTest.java
+++ b/topic-controller/src/test/java/io/strimzi/controller/topic/BackOffTest.java
@@ -19,13 +19,15 @@ public class BackOffTest {
         assertEquals(200L, b.delayMs());
         assertEquals(400L, b.delayMs());
         assertEquals(800L, b.delayMs());
+        assertEquals(1600L, b.delayMs());
+        assertEquals(3200L, b.delayMs());
         try {
             b.delayMs();
             fail("Should throw");
         } catch (MaxAttemptsExceededException e) {
 
         }
-        assertEquals(1400L, b.totalDelayMs());
+        assertEquals(6200L, b.totalDelayMs());
     }
 
     @Test

--- a/topic-controller/src/test/java/io/strimzi/controller/topic/ConfigTest.java
+++ b/topic-controller/src/test/java/io/strimzi/controller/topic/ConfigTest.java
@@ -65,4 +65,14 @@ public class ConfigTest {
 
         }
     }
+
+    @Test
+    public void topicMetadataMaxAttempts() {
+
+        Map<String, String> map = new HashMap<>(MANDATORY);
+        map.put(Config.TC_TOPIC_METADATA_MAX_ATTEMPTS, "3");
+
+        Config c = new Config(map);
+        assertEquals(3, c.get(Config.TOPIC_METADATA_MAX_ATTEMPTS).intValue());
+    }
 }

--- a/topic-controller/src/test/java/io/strimzi/controller/topic/ControllerTest.java
+++ b/topic-controller/src/test/java/io/strimzi/controller/topic/ControllerTest.java
@@ -48,13 +48,23 @@ public class ControllerTest {
     private MockTopicStore mockTopicStore = new MockTopicStore();
     private MockK8s mockK8s = new MockK8s();
     private Controller controller;
+    private io.strimzi.controller.topic.Config config;
+
+    private static final Map<String, String> MANDATORY_CONFIG = new HashMap<>();
+
+    static {
+        MANDATORY_CONFIG.put(io.strimzi.controller.topic.Config.ZOOKEEPER_CONNECT.key, "localhost:2181");
+        MANDATORY_CONFIG.put(io.strimzi.controller.topic.Config.KAFKA_BOOTSTRAP_SERVERS.key, "localhost:9092");
+        MANDATORY_CONFIG.put(io.strimzi.controller.topic.Config.NAMESPACE.key, "default");
+    }
 
     @Before
     public void setup() {
         mockKafka = new MockKafka();
         mockTopicStore = new MockTopicStore();
         mockK8s = new MockK8s();
-        controller = new Controller(vertx, mockKafka, mockK8s, mockTopicStore, cmPredicate, "default-namespace");
+        config = new io.strimzi.controller.topic.Config(new HashMap<>(MANDATORY_CONFIG));
+        controller = new Controller(vertx, mockKafka, mockK8s, mockTopicStore, cmPredicate, "default-namespace", config);
     }
 
     @After

--- a/topic-controller/src/test/java/io/strimzi/controller/topic/MockController.java
+++ b/topic-controller/src/test/java/io/strimzi/controller/topic/MockController.java
@@ -15,7 +15,7 @@ import java.util.List;
 class MockController extends Controller {
 
     public MockController() {
-        super(null, null, null, null, null, null);
+        super(null, null, null, null, null, null, null);
     }
 
     static class MockControllerEvent {

--- a/topic-controller/src/test/java/io/strimzi/controller/topic/TopicSerializationTest.java
+++ b/topic-controller/src/test/java/io/strimzi/controller/topic/TopicSerializationTest.java
@@ -9,9 +9,6 @@ import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.clients.admin.NewTopic;
-import org.apache.kafka.clients.admin.TopicDescription;
-import org.apache.kafka.common.Node;
-import org.apache.kafka.common.TopicPartitionInfo;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.requests.CreateTopicsRequest;
 import org.junit.Test;
@@ -24,7 +21,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static java.util.Arrays.asList;
 import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -127,18 +123,10 @@ public class TopicSerializationTest {
 
     @Test
     public void testFromTopicMetadata() {
-        Node node0 = new Node(0, "host0", 1234);
-        Node node1 = new Node(1, "host1", 1234);
-        Node node2 = new Node(1, "host2", 1234);
-        List<Node> nodes02 = asList(node0, node1, node2);
-        TopicDescription desc = new TopicDescription("test-topic", false,
-                asList(
-                        new TopicPartitionInfo(0, node0, asList(node0, node1, node2), nodes02),
-                        new TopicPartitionInfo(1, node0, asList(node0, node1, node2), nodes02)));
         List<ConfigEntry> entries = new ArrayList<>();
         entries.add(new ConfigEntry("foo", "bar"));
         Config topicConfig = new Config(entries);
-        TopicMetadata meta = new TopicMetadata(desc, topicConfig);
+        TopicMetadata meta = Utils.getTopicMetadata("test-topic", topicConfig);
         Topic topic = TopicSerialization.fromTopicMetadata(meta);
         assertEquals(new TopicName("test-topic"), topic.getTopicName());
         // Null map name because Kafka doesn't know about the map

--- a/topic-controller/src/test/java/io/strimzi/controller/topic/Utils.java
+++ b/topic-controller/src/test/java/io/strimzi/controller/topic/Utils.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017-2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.controller.topic;
+
+import org.apache.kafka.clients.admin.Config;
+import org.apache.kafka.clients.admin.ConfigEntry;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.TopicPartitionInfo;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Arrays.asList;
+
+public class Utils {
+
+    public static TopicMetadata getTopicMetadata(String topicName, Config config) {
+        Node node0 = new Node(0, "host0", 1234);
+        Node node1 = new Node(1, "host1", 1234);
+        Node node2 = new Node(2, "host2", 1234);
+        List<Node> nodes02 = asList(node0, node1, node2);
+        TopicDescription desc = new TopicDescription(topicName, false, asList(
+                new TopicPartitionInfo(0, node0, nodes02, nodes02),
+                new TopicPartitionInfo(1, node0, nodes02, nodes02)
+        ));
+        //org.apache.kafka.clients.admin.Config config = new Config(configs);
+        return new TopicMetadata(desc, config);
+    }
+
+    public static TopicMetadata getTopicMetadata(Topic kubeTopic) {
+        List<Node> nodes = new ArrayList<>();
+        for (int nodeId = 0; nodeId < kubeTopic.getNumReplicas(); nodeId++) {
+            nodes.add(new Node(nodeId, "localhost", 9092 + nodeId));
+        }
+        List<TopicPartitionInfo> partitions = new ArrayList<>();
+        for (int partitionId = 0; partitionId < kubeTopic.getNumPartitions(); partitionId++) {
+            partitions.add(new TopicPartitionInfo(partitionId, nodes.get(0), nodes, nodes));
+        }
+        List<ConfigEntry> configs = new ArrayList<>();
+        for (Map.Entry<String, String> entry: kubeTopic.getConfig().entrySet()) {
+            configs.add(new ConfigEntry(entry.getKey(), entry.getValue()));
+        }
+
+        return new TopicMetadata(new TopicDescription(kubeTopic.getTopicName().toString(), false,
+                partitions), new Config(configs));
+    }
+
+}


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature

### Description

This PR should fix the #257 making configurable the max attempts for the backoff used on topic metadata request in the topic controller. The default value was increased as well.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging

