### PR TITLE
Add init container fields to ignored paths in StatefulSet diff

### DIFF
--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operator/resource/StatefulSetDiff.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operator/resource/StatefulSetDiff.java
@@ -27,6 +27,10 @@ public class StatefulSetDiff {
     static {
         IGNORABLE_PATHS = asList(
             "/spec/revisionHistoryLimit",
+            "/spec/template/spec/initContainers/0/imagePullPolicy",
+            "/spec/template/spec/initContainers/0/resources",
+            "/spec/template/spec/initContainers/0/terminationMessagePath",
+            "/spec/template/spec/initContainers/0/terminationMessagePolicy",
             "/spec/template/spec/containers/0/imagePullPolicy",
             "/spec/template/spec/containers/0/livenessProbe/failureThreshold",
             "/spec/template/spec/containers/0/livenessProbe/periodSeconds",


### PR DESCRIPTION
### Type of change

- Bugfix
- ~~Enhancement / new feature~~
- ~~Refactoring~~

### Description

Persistent Kafka / Zookeeper on Kubernetes use init container to set permissions. Some fields of the init container are changing the triggering permanent rolling update. This PR adds these fields to the ignore list:

```
/spec/template/spec/initContainers/0/imagePullPolicy
/spec/template/spec/initContainers/0/resources
/spec/template/spec/initContainers/0/terminationMessagePath
/spec/template/spec/initContainers/0/terminationMessagePolicy
```