### PR TITLE
Fixes and minor improvements to the CI build system and system tests

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -15,6 +15,7 @@ echo "Login into Docker Hub ..."
 docker login -u $DOCKER_USER -p $DOCKER_PASS
 
 export DOCKER_TAG=$BRANCH
+export DOCKER_BUILD_TAG=$COMMIT
 echo "Pushing to docker org $DOCKER_ORG under tag $DOCKER_TAG"
 make docker_push
 

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -14,7 +14,12 @@ make docker_build
 echo "Login into Docker Hub ..."
 docker login -u $DOCKER_USER -p $DOCKER_PASS
 
-echo "Pushing to docker org $DOCKER_ORG"
+export DOCKER_TAG=$BRANCH
+echo "Pushing to docker org $DOCKER_ORG under tag $DOCKER_TAG"
+make docker_push
+
+export DOCKER_TAG=$COMMIT
+echo "Pushing to docker org $DOCKER_ORG under tag $DOCKER_TAG"
 make docker_push
 
 echo "Running systemtests"

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -11,6 +11,7 @@ DOCKERFILE_DIR     ?= ./
 DOCKER_REGISTRY    ?= docker.io
 DOCKER_ORG         ?= $(USER)
 DOCKER_TAG         ?= latest
+DOCKER_BUILD_TAG   ?= $(DOCKER_TAG)
 DOCKER_VERSION_ARG ?= latest
 
 all: docker_build docker_push
@@ -20,8 +21,8 @@ docker_build:
 	docker build --build-arg version=$(DOCKER_VERSION_ARG) -t strimzi/$(PROJECT_NAME):$(DOCKER_TAG) $(DOCKERFILE_DIR)
 
 docker_tag:
-	echo "Tagging strimzi/$(PROJECT_NAME):$(DOCKER_TAG) to $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG) ..."
-	docker tag strimzi/$(PROJECT_NAME):$(DOCKER_TAG) $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)
+	echo "Tagging strimzi/$(PROJECT_NAME):$(DOCKER_BUILD_TAG) to $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG) ..."
+	docker tag strimzi/$(PROJECT_NAME):$(DOCKER_BUILD_TAG) $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)
 
 docker_push: docker_tag
 	echo "Pushing $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG) ..."

--- a/common-test/src/main/java/io/strimzi/test/StrimziRunner.java
+++ b/common-test/src/main/java/io/strimzi/test/StrimziRunner.java
@@ -306,11 +306,8 @@ public class StrimziRunner extends BlockJUnit4ClassRunner {
             List<String> yamls = Arrays.stream(new File(CC_INSTALL_DIR).listFiles()).sorted().map(f -> getContent(f, node -> {
                 // Change the docker org of the images in the 04-deployment.yaml
                 if ("04-deployment.yaml".equals(f.getName())) {
-                    String dockerOrg = System.getenv().getOrDefault("DOCKER_ORG", "strimzici");
-                    String dockerTag = System.getenv().get("DOCKER_TAG");
-                    if (dockerTag == null || dockerTag.isEmpty()) {
-                        throw new RuntimeException("DOCKER_TAG environment variable not set");
-                    }
+                    String dockerOrg = System.getenv().getOrDefault("DOCKER_ORG", "strimzi");
+                    String dockerTag = System.getenv().getOrDefault("DOCKER_TAG", "latest");
                     JsonNode containerNode = node.get("spec").get("template").get("spec").get("containers").get(0);
                     JsonNode ccImageNode = containerNode.get("image");
                     ((ObjectNode) containerNode).put("image", changeOrgAndTag(ccImageNode.asText(), dockerOrg, dockerTag));


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature
- ~~Refactoring~~

### Description

This PR does some fixes and minor improvements to the CI and system test changes:
* Make it possible to run `make docker_tag` and `make docker_push` with different tag than what was used for `make docker_build` (this would currently crash in master)
* Since we are already using the `strimzici` org on Docker Hub, we can push there not only with the commit ID but also with the branch name - that would make it easier to use the images from branches for manual testing.
* To make it easy to run system tests locally using the default images, the `DOCKER_ORG` and `DOCKER_TAG` in `StrimziRunner` defaults to `strimzi` and `latest`. On Travis the environment variables are defined and would be used.

