### PR TITLE
Use hostname instead of IP address as advertised listeners - Closes #50

### DIFF
--- a/docker-images/kafka/scripts/kafka_run.sh
+++ b/docker-images/kafka/scripts/kafka_run.sh
@@ -39,7 +39,7 @@ cat > /tmp/strimzi.properties <<EOF
 broker.id=${KAFKA_BROKER_ID}
 # Listeners
 listeners=CLIENT://:9092,REPLICATION://:9091
-advertised.listeners=CLIENT://$(hostname -I | tr -d " " ):9092,REPLICATION://$(hostname -f):9091
+advertised.listeners=CLIENT://$(hostname -f):9092,REPLICATION://$(hostname -f):9091
 listener.security.protocol.map=CLIENT:PLAINTEXT,REPLICATION:PLAINTEXT
 inter.broker.listener.name=REPLICATION
 # Zookeeper


### PR DESCRIPTION
### Type of change

- Bugfix
- ~~Enhancement / new feature~~
- ~~Refactoring~~

### Description

With this PR the `advertised.listeners` field will not use Pod IP address anymore and use the fully qualifies hostname instead (as already used for the replication interface). This should make it easier to handle metadata updates after Pod restarts when the IP address might change (the hostname is still the same). This fixes the issue #50 