### PR TITLE
Kafka consumer and producer integration

### DIFF
--- a/common-test/src/main/java/io/strimzi/test/TestUtils.java
+++ b/common-test/src/main/java/io/strimzi/test/TestUtils.java
@@ -4,12 +4,17 @@
  */
 package io.strimzi.test;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
 
 public final class TestUtils {
 
@@ -73,5 +78,16 @@ public final class TestUtils {
             sb.append("    ").append(line).append(System.lineSeparator());
         }
         return sb.toString();
+    }
+
+    public static String getContent(File file, Consumer<JsonNode> edit) {
+        YAMLMapper mapper = new YAMLMapper();
+        try {
+            JsonNode node = mapper.readTree(file);
+            edit.accept(node);
+            return mapper.writeValueAsString(node);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/common-test/src/main/java/io/strimzi/test/Topic.java
+++ b/common-test/src/main/java/io/strimzi/test/Topic.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.test;
+
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.annotation.Repeatable;
+
+/**
+ * Annotation for test classes or methods run via {@code @RunWith(StrimziRunner.class)}
+ * which causes that runner to create kafka clusters before, and delete kafka clusters after,
+ * the tests.
+ */
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Repeatable(Topic.Container.class)
+public @interface Topic {
+
+    String name();
+    String clusterName();
+    int partitions() default 1;
+    int replicas() default 1;
+
+    @Target({ElementType.METHOD, ElementType.TYPE})
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface Container {
+        Topic[] value();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
         <zookeeper.version>3.4.10</zookeeper.version>
         <mockito.version>2.12.0</mockito.version>
         <jsonpath.version>2.4.0</jsonpath.version>
+        <commons-collections.version>3.2.2</commons-collections.version>
     </properties>
 
     <modules>
@@ -176,6 +177,11 @@
                 <artifactId>json-path</artifactId>
                 <version>${jsonpath.version}</version>
                 <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>commons-collections</groupId>
+                <artifactId>commons-collections</artifactId>
+                <version>${commons-collections.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -58,6 +58,10 @@
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
         </dependency>
+        <dependency>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
+        </dependency>
     </dependencies>
 
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterTest.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterTest.java
@@ -8,13 +8,15 @@ import io.fabric8.kubernetes.api.model.Event;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.strimzi.test.ClusterController;
-import io.strimzi.test.CmData;
-import io.strimzi.test.KafkaCluster;
 import io.strimzi.test.Namespace;
-import io.strimzi.test.OpenShiftOnly;
 import io.strimzi.test.Resources;
+import io.strimzi.test.OpenShiftOnly;
+import io.strimzi.test.KafkaCluster;
+import io.strimzi.test.CmData;
+import io.strimzi.test.Topic;
 import io.strimzi.test.StrimziRunner;
 import io.strimzi.test.k8s.Oc;
+import org.apache.commons.collections.CollectionUtils;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -305,5 +307,23 @@ public class KafkaClusterTest extends AbstractClusterTest {
             String initialDelaySecondsPath = "$.spec.containers[*].livenessProbe.initialDelaySeconds";
             assertEquals("23", getValueFromJson(zkPodJson, initialDelaySecondsPath));
         }
+    }
+
+    @Test
+    @KafkaCluster(name = "my-cluster", kafkaNodes = 3, config = {
+            @CmData(key = "KAFKA_DEFAULT_REPLICATION_FACTOR", value = "1")})
+    @Topic(name = "test-topic", clusterName = "my-cluster")
+    public void testSendMessages() {
+        String topicName = "test-topic";
+        String clusterName = "my-cluster";
+        int messagesCount = 5;
+        List<String> messagesToSend = new ArrayList<>();
+        for (int i = 0; i < messagesCount; i++) {
+            messagesToSend.add("Test message " + i);
+        }
+        sendMessages(messagesToSend, clusterName, topicName);
+        List<String> consumedMessages = consumeMessages(clusterName, topicName);
+        LOGGER.info("Comparing lists of sent and received messages");
+        assertTrue(CollectionUtils.isEqualCollection(messagesToSend, consumedMessages));
     }
 }


### PR DESCRIPTION
### Type of change
- Framework extension
- New test added

### Description
Added Kafka consumer and producer to the framework and created test for verification that messages go thru OpenShift cluster
The test starts cluster and sends 5 messages to the cluster and then tries to consume all messages also we verify that produced and consumed messages are equal.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging

