### PR TITLE
Bugfix - fix indentation

### DIFF
--- a/examples/install/topic-controller/03-role-binding.yaml
+++ b/examples/install/topic-controller/03-role-binding.yaml
@@ -10,4 +10,4 @@ subjects:
 roleRef:
   kind: Role
   name: strimzi-topic-controller-role
-apiGroup: rbac.authorization.k8s.io
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Bugfix

```kubectl create -f examples/install/topic-controller/03-role-binding.yaml
error: error validating "examples/install/topic-controller/03-role-binding.yaml": error validating data: [ValidationError(RoleBinding): unknown field "apiGroup" in io.k8s.api.rbac.v1beta1.RoleBinding, ValidationError(RoleBinding.roleRef): missing required field "apiGroup" in io.k8s.api.rbac.v1beta1.RoleRef]; if you choose to ignore these errors, turn validation off with --validate=false```