### PR TITLE
System tests: Recovery

### DIFF
--- a/common-test/src/main/java/io/strimzi/test/k8s/BaseKubeClient.java
+++ b/common-test/src/main/java/io/strimzi/test/k8s/BaseKubeClient.java
@@ -27,10 +27,13 @@ public abstract class BaseKubeClient<K extends BaseKubeClient<K>> implements Kub
 
     public static final String CREATE = "create";
     public static final String DELETE = "delete";
+    public static final String DEPLOYMENT = "deployment";
+    public static final String STATEFUL_SET = "statefulset";
     private String namespace = defaultNamespace();
 
     protected abstract String cmd();
 
+    @Override
     public K deleteByName(String resourceType, String resourceName) {
         Exec.exec(cmd(), DELETE, resourceType, resourceName);
         return (K) this;

--- a/common-test/src/main/java/io/strimzi/test/k8s/KubeClient.java
+++ b/common-test/src/main/java/io/strimzi/test/k8s/KubeClient.java
@@ -34,6 +34,9 @@ public interface KubeClient<K extends KubeClient<K>> {
 
     String defaultNamespace();
 
+    /** Deletes the resources by resource name. */
+    K deleteByName(String resourceType, String resourceName);
+
     String namespace(String namespace);
 
     boolean clientAvailable();

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterTest.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterTest.java
@@ -271,7 +271,7 @@ public class KafkaClusterTest {
         kubeClient.deleteByName(DEPLOYMENT, topicControllerName);
         kubeClient.waitForResourceDeletion(DEPLOYMENT, topicControllerName);
 
-        LOGGER.info("Waiting to recovery {}", topicControllerName);
+        LOGGER.info("Waiting for recovery {}", topicControllerName);
         kubeClient.waitForDeployment(topicControllerName);
     }
 
@@ -286,7 +286,7 @@ public class KafkaClusterTest {
         kubeClient.deleteByName(DEPLOYMENT, clusterControllerName);
         kubeClient.waitForResourceDeletion(DEPLOYMENT, clusterControllerName);
 
-        LOGGER.info("Waiting to recovery {}", clusterControllerName);
+        LOGGER.info("Waiting for recovery {}", clusterControllerName);
         kubeClient.waitForDeployment(clusterControllerName);
     }
 
@@ -302,7 +302,7 @@ public class KafkaClusterTest {
         kubeClient.deleteByName(STATEFUL_SET, kafkaStatefulSetName);
         kubeClient.waitForResourceDeletion(STATEFUL_SET, kafkaStatefulSetName);
 
-        LOGGER.info("Waiting to recovery {}", kafkaStatefulSetName);
+        LOGGER.info("Waiting for recovery {}", kafkaStatefulSetName);
         kubeClient.waitForStatefulSet(kafkaStatefulSetName, 1);
     }
 
@@ -318,7 +318,7 @@ public class KafkaClusterTest {
         kubeClient.deleteByName(STATEFUL_SET, zookeeperStatefulSetName);
         kubeClient.waitForResourceDeletion(STATEFUL_SET, zookeeperStatefulSetName);
 
-        LOGGER.info("Waiting to recovery {}", zookeeperStatefulSetName);
+        LOGGER.info("Waiting for recovery {}", zookeeperStatefulSetName);
         kubeClient.waitForStatefulSet(zookeeperStatefulSetName, 1);
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterTest.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterTest.java
@@ -271,7 +271,7 @@ public class KafkaClusterTest {
         kubeClient.deleteByName(DEPLOYMENT, topicControllerName);
         kubeClient.waitForResourceDeletion(DEPLOYMENT, topicControllerName);
 
-        // wait for reconciliation and check that deployment was recovered
+        LOGGER.info("Waiting to recovery {}", topicControllerName);
         kubeClient.waitForDeployment(topicControllerName);
     }
 
@@ -286,7 +286,7 @@ public class KafkaClusterTest {
         kubeClient.deleteByName(DEPLOYMENT, clusterControllerName);
         kubeClient.waitForResourceDeletion(DEPLOYMENT, clusterControllerName);
 
-        // wait for reconciliation and check that deployment was recovered
+        LOGGER.info("Waiting to recovery {}", clusterControllerName);
         kubeClient.waitForDeployment(clusterControllerName);
     }
 
@@ -302,7 +302,7 @@ public class KafkaClusterTest {
         kubeClient.deleteByName(STATEFUL_SET, kafkaStatefulSetName);
         kubeClient.waitForResourceDeletion(STATEFUL_SET, kafkaStatefulSetName);
 
-        // wait for reconciliation and check that stateful set was recovered
+        LOGGER.info("Waiting to recovery {}", kafkaStatefulSetName);
         kubeClient.waitForStatefulSet(kafkaStatefulSetName, 1);
     }
 
@@ -318,7 +318,7 @@ public class KafkaClusterTest {
         kubeClient.deleteByName(STATEFUL_SET, zookeeperStatefulSetName);
         kubeClient.waitForResourceDeletion(STATEFUL_SET, zookeeperStatefulSetName);
 
-        // wait for reconciliation and check that stateful set was recovered
+        LOGGER.info("Waiting to recovery {}", zookeeperStatefulSetName);
         kubeClient.waitForStatefulSet(zookeeperStatefulSetName, 1);
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterTest.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterTest.java
@@ -262,19 +262,26 @@ public class KafkaClusterTest {
 
     @Test
     @KafkaCluster(name = "my-cluster", kafkaNodes = 1)
-    public void testDeleteDeployments(){
+    public void testDeleteTopicControllerDeployment() {
         // kafka cluster already deployed via annotation
         String clusterName = "my-cluster";
         String topicControllerName = topicControllerDeploymentName(clusterName);
-        String clusterControllerName = "strimzi-cluster-controller";
-        LOGGER.info("Running deleteDeployments with cluster {}", clusterName);
-
+        LOGGER.info("Running deleteTopicControllerDeployment with cluster {}", clusterName);
 
         kubeClient.deleteByName(DEPLOYMENT, topicControllerName);
         kubeClient.waitForResourceDeletion(DEPLOYMENT, topicControllerName);
 
         // wait for reconciliation and check that deployment was recovered
         kubeClient.waitForDeployment(topicControllerName);
+    }
+
+    @Test
+    @KafkaCluster(name = "my-cluster", kafkaNodes = 1)
+    public void testDeleteClusterControllerDeployment() {
+        // kafka cluster already deployed via annotation
+        String clusterName = "my-cluster";
+        String clusterControllerName = "strimzi-cluster-controller";
+        LOGGER.info("Running deleteClusterControllerDeployment with cluster {}", clusterName);
 
         kubeClient.deleteByName(DEPLOYMENT, clusterControllerName);
         kubeClient.waitForResourceDeletion(DEPLOYMENT, clusterControllerName);
@@ -285,23 +292,33 @@ public class KafkaClusterTest {
 
     @Test
     @KafkaCluster(name = "my-cluster", kafkaNodes = 1)
-    public void testDeleteStatefulSets(){
+    public void testDeleteKafkaStatefulSet() {
         // kafka cluster already deployed via annotation
         String clusterName = "my-cluster";
         String kafkaStatefulSetName = kafkaStatefulSetName(clusterName);
-        String zookeeperStatefulSetName = zookeeperStatefulSetName(clusterName);
-        LOGGER.info("Running deleteStatefulSets with cluster {}", clusterName);
+
+        LOGGER.info("Running deleteKafkaStatefulSet with cluster {}", clusterName);
 
         kubeClient.deleteByName(STATEFUL_SET, kafkaStatefulSetName);
         kubeClient.waitForResourceDeletion(STATEFUL_SET, kafkaStatefulSetName);
 
         // wait for reconciliation and check that stateful set was recovered
-        kubeClient.waitForDeployment(kafkaStatefulSetName);
+        kubeClient.waitForStatefulSet(kafkaStatefulSetName, 1);
+    }
+
+    @Test
+    @KafkaCluster(name = "my-cluster", kafkaNodes = 1, zkNodes = 1)
+    public void testDeleteZookeeperStatefulSet() {
+        // kafka cluster already deployed via annotation
+        String clusterName = "my-cluster";
+        String zookeeperStatefulSetName = zookeeperStatefulSetName(clusterName);
+
+        LOGGER.info("Running deleteZookeeperStatefulSet with cluster {}", clusterName);
 
         kubeClient.deleteByName(STATEFUL_SET, zookeeperStatefulSetName);
         kubeClient.waitForResourceDeletion(STATEFUL_SET, zookeeperStatefulSetName);
 
         // wait for reconciliation and check that stateful set was recovered
-        kubeClient.waitForDeployment(zookeeperStatefulSetName);
+        kubeClient.waitForStatefulSet(zookeeperStatefulSetName, 1);
     }
 }


### PR DESCRIPTION
### Type of change
- System tests

### Description
System tests to check recovery when some deployments or stateful sets are deleted.
Case 1: Test deletes deployment TC and waits for recovering
Case 2: Test deletes deployment CC and waits for recovering
Case 3: Test deletes Kafka stateful set and waits for recovering
Case 4: Test deletes Zookeeper stateful set and waits for recovering

###Additional information
Test cases 1, 2-4 are failed now by issue #264 

### Checklist
- [ ] Write tests
- [ ] Make sure all tests pass
