### PR TITLE
When recreateConfigMapWatch fails, we should deal with it

### DIFF
--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterController.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterController.java
@@ -208,6 +208,7 @@ public class ClusterController extends AbstractVerticle {
                 configMapWatch = res.result();
             } else {
                 log.error("Failed to recreate ConfigMap watch in namespace {}", namespace);
+                vertx.close();
             }
         });
     }


### PR DESCRIPTION
### Type of change

- Bugfix
- ~~Enhancement / new feature~~
- ~~Refactoring~~

### Description

When the Config Map watch is closed we try to recreate it. But when the recreation for whatever reason fails, we will just record error and continue running without the watch. That obviously isn't right. We should either try to recreate it again later or just exit and let Kubernetes handle it. This PR closes Vert.x which causes the cluster controller to exit.