### PR TITLE
Added executing reconcile using the inflight queue

### DIFF
--- a/topic-controller/src/main/java/io/strimzi/controller/topic/Controller.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/Controller.java
@@ -354,15 +354,15 @@ public class Controller {
                             Topic kafkaTopic = TopicSerialization.fromTopicMetadata(kafkaTopicMeta);
                             reconcile(cm, k8sTopic, kafkaTopic, privateTopic, reconcileResult -> {
                                 if (reconcileResult.succeeded()) {
-                                    LOGGER.info("Success reconciling ConfigMap {}: ", logConfigMap(cm));
+                                    LOGGER.info("Success reconciling ConfigMap {}", logConfigMap(cm));
                                     fut.complete();
                                 } else {
-                                    LOGGER.error("Error reconciling ConfigMap {}: ", logConfigMap(cm), reconcileResult.cause());
+                                    LOGGER.error("Error reconciling ConfigMap {}", logConfigMap(cm), reconcileResult.cause());
                                     fut.fail(reconcileResult.cause());
                                 }
                             });
                         } else {
-                            LOGGER.error("Error reconciling ConfigMap {}: ", logConfigMap(cm), ar.cause());
+                            LOGGER.error("Error reconciling ConfigMap {}", logConfigMap(cm), ar.cause());
                             fut.fail(ar.cause());
                         }
                     });
@@ -370,7 +370,7 @@ public class Controller {
                     LOGGER.error("Error reconciling ConfigMap {}: Invalid 'data' section: ", logConfigMap(cm), e.getMessage());
                     fut.fail(e);
                 } catch (ControllerException e) {
-                    LOGGER.error("Error reconciling ConfigMap {}: ", logConfigMap(cm), e);
+                    LOGGER.error("Error reconciling ConfigMap {}", logConfigMap(cm), e);
                     fut.fail(e);
                 }
             }
@@ -958,6 +958,10 @@ public class Controller {
         return new BackOff(config.get(Config.TOPIC_METADATA_MAX_ATTEMPTS));
     }
 
+    /**
+     * @param cm ConfigMap instance to log
+     * @return ConfigMap representation as namespace/name for logging purposes
+     */
     static String logConfigMap(ConfigMap cm) {
         return cm != null ? cm.getMetadata().getNamespace() + "/" + cm.getMetadata().getName() : null;
     }

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/InFlight.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/InFlight.java
@@ -101,7 +101,7 @@ class InFlight<T> {
      * When the given {@code action} is complete it must complete its argument future,
      * which will complete the given {@code resultHandler}.
      */
-    public void enqueue(T key, Handler<AsyncResult<Void>> resultHandler, Handler<Future<Void>> action) {
+    public void enqueue(T key, Handler<Future<Void>> action, Handler<AsyncResult<Void>> resultHandler) {
         InflightHandler fut = new InflightHandler(key, action.toString(), resultHandler);
         LOGGER.debug("resultHandler:{}, action:{}, fut:{}", resultHandler, action, fut);
         map.compute(key, (k, current) -> {

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/Session.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/Session.java
@@ -169,9 +169,11 @@ public class Session extends AbstractVerticle {
 
                         controller.reconcile(cm, topicName, reconcileResult -> {
                             if (reconcileResult.succeeded()) {
-                                LOGGER.info("Success reconciling topic {}", topicName);
+                                LOGGER.info("Success {} reconciling ConfigMap {} topic {}",
+                                        reconciliationType, Controller.logConfigMap(cm), topicName);
                             } else {
-                                LOGGER.error("Error reconciling topic {}", topicName, reconcileResult.cause());
+                                LOGGER.error("Error {} reconciling ConfigMap {} topic {}",
+                                        reconciliationType, Controller.logConfigMap(cm), topicName, reconcileResult.cause());
                             }
                         });
                     });
@@ -193,9 +195,11 @@ public class Session extends AbstractVerticle {
                             TopicName topicName = new TopicName(cm);
                             controller.reconcile(cm, topicName, reconcileResult -> {
                                 if (reconcileResult.succeeded()) {
-                                    LOGGER.info("Success reconciling ConfigMap {}", Controller.logConfigMap(cm));
+                                    LOGGER.info("Success {} reconciling ConfigMap {}",
+                                            reconciliationType, Controller.logConfigMap(cm));
                                 } else {
-                                    LOGGER.error("Error reconciling ConfigMap {}", Controller.logConfigMap(cm), reconcileResult.cause());
+                                    LOGGER.error("Error {} reconciling ConfigMap {}",
+                                            reconciliationType, Controller.logConfigMap(cm), reconcileResult.cause());
                                 }
                             });
                         }

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/Session.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/Session.java
@@ -154,7 +154,7 @@ public class Session extends AbstractVerticle {
         LOGGER.info("Started");
     }
 
-    private void reconcileTopics(String reconciliationType) {
+    void reconcileTopics(String reconciliationType) {
         LOGGER.info("Starting {} reconciliation", reconciliationType);
         kafka.listTopics(arx -> {
             if (arx.succeeded()) {

--- a/topic-controller/src/test/java/io/strimzi/controller/topic/InFlightTest.java
+++ b/topic-controller/src/test/java/io/strimzi/controller/topic/InFlightTest.java
@@ -25,7 +25,7 @@ public class InFlightTest {
         Async async = context.async();
         InFlight<String> inflight = new InFlight(vertx);
 
-        inflight.enqueue("test", ignored -> async.complete(), fut -> fut.complete());
+        inflight.enqueue("test", fut -> fut.complete(), ignored -> async.complete());
     }
 
     @Test
@@ -34,24 +34,24 @@ public class InFlightTest {
         Async firstCompleted = context.async();
         Async secondCompleted = context.async();
         InFlight<String> inflight = new InFlight(vertx);
-        inflight.enqueue("test", v -> {
-            LOGGER.debug("completing firstCompleted");
-            firstCompleted.complete();
-        }, fut -> {
-                LOGGER.debug("1st task waiting for both to enqueue");
-                bothEnqueued.await();
-                LOGGER.debug("1st task completing");
-                fut.complete();
+        inflight.enqueue("test", fut -> {
+            LOGGER.debug("1st task waiting for both to enqueue");
+            bothEnqueued.await();
+            LOGGER.debug("1st task completing");
+            fut.complete();
+        }, v -> {
+                LOGGER.debug("completing firstCompleted");
+                firstCompleted.complete();
             });
 
-        inflight.enqueue("test", v -> {
-            LOGGER.debug("completing secondCompleted");
-            secondCompleted.complete();
-        }, fut -> {
-                LOGGER.debug("2nd task waiting for both to enqueue");
-                bothEnqueued.await();
-                LOGGER.debug("2nd task completing");
-                fut.complete();
+        inflight.enqueue("test", fut -> {
+            LOGGER.debug("2nd task waiting for both to enqueue");
+            bothEnqueued.await();
+            LOGGER.debug("2nd task completing");
+            fut.complete();
+        }, v -> {
+                LOGGER.debug("completing secondCompleted");
+                secondCompleted.complete();
             });
         LOGGER.debug("completing bothEnqueued");
         bothEnqueued.complete();
@@ -77,26 +77,26 @@ public class InFlightTest {
         Async firstCompleted = context.async();
         Async secondCompleted = context.async();
         InFlight<String> inflight = new InFlight(vertx);
-        inflight.enqueue("test", v -> {
-            LOGGER.debug("completing firstCompleted");
-            firstCompleted.complete();
-            context.assertTrue(v.failed());
-            context.assertEquals("Oops!", v.cause().getMessage());
-        }, fut -> {
-                LOGGER.debug("1st task waiting for both to enqueue");
-                bothEnqueued.await();
-                LOGGER.debug("1st task failing");
-                fut.fail("Oops!");
+        inflight.enqueue("test", fut -> {
+            LOGGER.debug("1st task waiting for both to enqueue");
+            bothEnqueued.await();
+            LOGGER.debug("1st task failing");
+            fut.fail("Oops!");
+        }, v -> {
+                LOGGER.debug("completing firstCompleted");
+                firstCompleted.complete();
+                context.assertTrue(v.failed());
+                context.assertEquals("Oops!", v.cause().getMessage());
             });
 
-        inflight.enqueue("test", v -> {
-            LOGGER.debug("completing secondCompleted");
-            secondCompleted.complete();
-        }, fut -> {
-                LOGGER.debug("2nd task waiting for both to enqueue");
-                bothEnqueued.await();
-                LOGGER.debug("2nd task completing");
-                fut.complete();
+        inflight.enqueue("test", fut -> {
+            LOGGER.debug("2nd task waiting for both to enqueue");
+            bothEnqueued.await();
+            LOGGER.debug("2nd task completing");
+            fut.complete();
+        }, v -> {
+                LOGGER.debug("completing secondCompleted");
+                secondCompleted.complete();
             });
         LOGGER.debug("completing bothEnqueued");
         bothEnqueued.complete();

--- a/topic-controller/src/test/java/io/strimzi/controller/topic/MockController.java
+++ b/topic-controller/src/test/java/io/strimzi/controller/topic/MockController.java
@@ -97,9 +97,9 @@ class MockController extends Controller {
     }
 
     @Override
-    public void onTopicDeleted(TopicName topicName, Handler<AsyncResult<Void>> handler) {
+    public void onTopicDeleted(TopicName topicName, Handler<AsyncResult<Void>> resultHandler) {
         mockControllerEvents.add(new MockControllerEvent(MockControllerEvent.Type.DELETE, topicName));
-        handler.handle(topicDeletedResult);
+        resultHandler.handle(topicDeletedResult);
     }
 
     @Override
@@ -115,20 +115,20 @@ class MockController extends Controller {
     }
 
     @Override
-    public void onConfigMapAdded(ConfigMap cm, Handler<AsyncResult<Void>> handler) {
+    public void onConfigMapAdded(ConfigMap cm, Handler<AsyncResult<Void>> resultHandler) {
         mockControllerEvents.add(new MockControllerEvent(MockControllerEvent.Type.CREATE, cm));
-        handler.handle(cmAddedResult);
+        resultHandler.handle(cmAddedResult);
     }
 
     @Override
-    public void onConfigMapModified(ConfigMap cm, Handler<AsyncResult<Void>> handler) {
+    public void onConfigMapModified(ConfigMap cm, Handler<AsyncResult<Void>> resultHandler) {
         mockControllerEvents.add(new MockControllerEvent(MockControllerEvent.Type.MODIFY, cm));
-        handler.handle(cmModifiedResult);
+        resultHandler.handle(cmModifiedResult);
     }
 
     @Override
-    public void onConfigMapDeleted(ConfigMap cm, Handler<AsyncResult<Void>> handler) {
+    public void onConfigMapDeleted(ConfigMap cm, Handler<AsyncResult<Void>> resultHandler) {
         mockControllerEvents.add(new MockControllerEvent(MockControllerEvent.Type.DELETE, cm));
-        handler.handle(cmDeletedResult);
+        resultHandler.handle(cmDeletedResult);
     }
 }


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

This PR adds the periodic reconciliation executed through the inflight queue. Other than being something missing before that, the PR should fix the #258 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging

