### PR TITLE
Logging exception and return when znode watching reports a failure

### DIFF
--- a/documentation/adoc/cluster-controller.adoc
+++ b/documentation/adoc/cluster-controller.adoc
@@ -135,9 +135,6 @@ data:
     }
 ----
 
-WARNING: If the zookeeper cluster is deployed using "ephemeral" storage, the Kafka brokers can have problems dealing with
-Zookeeper node restarts which could happen via updates in the cluster ConfigMap.
-
 The resources created by the cluster controller into the Kubernetes/OpenShift cluster will be the following :
 
 * `[cluster-name]-zookeeper` StatefulSet which is in charge to create the Zookeeper node pods
@@ -172,6 +169,9 @@ The "ephemeral" storage is really simple to configure and the related JSON strin
 { "type": "ephemeral" }
 
 ----
+
+WARNING: If the Zookeeper cluster is deployed using "ephemeral" storage, the Kafka brokers can have problems dealing with
+Zookeeper node restarts which could happen via updates in the cluster ConfigMap.
 
 In case of "persistent-claim" type the following fields can be provided as well :
 

--- a/documentation/adoc/cluster-controller.adoc
+++ b/documentation/adoc/cluster-controller.adoc
@@ -135,8 +135,8 @@ data:
     }
 ----
 
-WARNING: If the cluster is deployed using the "ephemeral" storage, the Kafka brokers could have problems to deal with
-Zookeeper nodes restarts which could happen on configuration updates in the cluster ConfigMap.
+WARNING: If the zookeeper cluster is deployed using "ephemeral" storage, the Kafka brokers can have problems dealing with
+Zookeeper node restarts which could happen via updates in the cluster ConfigMap.
 
 The resources created by the cluster controller into the Kubernetes/OpenShift cluster will be the following :
 

--- a/documentation/adoc/cluster-controller.adoc
+++ b/documentation/adoc/cluster-controller.adoc
@@ -135,6 +135,9 @@ data:
     }
 ----
 
+WARNING: If the cluster is deployed using the "ephemeral" storage, the Kafka brokers could have problems to deal with
+Zookeeper nodes restarts which could happen on configuration updates in the cluster ConfigMap.
+
 The resources created by the cluster controller into the Kubernetes/OpenShift cluster will be the following :
 
 * `[cluster-name]-zookeeper` StatefulSet which is in charge to create the Zookeeper node pods

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/TopicsWatcher.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/TopicsWatcher.java
@@ -64,7 +64,8 @@ class TopicsWatcher {
                 return;
             }
             if (childResult.failed()) {
-                throw new RuntimeException(childResult.cause());
+                LOGGER.error("Error on zone {} children", TOPICS_ZNODE, childResult.cause());
+                return;
             }
             List<String> result = childResult.result();
             LOGGER.debug("znode {} now has children {}, previous children {}", TOPICS_ZNODE, result, this.children);
@@ -106,7 +107,8 @@ class TopicsWatcher {
 
         }).children(TOPICS_ZNODE, childResult -> {
             if (childResult.failed()) {
-                throw new RuntimeException(childResult.cause());
+                LOGGER.error("Error on zone {} children", TOPICS_ZNODE, childResult.cause());
+                return;
             }
             List<String> result = childResult.result();
             LOGGER.debug("Setting initial children {}", result);

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/TopicsWatcher.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/TopicsWatcher.java
@@ -64,7 +64,7 @@ class TopicsWatcher {
                 return;
             }
             if (childResult.failed()) {
-                LOGGER.error("Error on zone {} children", TOPICS_ZNODE, childResult.cause());
+                LOGGER.error("Error on znode {} children", TOPICS_ZNODE, childResult.cause());
                 return;
             }
             List<String> result = childResult.result();
@@ -107,7 +107,7 @@ class TopicsWatcher {
 
         }).children(TOPICS_ZNODE, childResult -> {
             if (childResult.failed()) {
-                LOGGER.error("Error on zone {} children", TOPICS_ZNODE, childResult.cause());
+                LOGGER.error("Error on znode {} children", TOPICS_ZNODE, childResult.cause());
                 return;
             }
             List<String> result = childResult.result();


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes #238 just logging the failure reported by a znode child.
While using "ephemeral" storage as described by #238 doesn't make more sense even because Kafka brokers cannot deal with Zookeeper pod restart, using the "persistent" storage has another problem. The cluster works fine but the topic controller is not able to handle new topic CMs due "Session expired" errors on watched znode. I'm going to open another issue for that.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging

