### PR TITLE
Pulling event appears always only with latest

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterTest.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterTest.java
@@ -32,7 +32,6 @@ import static io.strimzi.systemtest.k8s.Events.FailedSync;
 import static io.strimzi.systemtest.k8s.Events.FailedValidation;
 import static io.strimzi.systemtest.k8s.Events.Killing;
 import static io.strimzi.systemtest.k8s.Events.Pulled;
-import static io.strimzi.systemtest.k8s.Events.Pulling;
 import static io.strimzi.systemtest.k8s.Events.Scheduled;
 import static io.strimzi.systemtest.k8s.Events.Started;
 import static io.strimzi.systemtest.k8s.Events.SuccessfulDelete;

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterTest.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterTest.java
@@ -106,7 +106,7 @@ public class KafkaClusterTest extends AbstractClusterTest {
 
         //Test that the new pod does not have errors or failures in events
         List<Event> events = getEvents("Pod", newPodName);
-        assertThat(events, hasAllOfReasons(Scheduled, Pulling, Pulled, Created, Started));
+        assertThat(events, hasAllOfReasons(Scheduled, Pulled, Created, Started));
         assertThat(events, hasNoneOfReasons(Failed, Unhealthy, FailedSync, FailedValidation));
 
         // TODO Check logs for errors
@@ -163,12 +163,12 @@ public class KafkaClusterTest extends AbstractClusterTest {
         // TODO Check logs for errors
         //Test that first pod does not have errors or failures in events
         List<Event> eventsForFirstPod = getEvents("Pod", newPodName[0]);
-        assertThat(eventsForFirstPod, hasAllOfReasons(Scheduled, Pulling, Pulled, Created, Started));
+        assertThat(eventsForFirstPod, hasAllOfReasons(Scheduled, Pulled, Created, Started));
         assertThat(eventsForFirstPod, hasNoneOfReasons(Failed, Unhealthy, FailedSync, FailedValidation));
 
         //Test that second pod does not have errors or failures in events
         List<Event> eventsForSecondPod = getEvents("Pod", newPodName[1]);
-        assertThat(eventsForSecondPod, hasAllOfReasons(Scheduled, Pulling, Pulled, Created, Started));
+        assertThat(eventsForSecondPod, hasAllOfReasons(Scheduled, Pulled, Created, Started));
         assertThat(eventsForSecondPod, hasNoneOfReasons(Failed, Unhealthy, FailedSync, FailedValidation));
 
         // scale down


### PR DESCRIPTION
### Type of change

- Bugfix
- ~~Enhancement / new feature~~
- ~~Refactoring~~

### Description

The tests are testing the presence of the Pulling event. However this event isn't guaranteed to appear. Since until now the system tests were always run using `:latest` images, this didn't show up because the latest images are always pulled. But when you try to run the actual tests using the correct image, this starts failing since the images for example with tag `:my-bransh` will be `Pulling` only once. Afterwards it is already in the cluster and will never get into the `Pulling` state - it will jump into `Pulled` directly. This PR removes `Pulling` from the list of required events.

