### PR TITLE
Moved volume name initialization in the base AbstractCluster class

### DIFF
--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/AbstractCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/AbstractCluster.java
@@ -85,7 +85,7 @@ public abstract class AbstractCluster {
     protected Storage storage;
 
     protected String mountPath;
-    protected String volumeName;
+    protected String volumeName = "data";
     protected String metricsConfigVolumeName;
     protected String metricsConfigMountPath;
 

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/KafkaCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/KafkaCluster.java
@@ -91,7 +91,6 @@ public class KafkaCluster extends AbstractCluster {
         this.isMetricsEnabled = DEFAULT_KAFKA_METRICS_ENABLED;
 
         this.mountPath = "/var/lib/kafka";
-        this.volumeName = "data";
         this.metricsConfigVolumeName = "kafka-metrics-config";
         this.metricsConfigMountPath = "/opt/prometheus/config/";
     }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/ZookeeperCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/resources/ZookeeperCluster.java
@@ -94,7 +94,6 @@ public class ZookeeperCluster extends AbstractCluster {
         this.isMetricsEnabled = DEFAULT_ZOOKEEPER_METRICS_ENABLED;
 
         this.mountPath = "/var/lib/zookeeper";
-        this.volumeName = "data";
         this.metricsConfigVolumeName = "zookeeper-metrics-config";
         this.metricsConfigMountPath = "/opt/prometheus/config/";
     }


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Now that the `volumeName` has the same name for Kafka and Zookeeper (it's just "data") in order to reduce its length and even because the fact that it's related to Kafka or Zookeeper is described in the StatefulSet part of the PVC name, we can move it in the base class. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging

