### PR TITLE
Add cluster label, so example topic CM just works™ with CC-deployed TC

### DIFF
--- a/examples/configmaps/topic-controller/kafka-topic-configmap.yaml
+++ b/examples/configmaps/topic-controller/kafka-topic-configmap.yaml
@@ -4,6 +4,7 @@ metadata:
   name: my-topic
   labels:
     strimzi.io/kind: topic
+    strimzi.io/cluster: my-cluster
 data:
   name: my-topic
   partitions: "1"

--- a/examples/templates/topic-controller/topic-configmap-template.yaml
+++ b/examples/templates/topic-controller/topic-configmap-template.yaml
@@ -13,6 +13,11 @@ metadata:
     iconClass: "fa fa-exchange"
     template.openshift.io/documentation-url: "http://strimzi.io"
 parameters:
+- name: CLUSTER_NAME
+  displayName: Name of the Kafka cluster
+  description: Specifies the name of the Kafka cluster in which the topic should be created.
+  required: true
+  value: my-cluster
 - name: MAP_NAME
   displayName: Name of the ConfigMap
   description: Specifies the name of the ConfigMap. If possible this should be the same as the TOPIC_NAME parameter.
@@ -48,6 +53,7 @@ objects:
     name: "${MAP_NAME}"
     labels:
       strimzi.io/kind: topic
+      strimzi.io/cluster: "${CLUSTER_NAME}"
   data:
     name: "${TOPIC_NAME}"
     partitions: "${TOPIC_PARTITIONS}"


### PR DESCRIPTION
### Type of change

- Bugfix
- ~Enhancement / new feature~
- ~Refactoring~

### Description

If you deploy the CC, create a Kafka cluster CM and then create the example topic CM the CC-deployed TC will ignore the topic CM because it lacks the cluster label. This PR fixes the example CM to include that label.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging

