### PR TITLE
ST: Update CC's env variables

### DIFF
--- a/common-test/src/main/java/io/strimzi/test/ClusterController.java
+++ b/common-test/src/main/java/io/strimzi/test/ClusterController.java
@@ -17,4 +17,6 @@ import java.lang.annotation.Target;
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ClusterController {
+
+    EnvVariables[] envVariables() default {};
 }

--- a/common-test/src/main/java/io/strimzi/test/EnvVariables.java
+++ b/common-test/src/main/java/io/strimzi/test/EnvVariables.java
@@ -9,22 +9,22 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotation is used in ({@link ConnectCluster}, {@link KafkaCluster})
- * to configure a cluster with custom parameters and values.
+ * Annotation is used in ({@link ClusterController})
+ * to configure a Cluster Controller with custom environment variables.
  * <p>
  * An example would be:
  * <pre>
- * &#064;Test
- * &#064;KafkaCluster(config = {
- * &#064;CmData(key = "foo", value = "bar")
+ * &#064;RunWith({@link StrimziRunner})
+ * &#064;ClusterController(envVariables = {
+ * &#064;EnvVariables(key = "foo", value = "bar")
  * })
- * public void test() {
+ * public class ClusterTest {
  * }
  * </pre>
  */
 @Target({})
 @Retention(RetentionPolicy.RUNTIME)
-public @interface CmData {
+public @interface EnvVariables {
 
     String key();
     String value();

--- a/common-test/src/main/java/io/strimzi/test/StrimziRunner.java
+++ b/common-test/src/main/java/io/strimzi/test/StrimziRunner.java
@@ -321,6 +321,12 @@ public class StrimziRunner extends BlockJUnit4ClassRunner {
                             String value = envVar.get("value").textValue();
                             ((ObjectNode) envVar).put("value", changeOrgAndTag(value, dockerOrg, dockerTag));
                         }
+                        // Updates default values of env variables
+                        for (EnvVariables envVariable : cc.envVariables()) {
+                            if (varName.equals(envVariable.key())) {
+                                ((ObjectNode) envVar).put("value", envVariable.value());
+                            }
+                        }
                     }
                 }
             })).collect(Collectors.toList());


### PR DESCRIPTION
### Type of change
- Enhancement / new feature

### Description
In PR #320 we have system tests that wait for reconciliation and looks like it can take a lot of time because default timeout for reconciliation is 120 sec. 
As a solution, I created an annotation `@EnvVariables` with which we can update the default values of environment variables, so in this way, we can reduce execution time.

### Checklist
- [ ] Make sure all tests pass
- [ ] Update documentation
