### PR TITLE
Add /spec/volumeClaimTemplates/0/status to list of ignorable paths

### DIFF
--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operator/resource/StatefulSetDiff.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operator/resource/StatefulSetDiff.java
@@ -43,6 +43,7 @@ public class StatefulSetDiff {
             "/spec/template/spec/securityContext",
             "/spec/template/spec/terminationGracePeriodSeconds",
             "/spec/template/spec/volumes/[0-9]+/configMap/defaultMode",
+            "/spec/volumeClaimTemplates/[0-9]+/status",
             "/status").stream().map(Pattern::compile).collect(Collectors.toList());
     }
 


### PR DESCRIPTION
### Type of change

- Bugfix
- ~~Enhancement / new feature~~
- ~~Refactoring~~

### Description

When running Kafka and/or Zookeeper with persistent storage, the status of PersistentVolumeClaim will be appearing in diff and triggering the warning against storage changes. It has to be added to the ignore list.

