### PR TITLE
Changes to storage need to be reverted also in Volumes

### DIFF
--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/AbstractModel.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/AbstractModel.java
@@ -85,7 +85,7 @@ public abstract class AbstractModel {
     protected Storage storage;
 
     protected String mountPath;
-    protected static final String VOLUME_NAME = "data";
+    public static final String VOLUME_NAME = "data";
     protected String metricsConfigVolumeName;
     protected String metricsConfigMountPath;
 

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operator/resource/KafkaSetOperator.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operator/resource/KafkaSetOperator.java
@@ -32,9 +32,8 @@ public class KafkaSetOperator extends StatefulSetOperator<Boolean> {
     protected Future<ReconcileResult<Boolean>> internalPatch(String namespace, String name, StatefulSet current, StatefulSet desired) {
         StatefulSetDiff diff = new StatefulSetDiff(current, desired);
         if (diff.changesVolumeClaimTemplates()) {
-            log.warn("Changing storage type or size is not possible.");
-            revertStorageChanges(current, desired);
-            diff = new StatefulSetDiff(current, desired);
+            log.warn("Changing Kafka storage type or size is not possible. The changes will be ignored.");
+            diff = revertStorageChanges(current, desired);
         }
         if (diff.isEmpty()) {
             return Future.succeededFuture(ReconcileResult.noop());

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operator/resource/KafkaSetOperator.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operator/resource/KafkaSetOperator.java
@@ -32,8 +32,8 @@ public class KafkaSetOperator extends StatefulSetOperator<Boolean> {
     protected Future<ReconcileResult<Boolean>> internalPatch(String namespace, String name, StatefulSet current, StatefulSet desired) {
         StatefulSetDiff diff = new StatefulSetDiff(current, desired);
         if (diff.changesVolumeClaimTemplates()) {
-            log.warn("Ignoring change to volumeClaim");
-            desired.getSpec().setVolumeClaimTemplates(current.getSpec().getVolumeClaimTemplates());
+            log.warn("Changing storage type or size is not possible.");
+            revertStorageChanges(current, desired);
             diff = new StatefulSetDiff(current, desired);
         }
         if (diff.isEmpty()) {

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operator/resource/StatefulSetOperator.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operator/resource/StatefulSetOperator.java
@@ -259,8 +259,10 @@ public class StatefulSetOperator<P> extends AbstractScalableResourceOperator<Kub
      *
      * @param current Current StatefulSet
      * @param desired New StatefulSet
+     *
+     * @return Updated StatefulSetDiff after the storage patching
      */
-    protected void revertStorageChanges(StatefulSet current, StatefulSet desired) {
+    protected StatefulSetDiff revertStorageChanges(StatefulSet current, StatefulSet desired) {
         desired.getSpec().setVolumeClaimTemplates(current.getSpec().getVolumeClaimTemplates());
 
         if (current.getSpec().getVolumeClaimTemplates().isEmpty()) {
@@ -284,5 +286,7 @@ public class StatefulSetOperator<P> extends AbstractScalableResourceOperator<Kub
                 }
             }
         }
+
+        return new StatefulSetDiff(current, desired);
     }
 }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operator/resource/StatefulSetOperator.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operator/resource/StatefulSetOperator.java
@@ -15,6 +15,7 @@ import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
+import io.strimzi.controller.cluster.model.AbstractModel;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
@@ -267,7 +268,7 @@ public class StatefulSetOperator<P> extends AbstractScalableResourceOperator<Kub
             List<Volume> volumes = current.getSpec().getTemplate().getSpec().getVolumes();
             for (int i = 0; i < volumes.size(); i++) {
                 Volume vol = volumes.get(i);
-                if ("data".equals(vol.getName()) && vol.getEmptyDir() != null) {
+                if (AbstractModel.VOLUME_NAME.equals(vol.getName()) && vol.getEmptyDir() != null) {
                     desired.getSpec().getTemplate().getSpec().getVolumes().add(0, volumes.get(i));
                     break;
                 }
@@ -279,7 +280,7 @@ public class StatefulSetOperator<P> extends AbstractScalableResourceOperator<Kub
             List<Volume> volumes = desired.getSpec().getTemplate().getSpec().getVolumes();
             for (int i = 0; i < volumes.size(); i++) {
                 Volume vol = volumes.get(i);
-                if ("data".equals(vol.getName()) && vol.getEmptyDir() != null) {
+                if (AbstractModel.VOLUME_NAME.equals(vol.getName()) && vol.getEmptyDir() != null) {
                     volumes.remove(i);
                     break;
                 }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operator/resource/StatefulSetOperator.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operator/resource/StatefulSetOperator.java
@@ -261,10 +261,10 @@ public class StatefulSetOperator<P> extends AbstractScalableResourceOperator<Kub
      * @param desired New StatefulSet
      */
     protected void revertStorageChanges(StatefulSet current, StatefulSet desired) {
+        desired.getSpec().setVolumeClaimTemplates(current.getSpec().getVolumeClaimTemplates());
+
         if (current.getSpec().getVolumeClaimTemplates().isEmpty()) {
             // We are on ephemeral storage and changing to persistent
-            desired.getSpec().setVolumeClaimTemplates(current.getSpec().getVolumeClaimTemplates());
-
             List<Volume> volumes = current.getSpec().getTemplate().getSpec().getVolumes();
             for (int i = 0; i < volumes.size(); i++) {
                 Volume vol = volumes.get(i);
@@ -275,8 +275,6 @@ public class StatefulSetOperator<P> extends AbstractScalableResourceOperator<Kub
             }
         } else {
             // We are on persistent storage and changing to ephemeral
-            desired.getSpec().setVolumeClaimTemplates(current.getSpec().getVolumeClaimTemplates());
-
             List<Volume> volumes = desired.getSpec().getTemplate().getSpec().getVolumes();
             for (int i = 0; i < volumes.size(); i++) {
                 Volume vol = volumes.get(i);

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operator/resource/ZookeeperSetOperator.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operator/resource/ZookeeperSetOperator.java
@@ -32,9 +32,8 @@ public class ZookeeperSetOperator extends StatefulSetOperator<Boolean> {
     protected Future<ReconcileResult<Boolean>> internalPatch(String namespace, String name, StatefulSet current, StatefulSet desired) {
         StatefulSetDiff diff = new StatefulSetDiff(current, desired);
         if (diff.changesVolumeClaimTemplates()) {
-            log.warn("Changing storage type or size is not possible.");
-            revertStorageChanges(current, desired);
-            diff = new StatefulSetDiff(current, desired);
+            log.warn("Changing Zookeeper storage type or size is not possible. The changes will be ignored.");
+            diff = revertStorageChanges(current, desired);
         }
         if (diff.isEmpty()) {
             return Future.succeededFuture(ReconcileResult.noop());

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operator/resource/ZookeeperSetOperator.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operator/resource/ZookeeperSetOperator.java
@@ -32,8 +32,8 @@ public class ZookeeperSetOperator extends StatefulSetOperator<Boolean> {
     protected Future<ReconcileResult<Boolean>> internalPatch(String namespace, String name, StatefulSet current, StatefulSet desired) {
         StatefulSetDiff diff = new StatefulSetDiff(current, desired);
         if (diff.changesVolumeClaimTemplates()) {
-            log.warn("Ignoring change to volumeClaim");
-            desired.getSpec().setVolumeClaimTemplates(current.getSpec().getVolumeClaimTemplates());
+            log.warn("Changing storage type or size is not possible.");
+            revertStorageChanges(current, desired);
             diff = new StatefulSetDiff(current, desired);
         }
         if (diff.isEmpty()) {

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/operator/assembly/KafkaAssemblyOperatorMockIT.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/operator/assembly/KafkaAssemblyOperatorMockIT.java
@@ -559,8 +559,7 @@ public class KafkaAssemblyOperatorMockIT {
             data.put(KafkaCluster.KEY_STORAGE,
                     new JsonObject("{\"type\": \"persistent-claim\", " +
                             "\"size\": \"123\"}").toString());
-        }
-        else if ("persistent-claim".equals(kafkaStorage.getString("type"))) {
+        } else if ("persistent-claim".equals(kafkaStorage.getString("type"))) {
             data.put(KafkaCluster.KEY_STORAGE,
                     new JsonObject("{\"type\": \"ephemeral\"}").toString());
         }

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/operator/assembly/KafkaAssemblyOperatorMockIT.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/operator/assembly/KafkaAssemblyOperatorMockIT.java
@@ -8,6 +8,7 @@ import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaimBuilder;
+import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.extensions.StatefulSet;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.strimzi.controller.cluster.Reconciliation;
@@ -536,6 +537,62 @@ public class KafkaAssemblyOperatorMockIT {
         List<PersistentVolumeClaim> volumeClaimTemplates = statefulSet.getSpec().getVolumeClaimTemplates();
         context.assertFalse(volumeClaimTemplates.isEmpty());
         context.assertEquals(expectedClass, volumeClaimTemplates.get(0).getSpec().getStorageClassName());
+    }
+
+    @Test
+    public void testUpdateKafkaWithChangedStorageType(TestContext context) {
+        if (!Storage.StorageType.LOCAL.equals(storageType(kafkaStorage))) {
+            LOGGER.info("Skipping change storage type test because using storage type {}", kafkaStorage);
+            return;
+        }
+
+        KafkaAssemblyOperator kco = createCluster(context);
+        List<PersistentVolumeClaim> originalPVCs = mockClient.apps().statefulSets().inNamespace(NAMESPACE).withName(KafkaCluster.kafkaClusterName(CLUSTER_NAME)).get().getSpec().getVolumeClaimTemplates();
+        List<Volume> originalVolumes = mockClient.apps().statefulSets().inNamespace(NAMESPACE).withName(KafkaCluster.kafkaClusterName(CLUSTER_NAME)).get().getSpec().getTemplate().getSpec().getVolumes();
+
+        Async updateAsync = context.async();
+
+        // Try to update the storage type
+        HashMap<String, String> data = new HashMap<>(cluster.getData());
+
+        if ("ephemeral".equals(kafkaStorage.getString("type"))) {
+            data.put(KafkaCluster.KEY_STORAGE,
+                    new JsonObject("{\"type\": \"persistent-claim\", " +
+                            "\"size\": \"123\"}").toString());
+        }
+        else if ("persistent-claim".equals(kafkaStorage.getString("type"))) {
+            data.put(KafkaCluster.KEY_STORAGE,
+                    new JsonObject("{\"type\": \"ephemeral\"}").toString());
+        }
+
+        ConfigMap changedClusterCm = new ConfigMapBuilder(cluster).withData(data).build();
+        mockClient.configMaps().inNamespace(NAMESPACE).withName(CLUSTER_NAME).patch(changedClusterCm);
+
+        LOGGER.info("Updating with changed storage type");
+        kco.reconcileAssembly(new Reconciliation("test-trigger", AssemblyType.KAFKA, NAMESPACE, CLUSTER_NAME), ar -> {
+            if (ar.failed()) ar.cause().printStackTrace();
+            context.assertTrue(ar.succeeded());
+            // Check the Volumes and PVCs were not changed
+            assertPVCs(context, KafkaCluster.kafkaClusterName(CLUSTER_NAME), originalPVCs);
+            assertVolumes(context, KafkaCluster.kafkaClusterName(CLUSTER_NAME), originalVolumes);
+            updateAsync.complete();
+        });
+    }
+
+    private void assertPVCs(TestContext context, String statefulSetName, List<PersistentVolumeClaim> originalPVCs) {
+        StatefulSet statefulSet = mockClient.apps().statefulSets().inNamespace(NAMESPACE).withName(statefulSetName).get();
+        context.assertNotNull(statefulSet);
+        List<PersistentVolumeClaim> pvcs = statefulSet.getSpec().getVolumeClaimTemplates();
+        context.assertEquals(pvcs.size(), originalPVCs.size());
+        context.assertEquals(pvcs, originalPVCs);
+    }
+
+    private void assertVolumes(TestContext context, String statefulSetName, List<Volume> originalVolumes) {
+        StatefulSet statefulSet = mockClient.apps().statefulSets().inNamespace(NAMESPACE).withName(statefulSetName).get();
+        context.assertNotNull(statefulSet);
+        List<Volume> volumes = statefulSet.getSpec().getTemplate().getSpec().getVolumes();
+        context.assertEquals(volumes.size(), originalVolumes.size());
+        context.assertEquals(volumes, originalVolumes);
     }
 
     /** Test that we can change the deleteClaim flag, and that it's honoured */


### PR DESCRIPTION
### Type of change

- Bugfix
- ~~Enhancement / new feature~~
- ~~Refactoring~~

### Description

When changing between ephemeral and persistent storage of running cluster, it is not sufficient to just revert the PersistentVolumeClaim change. Also the Volumes list has to be patched. Otherwise a rolling update will still be triggered and the Cluster will get into strange state with two volumes using the same name (Volume and PVC).