### PR TITLE
Exit on missing config env

### DIFF
--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/Main.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/Main.java
@@ -31,7 +31,6 @@ import org.slf4j.LoggerFactory;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 public class Main {
     private static final Logger log = LoggerFactory.getLogger(Main.class.getName());

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/Main.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/Main.java
@@ -37,12 +37,13 @@ public class Main {
     private static final Logger log = LoggerFactory.getLogger(Main.class.getName());
 
     public static void main(String[] args) {
+        ClusterControllerConfig config = ClusterControllerConfig.fromMap(System.getenv());
         Vertx vertx = Vertx.vertx();
         KubernetesClient client = new DefaultKubernetesClient();
 
         isOnOpenShift(vertx, client).setHandler(os -> {
             if (os.succeeded()) {
-                run(vertx, client, os.result().booleanValue(), System.getenv()).setHandler(ar -> {
+                run(vertx, client, os.result().booleanValue(), config).setHandler(ar -> {
                     if (ar.failed()) {
                         log.error("Unable to start controller for 1 or more namespace", ar.cause());
                         System.exit(1);
@@ -55,9 +56,7 @@ public class Main {
         });
     }
 
-    static CompositeFuture run(Vertx vertx, KubernetesClient client, boolean isOpenShift, Map<String, String> env) {
-        ClusterControllerConfig config = ClusterControllerConfig.fromMap(env);
-
+    static CompositeFuture run(Vertx vertx, KubernetesClient client, boolean isOpenShift, ClusterControllerConfig config) {
         ServiceOperator serviceOperations = new ServiceOperator(vertx, client);
         ZookeeperSetOperator zookeeperSetOperations = new ZookeeperSetOperator(vertx, client);
         KafkaSetOperator kafkaSetOperations = new KafkaSetOperator(vertx, client);

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/ClusterControllerTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/ClusterControllerTest.java
@@ -88,7 +88,7 @@ public class ClusterControllerTest {
         env.put(ClusterControllerConfig.STRIMZI_NAMESPACE, namespaces);
         env.put(ClusterControllerConfig.STRIMZI_CONFIGMAP_LABELS, STRIMZI_IO_KIND_CLUSTER);
         env.put(ClusterControllerConfig.STRIMZI_FULL_RECONCILIATION_INTERVAL_MS, "120000");
-        Main.run(vertx, client, true, env).setHandler(ar -> {
+        Main.run(vertx, client, true, ClusterControllerConfig.fromMap(env)).setHandler(ar -> {
             context.assertNull(ar.cause(), "Expected all verticles to start OK");
             async.complete();
         });


### PR DESCRIPTION
### Type of change

- Bugfix
- ~~Enhancement / new feature~~
- ~~Refactoring~~

### Description

When some required environment variables are not defined (such as `STRIMZI_NAMESPACE`), we should exit and not keep running. It is done by initializing the `ClusterControllerConfig` object in the `main` method, so that the exceptions are properly propagated and the main exits.

This closes the issue #292 
