### PR TITLE
Differences in any volume's defaultMode should be ignored

### DIFF
--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/operator/resource/StatefulSetDiffTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/operator/resource/StatefulSetDiffTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.controller.cluster.operator.resource;
+
+import io.fabric8.kubernetes.api.model.ConfigMapVolumeSourceBuilder;
+import io.fabric8.kubernetes.api.model.VolumeBuilder;
+import io.fabric8.kubernetes.api.model.extensions.StatefulSet;
+import io.fabric8.kubernetes.api.model.extensions.StatefulSetBuilder;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+
+public class StatefulSetDiffTest {
+
+    @Test
+    public void testSpecVolumesIgnored() {
+        StatefulSet ss1 = new StatefulSetBuilder()
+            .withNewMetadata()
+                .withNamespace("test")
+                .withName("foo")
+            .endMetadata()
+            .withNewSpec().
+                withNewTemplate()
+                    .withNewSpec()
+                        .addToVolumes(0, new VolumeBuilder()
+                                    .withConfigMap(new ConfigMapVolumeSourceBuilder().withDefaultMode(1).build())
+                                .build())
+                    .endSpec()
+                .endTemplate()
+            .endSpec()
+            .build();
+        StatefulSet ss2 = new StatefulSetBuilder()
+            .withNewMetadata()
+                .withNamespace("test")
+                .withName("foo")
+            .endMetadata()
+            .withNewSpec()
+                .withNewTemplate()
+                    .withNewSpec()
+                        .addToVolumes(0, new VolumeBuilder()
+                                .withConfigMap(new ConfigMapVolumeSourceBuilder().withDefaultMode(2).build())
+                                .build())
+                    .endSpec()
+                .endTemplate()
+            .endSpec()
+            .build();
+        assertFalse(new StatefulSetDiff(ss1, ss2).changesSpecTemplateSpec());
+    }
+}


### PR DESCRIPTION

### Type of change

_Select the type of your PR_

- Bugfix

### Description

It can happen that paths matching regex `/spec/template/spec/volumes/[0-9]+/configMap/defaultMode`
differ, but this should not cause a rolling update.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging

