### PR TITLE
Minor build improvements

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -7,7 +7,6 @@ export TAG=${TAG:-latest}
 export DOCKER_ORG=${DOCKER_ORG:-strimzici}
 export DOCKER_REGISTRY=${DOCKER_REGISTRY:-docker.io}
 export DOCKER_TAG=$COMMIT
-export DOCKER_VERSION_ARG=${COMMIT:-latest}
 
 make docker_build
 

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,6 @@ release_version:
 	find ./examples -name '*.yaml' -type f -exec sed -i '/image: "\?strimzi\/[a-zA-Z0-9_-.]\+:[a-zA-Z0-9_-.]\+"\?/s/:[a-zA-Z0-9_-.]\+/:$(RELEASE_VERSION)/g' {} \;
 	find ./examples -name '*.yaml' -type f -exec sed -i '/name: [a-zA-Z0-9_-]*IMAGE_TAG/{n;s/value: [a-zA-Z0-9_-.]\+/value: $(RELEASE_VERSION)/}' {} \;
 	find ./examples -name '*.yaml' -type f -exec sed -i '/name: STRIMZI_DEFAULT_[a-zA-Z0-9_-]*IMAGE/{n;s/:[a-zA-Z0-9_-.]\+/:$(RELEASE_VERSION)/}' {} \;
-	echo "Changing documentation version to $(RELEASE_VERSION)"
-	find ./documentation/adoc/ -name '*.adoc' -type f -exec sed -i '/:revnumber: [a-zA-Z0-9_-.]\+/s/:revnumber: [a-zA-Z0-9_-.]\+/:revnumber: $(RELEASE_VERSION)/' {} \;
 
 release_maven:
 	echo "Update pom versions to $(RELEASE_VERSION)"
@@ -33,12 +31,12 @@ release_pkg:
 
 docu_html: docu_htmlclean
 	mkdir -p documentation/html
-	asciidoctor documentation/adoc/docu.adoc -o documentation/html/master.html
+	asciidoctor -a revnumber=$(RELEASE_VERSION) documentation/adoc/docu.adoc -o documentation/html/master.html
 	cp -vr documentation/adoc/images documentation/html/images
 
 docu_htmlnoheader: docu_htmlnoheaderclean
 	mkdir -p documentation/htmlnoheader
-	asciidoctor -s documentation/adoc/docu.adoc -o documentation/htmlnoheader/master.html
+	asciidoctor -a revnumber=$(RELEASE_VERSION) -s documentation/adoc/docu.adoc -o documentation/htmlnoheader/master.html
 
 docu_pushtowebsite: docu_htmlnoheader
 	./.travis/docu-push-to-website.sh

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -4,20 +4,18 @@
 #
 # The DOCKER_ORG (default is name of the current user) and DOCKER_TAG (based on Git Tag,
 # default latest) variables are used to name the Docker image. DOCKER_REGISTRY identifies
-# the registry where the image will be pushed (default is Docker Hub). DOCKER_VERSION_ARG
-# is passed to the image build (based on Git commit, default latest)
+# the registry where the image will be pushed (default is Docker Hub).
 
 DOCKERFILE_DIR     ?= ./
 DOCKER_REGISTRY    ?= docker.io
 DOCKER_ORG         ?= $(USER)
 DOCKER_TAG         ?= latest
-DOCKER_VERSION_ARG ?= latest
 
 all: docker_build docker_push
 
 docker_build:
 	# Build Docker image ...
-	docker build --build-arg version=$(DOCKER_VERSION_ARG) -t strimzi/$(PROJECT_NAME):latest $(DOCKERFILE_DIR)
+	docker build -t strimzi/$(PROJECT_NAME):latest $(DOCKERFILE_DIR)
 
 docker_tag:
 	# Tag the "latest" image we built with the given tag

--- a/Makefile.maven
+++ b/Makefile.maven
@@ -5,11 +5,7 @@
 
 java_build:
 	echo "Building JAR file ..."
-ifndef CI
-	mvn ${MVN_ARGS} package
-else
 	mvn ${MVN_ARGS} verify
-endif
 
 java_clean:
 	echo "Cleaning Maven build ..."

--- a/Makefile.maven
+++ b/Makefile.maven
@@ -6,9 +6,9 @@
 java_build:
 	echo "Building JAR file ..."
 ifndef CI
-	mvn package
+	mvn ${MVN_ARGS} package
 else
-	mvn verify
+	mvn ${MVN_ARGS} verify
 endif
 
 java_clean:

--- a/cluster-controller/Dockerfile
+++ b/cluster-controller/Dockerfile
@@ -1,7 +1,5 @@
 FROM strimzi/java-base:8-3
 
-ARG version=latest
-ENV VERSION ${version}
 ADD target/cluster-controller.jar /
 
 CMD ["/bin/launch_java.sh", "/cluster-controller.jar"]

--- a/docker-images/kafka-base/Dockerfile
+++ b/docker-images/kafka-base/Dockerfile
@@ -17,10 +17,6 @@ ENV JMX_EXPORTER_VERSION=0.1.0
 ENV KAFKA_CHECKSUM="935c0df1cf742405c40d9248cfdd1578038b595b59ec5a350543a7fe67b6be26ff6c4426f7c0c072ff4aa006b701502a55fcf7e2ced1fdc64330e3383035078c  kafka_2.12-1.0.1.tgz"
 ENV JMX_EXPORTER_CHECKSUM="6ab370edccc2eeb3985f4c95769c26c090d0e052 jmx_prometheus_javaagent-0.1.0.jar"
 
-# Set from build args
-ARG version=latest
-ENV VERSION ${version}
-
 # Downloading/extracting Apache Kafka
 RUN curl -O https://www.apache.org/dist/kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz \
     && echo $KAFKA_CHECKSUM > kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz.sha512 \

--- a/topic-controller/Dockerfile
+++ b/topic-controller/Dockerfile
@@ -1,7 +1,5 @@
 FROM strimzi/java-base:8-3
 
-ARG version=latest
-ENV VERSION ${version}
 ADD target/topic-controller.jar /
 
 CMD ["/bin/launch_java.sh", "/topic-controller.jar"]


### PR DESCRIPTION
### Type of change

- Build improvement

### Description

* Remove the unused VERSION from the docker images and the build.
* Allow the specify a fixed minikube and kubectl version in the .travis.yml, or `latest`.
* Used fixed versions currently because minikube latest is broken.
* Allow a MVN_ARGS env var, because sometimes when testing the build its useful to pass things like `-DskipTests`

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging

