### PR TITLE
Added ST for testing of Update values in Config map

### DIFF
--- a/.travis/setup-kubernetes.sh
+++ b/.travis/setup-kubernetes.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+rm ~/.kube/config
+
 function install_kubectl {
     curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && chmod +x kubectl
     sudo cp kubectl /usr/bin

--- a/common-test/pom.xml
+++ b/common-test/pom.xml
@@ -8,6 +8,9 @@
         <version>1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
+    <properties>
+        <jsonpath.version>RELEASE</jsonpath.version>
+    </properties>
 
     <artifactId>common-test</artifactId>
 
@@ -53,7 +56,12 @@
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
-            <version>RELEASE</version>
+            <version>${jsonpath.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.jayway.jsonpath</groupId>
+            <artifactId>json-path-assert</artifactId>
+            <version>${jsonpath.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/common-test/pom.xml
+++ b/common-test/pom.xml
@@ -54,6 +54,7 @@
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
             <version>RELEASE</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/common-test/pom.xml
+++ b/common-test/pom.xml
@@ -50,6 +50,11 @@
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.jayway.jsonpath</groupId>
+            <artifactId>json-path</artifactId>
+            <version>RELEASE</version>
+        </dependency>
     </dependencies>
 
 

--- a/common-test/src/main/java/io/strimzi/test/k8s/BaseKubeClient.java
+++ b/common-test/src/main/java/io/strimzi/test/k8s/BaseKubeClient.java
@@ -297,6 +297,10 @@ public abstract class BaseKubeClient<K extends BaseKubeClient<K>> implements Kub
         return asList(Exec.exec(namespacedCommand("get", resourceType, "-o", "jsonpath={range .items[*]}{.metadata.name} ")).out().trim().split(" +"));
     }
 
+    public List<String> listByLabel(String resourceType, String labelName) {
+        return asList(Exec.exec(namespacedCommand("get", resourceType, "-l", "name="+labelName, "-o", "jsonpath={range .items[*]}{.metadata.name} ")).out().trim().split(" +"));
+    }
+
     @Override
     public String describe(String resourceType, String resourceName) {
         return Exec.exec(namespacedCommand("describe", resourceType, resourceName)).out();

--- a/common-test/src/main/java/io/strimzi/test/k8s/BaseKubeClient.java
+++ b/common-test/src/main/java/io/strimzi/test/k8s/BaseKubeClient.java
@@ -293,7 +293,7 @@ public abstract class BaseKubeClient<K extends BaseKubeClient<K>> implements Kub
         TestUtils.waitFor(resourceType + " " + resourceName + " update",
                 1_000L, 240_000L, () -> {
                 try {
-                    return !startTime.equals(JsonPath.parse(getConfig(resourceType, resourceName)).
+                    return !startTime.equals(JsonPath.parse(getResourceAsJson(resourceType, resourceName)).
                             read("$.metadata.creationTimestamp").toString().replaceAll("\\p{P}", ""));
                 } catch (KubeClusterException.NotFound e) {
                     return false;
@@ -312,11 +312,7 @@ public abstract class BaseKubeClient<K extends BaseKubeClient<K>> implements Kub
         return asList(Exec.exec(namespacedCommand("get", resourceType, "-o", "jsonpath={range .items[*]}{.metadata.name} ")).out().trim().split(" +"));
     }
 
-    public List<String> listByLabel(String resourceType, String labelName) {
-        return asList(Exec.exec(namespacedCommand("get", resourceType, "-l", "name=" + labelName, "-o", "jsonpath={range .items[*]}{.metadata.name} ")).out().trim().split(" +"));
-    }
-
-    public String getConfig(String resourceType, String resourceName) {
+    public String getResourceAsJson(String resourceType, String resourceName) {
         return Exec.exec(namespacedCommand("get", resourceType, resourceName, "-o", "json")).out();
     }
 

--- a/common-test/src/main/java/io/strimzi/test/k8s/BaseKubeClient.java
+++ b/common-test/src/main/java/io/strimzi/test/k8s/BaseKubeClient.java
@@ -298,7 +298,7 @@ public abstract class BaseKubeClient<K extends BaseKubeClient<K>> implements Kub
     }
 
     public List<String> listByLabel(String resourceType, String labelName) {
-        return asList(Exec.exec(namespacedCommand("get", resourceType, "-l", "name="+labelName, "-o", "jsonpath={range .items[*]}{.metadata.name} ")).out().trim().split(" +"));
+        return asList(Exec.exec(namespacedCommand("get", resourceType, "-l", "name=" + labelName, "-o", "jsonpath={range .items[*]}{.metadata.name} ")).out().trim().split(" +"));
     }
 
     @Override

--- a/common-test/src/main/java/io/strimzi/test/k8s/BaseKubeClient.java
+++ b/common-test/src/main/java/io/strimzi/test/k8s/BaseKubeClient.java
@@ -295,9 +295,6 @@ public abstract class BaseKubeClient<K extends BaseKubeClient<K>> implements Kub
                 try {
                     return !startTime.equals(JsonPath.parse(getConfig(resourceType, resourceName)).
                             read("$.metadata.creationTimestamp").toString().replaceAll("\\p{P}", ""));
-
-
-
                 } catch (KubeClusterException.NotFound e) {
                     return false;
                 }

--- a/common-test/src/main/java/io/strimzi/test/k8s/KubeClient.java
+++ b/common-test/src/main/java/io/strimzi/test/k8s/KubeClient.java
@@ -119,4 +119,8 @@ public interface KubeClient<K extends KubeClient<K>> {
     String describe(String resourceType, String resourceName);
 
     String logs(String pod);
+
+    String getConfig(String resourceType, String resourceName);
+
+    K waitForResourceUpdate(String resourceType, String resourceName, String startTime);
 }

--- a/common-test/src/main/java/io/strimzi/test/k8s/KubeClient.java
+++ b/common-test/src/main/java/io/strimzi/test/k8s/KubeClient.java
@@ -6,6 +6,7 @@ package io.strimzi.test.k8s;
 
 import java.io.File;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 
 import static java.util.Arrays.asList;
@@ -122,5 +123,7 @@ public interface KubeClient<K extends KubeClient<K>> {
 
     String getResourceAsJson(String resourceType, String resourceName);
 
-    K waitForResourceUpdate(String resourceType, String resourceName, String startTime);
+    K waitForResourceUpdate(String resourceType, String resourceName, Date startTime);
+
+    Date getResourceCreateTimestamp(String pod, String s);
 }

--- a/common-test/src/main/java/io/strimzi/test/k8s/KubeClient.java
+++ b/common-test/src/main/java/io/strimzi/test/k8s/KubeClient.java
@@ -120,7 +120,7 @@ public interface KubeClient<K extends KubeClient<K>> {
 
     String logs(String pod);
 
-    String getConfig(String resourceType, String resourceName);
+    String getResourceAsJson(String resourceType, String resourceName);
 
     K waitForResourceUpdate(String resourceType, String resourceName, String startTime);
 }

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -42,6 +42,11 @@
             <artifactId>hamcrest-all</artifactId>
             <version>${hamcrest.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.jayway.jsonpath</groupId>
+            <artifactId>json-path-assert</artifactId>
+            <version>2.2.0</version>
+        </dependency>
     </dependencies>
 
 

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -46,6 +46,7 @@
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path-assert</artifactId>
             <version>2.2.0</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -11,6 +11,7 @@
 
     <properties>
         <hamcrest.version>1.3</hamcrest.version>
+        <jsonpath.version>2.2.0</jsonpath.version>
     </properties>
 
     <artifactId>systemtest</artifactId>
@@ -45,7 +46,7 @@
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path-assert</artifactId>
-            <version>2.2.0</version>
+            <version>${jsonpath.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterTest.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterTest.java
@@ -347,7 +347,7 @@ public class KafkaClusterTest {
         assertThat(configMap, valueOfCmEquals("KAFKA_DEFAULT_REPLICATION_FACTOR", "1"));
         LOGGER.info("Verified CM and Testing kafka pods");
         for (int i = 0; i < expectedKafkaPods; i++) {
-            String kafkaPodJson = oc.getConfig("pod", kafkaPodName(clusterName, i));
+            String kafkaPodJson = oc.getResourceAsJson("pod", kafkaPodName(clusterName, i));
             assertEquals("1", getValueFromJson(kafkaPodJson,
                     globalVariableJsonPathBuilder("KAFKA_DEFAULT_REPLICATION_FACTOR")));
             String initialDelaySecondsPath = "$.spec.containers[*].livenessProbe.initialDelaySeconds";
@@ -355,7 +355,7 @@ public class KafkaClusterTest {
         }
         LOGGER.info("Testing Zookeepers");
         for (int i = 0; i < expectedZKPods; i++) {
-            String zkPodJson = kubeClient.getConfig("pod", zookeeperPodName(clusterName, i));
+            String zkPodJson = kubeClient.getResourceAsJson("pod", zookeeperPodName(clusterName, i));
             String initialDelaySecondsPath = "$.spec.containers[*].livenessProbe.initialDelaySeconds";
             assertEquals("23", getValueFromJson(zkPodJson, initialDelaySecondsPath));
         }
@@ -372,7 +372,7 @@ public class KafkaClusterTest {
     }
 
     private String getResourceCreateTimestamp(String resourceType, String resourceName) {
-        return JsonPath.parse(kubeClient.getConfig(resourceType, resourceName)).
+        return JsonPath.parse(kubeClient.getResourceAsJson(resourceType, resourceName)).
                 read("$.metadata.creationTimestamp").toString().replaceAll("\\p{P}", "");
     }
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterTest.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterTest.java
@@ -331,8 +331,8 @@ public class KafkaClusterTest {
         assertThat(configMap, valueOfCmEquals("zookeeper-healthcheck-timeout", "10"));
 
         List<String> ccPods = oc.listByLabel("pod", "strimzi-cluster-controller");
-        LOGGER.info("Count of Cluster controllers is: "+ ccPods.size());
-        for(int i=0; i<ccPods.size(); i++){
+        LOGGER.info("Count of Cluster controllers is: " + ccPods.size());
+        for (int i = 0; i < ccPods.size(); i++) {
             Assert.assertThat(oc.logs(ccPods.get(i)),
                     CoreMatchers.containsString("Diff: Zookeeper healthcheck timing changed"));
         }

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterTest.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterTest.java
@@ -309,6 +309,7 @@ public class KafkaClusterTest {
     }
 
     @Test
+    @OpenShiftOnly
     @KafkaCluster(name = "my-cluster", kafkaNodes = 2, zkNodes = 2, config = {
             @CmData(key = "zookeeper-healthcheck-delay", value = "30"),
             @CmData(key = "zookeeper-healthcheck-timeout", value = "10"),

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterTest.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterTest.java
@@ -28,14 +28,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
-
-
 import static io.strimzi.test.TestUtils.indent;
 import static io.strimzi.test.TestUtils.map;
 import static junit.framework.TestCase.assertTrue;
@@ -324,39 +321,30 @@ public class KafkaClusterTest {
         String clusterName = "my-cluster";
         int expectedZKPods = 2;
         int expectedKafkaPods = 2;
-
         List<String> zkPodStartTime = new ArrayList<>();
         for (int i = 0; i < expectedZKPods; i++) {
             zkPodStartTime.add(getResourceCreateTimestamp("pod", zookeeperPodName(clusterName, i)));
         }
-
         List<String> kafkaPodStartTime = new ArrayList<>();
         for (int i = 0; i < expectedKafkaPods; i++) {
             kafkaPodStartTime.add(getResourceCreateTimestamp("pod", kafkaPodName(clusterName, i)));
         }
-
         Oc oc = (Oc) this.kubeClient;
-
         replaceCm(clusterName, "zookeeper-healthcheck-delay", "23");
         replaceCm(clusterName, "kafka-healthcheck-delay", "23");
         replaceCm(clusterName, "KAFKA_DEFAULT_REPLICATION_FACTOR", "1");
-
         for (int i = 0; i < expectedZKPods; i++) {
             kubeClient.waitForResourceUpdate("pod", zookeeperPodName(clusterName, i), zkPodStartTime.get(i));
             kubeClient.waitForPod(zookeeperPodName(clusterName,  i));
         }
-
         for (int i = 0; i < expectedKafkaPods; i++) {
             kubeClient.waitForResourceUpdate("pod", kafkaPodName(clusterName, i), kafkaPodStartTime.get(i));
             kubeClient.waitForPod(kafkaPodName(clusterName,  i));
         }
-
         String configMap = kubeClient.get("cm", clusterName);
         assertThat(configMap, valueOfCmEquals("zookeeper-healthcheck-delay", "23"));
         assertThat(configMap, valueOfCmEquals("kafka-healthcheck-delay", "23"));
         assertThat(configMap, valueOfCmEquals("KAFKA_DEFAULT_REPLICATION_FACTOR", "1"));
-
-
         LOGGER.info("Verified CM and Testing kafka pods");
         for (int i = 0; i < expectedKafkaPods; i++) {
             String kafkaPodJson = oc.getConfig("pod", kafkaPodName(clusterName, i));
@@ -365,7 +353,6 @@ public class KafkaClusterTest {
             String initialDelaySecondsPath = "$.spec.containers[*].livenessProbe.initialDelaySeconds";
             assertEquals("23", getValueFromJson(kafkaPodJson, initialDelaySecondsPath));
         }
-
         LOGGER.info("Testing Zookeepers");
         for (int i = 0; i < expectedZKPods; i++) {
             String zkPodJson = kubeClient.getConfig("pod", zookeeperPodName(clusterName, i));

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterTest.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterTest.java
@@ -30,6 +30,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
@@ -321,13 +322,13 @@ public class KafkaClusterTest {
         String clusterName = "my-cluster";
         int expectedZKPods = 2;
         int expectedKafkaPods = 2;
-        List<String> zkPodStartTime = new ArrayList<>();
+        List<Date> zkPodStartTime = new ArrayList<>();
         for (int i = 0; i < expectedZKPods; i++) {
-            zkPodStartTime.add(getResourceCreateTimestamp("pod", zookeeperPodName(clusterName, i)));
+            zkPodStartTime.add(kubeClient.getResourceCreateTimestamp("pod", zookeeperPodName(clusterName, i)));
         }
-        List<String> kafkaPodStartTime = new ArrayList<>();
+        List<Date> kafkaPodStartTime = new ArrayList<>();
         for (int i = 0; i < expectedKafkaPods; i++) {
-            kafkaPodStartTime.add(getResourceCreateTimestamp("pod", kafkaPodName(clusterName, i)));
+            kafkaPodStartTime.add(kubeClient.getResourceCreateTimestamp("pod", kafkaPodName(clusterName, i)));
         }
         Oc oc = (Oc) this.kubeClient;
         replaceCm(clusterName, "zookeeper-healthcheck-delay", "23");
@@ -370,11 +371,5 @@ public class KafkaClusterTest {
         String path = "$.spec.containers[*].env[?(@.name=='" + variable + "')].value";
         return path;
     }
-
-    private String getResourceCreateTimestamp(String resourceType, String resourceName) {
-        return JsonPath.parse(kubeClient.getResourceAsJson(resourceType, resourceName)).
-                read("$.metadata.creationTimestamp").toString().replaceAll("\\p{P}", "");
-    }
-
 
 }


### PR DESCRIPTION
### Type of change

- Added new System test for update values in Config map

### Description

System test starts Kafka cluster with custom parameters and then updates the value of `zookeeper-healthcheck-delay`. Than test waits for pods update and then check `zookeeper-healthcheck-delay` value and also checks logs on the Cluster controller pod.
CC logs should contain folloving message: `Diff: Zookeeper healthcheck timing changed`
### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging

