### PR TITLE
Make sure changes to DeploymentConfig and BuildConfig are not trigger…

### DIFF
--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operator/resource/BuildConfigOperator.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operator/resource/BuildConfigOperator.java
@@ -11,13 +11,13 @@ import io.fabric8.openshift.api.model.BuildConfigList;
 import io.fabric8.openshift.api.model.DoneableBuildConfig;
 import io.fabric8.openshift.client.OpenShiftClient;
 import io.fabric8.openshift.client.dsl.BuildConfigResource;
+import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 
 /**
  * Operations for {@code BuildConfig}s.
  */
 public class BuildConfigOperator extends AbstractResourceOperator<OpenShiftClient, BuildConfig, BuildConfigList, DoneableBuildConfig, BuildConfigResource<BuildConfig, DoneableBuildConfig, Void, Build>, Void> {
-
     /**
      * Constructor
      * @param vertx The Vertx instance
@@ -30,5 +30,10 @@ public class BuildConfigOperator extends AbstractResourceOperator<OpenShiftClien
     @Override
     protected MixedOperation<BuildConfig, BuildConfigList, DoneableBuildConfig, BuildConfigResource<BuildConfig, DoneableBuildConfig, Void, Build>> operation() {
         return client.buildConfigs();
+    }
+
+    protected Future<ReconcileResult<Void>> internalPatch(String namespace, String name, BuildConfig current, BuildConfig desired) {
+        desired.getSpec().setTriggers(current.getSpec().getTriggers());
+        return super.internalPatch(namespace, name, current, desired);
     }
 }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operator/resource/DeploymentConfigOperator.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operator/resource/DeploymentConfigOperator.java
@@ -10,6 +10,7 @@ import io.fabric8.openshift.api.model.DeploymentConfigList;
 import io.fabric8.openshift.api.model.DoneableDeploymentConfig;
 import io.fabric8.openshift.client.OpenShiftClient;
 import io.fabric8.openshift.client.dsl.DeployableScalableResource;
+import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 
 /**
@@ -38,5 +39,10 @@ public class DeploymentConfigOperator extends AbstractScalableResourceOperator<O
         } else {
             return null;
         }
+    }
+
+    protected Future<ReconcileResult<Void>> internalPatch(String namespace, String name, DeploymentConfig current, DeploymentConfig desired) {
+        desired.getSpec().getTemplate().getSpec().getContainers().get(0).setImage(current.getSpec().getTemplate().getSpec().getContainers().get(0).getImage());
+        return super.internalPatch(namespace, name, current, desired);
     }
 }

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/operator/resource/AbstractResourceOperatorTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/operator/resource/AbstractResourceOperatorTest.java
@@ -96,6 +96,9 @@ public abstract class AbstractResourceOperatorTest<C extends KubernetesClient, T
         Async async = context.async();
         Future<ReconcileResult<P>> fut = op.createOrUpdate(resource);
         fut.setHandler(ar -> {
+            if (!ar.succeeded()) {
+                ar.cause().printStackTrace();
+            }
             assertTrue(ar.succeeded());
             verify(mockResource).get();
             verify(mockResource).patch(any());

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/operator/resource/BuildConfigOperatorTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/operator/resource/BuildConfigOperatorTest.java
@@ -9,6 +9,7 @@ import io.fabric8.openshift.api.model.Build;
 import io.fabric8.openshift.api.model.BuildConfig;
 import io.fabric8.openshift.api.model.BuildConfigBuilder;
 import io.fabric8.openshift.api.model.BuildConfigList;
+import io.fabric8.openshift.api.model.BuildTriggerPolicy;
 import io.fabric8.openshift.api.model.DoneableBuildConfig;
 import io.fabric8.openshift.client.OpenShiftClient;
 import io.fabric8.openshift.client.dsl.BuildConfigResource;
@@ -41,6 +42,12 @@ public class BuildConfigOperatorTest extends AbstractResourceOperatorTest<OpenSh
 
     @Override
     protected BuildConfig resource() {
-        return new BuildConfigBuilder().withNewMetadata().withNamespace(NAMESPACE).withName(RESOURCE_NAME).endMetadata().build();
+        return new BuildConfigBuilder().withNewMetadata()
+                .withNamespace(NAMESPACE)
+                .withName(RESOURCE_NAME)
+            .endMetadata()
+            .withNewSpec()
+                .withTriggers(new BuildTriggerPolicy())
+            .endSpec().build();
     }
 }

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/operator/resource/DeploymentConfigOperatorTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/operator/resource/DeploymentConfigOperatorTest.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.controller.cluster.operator.resource;
 
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.ScalableResource;
 import io.fabric8.openshift.api.model.DeploymentConfig;
@@ -32,7 +33,17 @@ public class DeploymentConfigOperatorTest extends ScalableResourceOperatorTest<O
 
     @Override
     protected DeploymentConfig resource() {
-        return new DeploymentConfigBuilder().withNewMetadata().withNamespace(NAMESPACE).withName(RESOURCE_NAME).endMetadata().build();
+        return new DeploymentConfigBuilder().withNewMetadata()
+                .withNamespace(NAMESPACE)
+                .withName(RESOURCE_NAME)
+            .endMetadata()
+            .withNewSpec()
+                .withNewTemplate()
+                    .withNewSpec()
+                        .addToContainers(new ContainerBuilder().withImage("img").build())
+                    .endSpec()
+                .endTemplate()
+            .endSpec().build();
     }
 
     @Override


### PR DESCRIPTION
…ing constant rolling updates to KAfka Connect S2I deployment

### Type of change

- Bugfix
- ~~Enhancement / new feature~~
- ~~Refactoring~~

### Description

After #346 we are not patching the resources anymore when updating them. That seems to be wrong - at least for the `BuildConfig` and `DeploymentConfig` resources used by Kafka Connect S2I deployment. Since we always overwrite the complete object, we delete the changes which were done by the S2I system. As a result, the Kafka Connect S2I deployment is constantly updating in a loop - CC updates it to wrong state, OpenShift fixes that back to normal etc.

This PR includes a hack which will block this by reusing some values from the current state. However, this seems more like hack to get 0.3.0 out. The proper solutions should be probably in properly patching the objects in the Model.

