### PR TITLE
Fix #312: Remove use of assert and prevent future use

### DIFF
--- a/.checkstyle/checkstyle.xml
+++ b/.checkstyle/checkstyle.xml
@@ -115,6 +115,10 @@
             <!-- default is 200 -->
             <property name="max" value="500"/>
         </module>
+
+        <module name="IllegalToken">
+            <property name="tokens" value="LITERAL_ASSERT"/>
+        </module>
     </module>
 
     <module name="SuppressionFilter">

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/BackOff.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/BackOff.java
@@ -27,9 +27,15 @@ public class BackOff {
     }
 
     public BackOff(long scaleMs, int base, int maxAttempts) {
-        assert scaleMs > 0;
-        assert base > 0;
-        assert maxAttempts > 0;
+        if (scaleMs <= 0) {
+            throw new IllegalArgumentException();
+        }
+        if (base <= 0) {
+            throw new IllegalArgumentException();
+        }
+        if (maxAttempts <= 0) {
+            throw new IllegalArgumentException();
+        }
         this.scaleMs = scaleMs;
         this.base = base;
         this.maxAttempts = maxAttempts;

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/TopicDiff.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/TopicDiff.java
@@ -118,7 +118,9 @@ public class TopicDiff {
         private final String configValue;
 
         public AddedConfigEntry(String configKey, String configValue) {
-            assert configKey != null && configValue != null;
+            if (configKey == null || configValue == null) {
+                throw new IllegalArgumentException();
+            }
             this.configKey = configKey;
             this.configValue = configValue;
         }

--- a/topic-controller/src/main/java/io/strimzi/controller/topic/TopicName.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/TopicName.java
@@ -19,7 +19,9 @@ class TopicName {
     private final String name;
 
     public TopicName(String name) {
-        assert name != null && !name.isEmpty();
+        if (name == null || name.isEmpty()) {
+            throw new IllegalArgumentException();
+        }
         // TODO Shame we can't validate a topic name without relying on an internal class
         Topic.validate(name);
         this.name = name;


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Refactoring

### Description

Fix #312: Remove use of assert and prevent future use

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging

