### PR TITLE
Revert some more changes when storage type change is attempted

### DIFF
--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operator/resource/KafkaSetOperator.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operator/resource/KafkaSetOperator.java
@@ -31,7 +31,7 @@ public class KafkaSetOperator extends StatefulSetOperator<Boolean> {
     @Override
     protected Future<ReconcileResult<Boolean>> internalPatch(String namespace, String name, StatefulSet current, StatefulSet desired) {
         StatefulSetDiff diff = new StatefulSetDiff(current, desired);
-        if (diff.changesVolumeClaimTemplates()) {
+        if (diff.changesVolumeClaimTemplates() || diff.changesSpecTemplateSpecInitContainers()) {
             log.warn("Changing Kafka storage type or size is not possible. The changes will be ignored.");
             diff = revertStorageChanges(current, desired);
         }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operator/resource/StatefulSetDiff.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operator/resource/StatefulSetDiff.java
@@ -64,6 +64,7 @@ public class StatefulSetDiff {
     private final boolean changesVolumeClaimTemplate;
     private final boolean isEmpty;
     private final boolean changesSpecTemplateSpec;
+    private final boolean changesSpecTemplateSpecInitContainers;
     private final boolean changesLabels;
     private final boolean changesSpecReplicas;
 
@@ -86,6 +87,7 @@ public class StatefulSetDiff {
         // Change changes to /spec/template/spec, except to imagePullPolicy, which gets changed
         // by k8s
         changesSpecTemplateSpec = containsPathOrChild(paths, "/spec/template/spec");
+        changesSpecTemplateSpecInitContainers = containsPathOrChild(paths, "/spec/template/spec/initContainers");
         changesLabels = containsPathOrChild(paths, "/metadata/labels");
         changesSpecReplicas = containsPathOrChild(paths, "/spec/replicas");
     }
@@ -100,6 +102,10 @@ public class StatefulSetDiff {
 
     public boolean changesSpecTemplateSpec() {
         return changesSpecTemplateSpec;
+    }
+
+    public boolean changesSpecTemplateSpecInitContainers() {
+        return changesSpecTemplateSpecInitContainers;
     }
 
     public boolean changesLabels() {

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operator/resource/StatefulSetOperator.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operator/resource/StatefulSetOperator.java
@@ -265,6 +265,7 @@ public class StatefulSetOperator<P> extends AbstractScalableResourceOperator<Kub
     protected StatefulSetDiff revertStorageChanges(StatefulSet current, StatefulSet desired) {
         desired.getSpec().setVolumeClaimTemplates(current.getSpec().getVolumeClaimTemplates());
         desired.getSpec().getTemplate().getSpec().setInitContainers(current.getSpec().getTemplate().getSpec().getInitContainers());
+        desired.getSpec().getTemplate().getSpec().setSecurityContext(current.getSpec().getTemplate().getSpec().getSecurityContext());
 
         if (current.getSpec().getVolumeClaimTemplates().isEmpty()) {
             // We are on ephemeral storage and changing to persistent

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operator/resource/StatefulSetOperator.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operator/resource/StatefulSetOperator.java
@@ -264,6 +264,7 @@ public class StatefulSetOperator<P> extends AbstractScalableResourceOperator<Kub
      */
     protected StatefulSetDiff revertStorageChanges(StatefulSet current, StatefulSet desired) {
         desired.getSpec().setVolumeClaimTemplates(current.getSpec().getVolumeClaimTemplates());
+        desired.getSpec().getTemplate().getSpec().setInitContainers(current.getSpec().getTemplate().getSpec().getInitContainers());
 
         if (current.getSpec().getVolumeClaimTemplates().isEmpty()) {
             // We are on ephemeral storage and changing to persistent

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operator/resource/ZookeeperSetOperator.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operator/resource/ZookeeperSetOperator.java
@@ -31,7 +31,7 @@ public class ZookeeperSetOperator extends StatefulSetOperator<Boolean> {
     @Override
     protected Future<ReconcileResult<Boolean>> internalPatch(String namespace, String name, StatefulSet current, StatefulSet desired) {
         StatefulSetDiff diff = new StatefulSetDiff(current, desired);
-        if (diff.changesVolumeClaimTemplates()) {
+        if (diff.changesVolumeClaimTemplates() || diff.changesSpecTemplateSpecInitContainers()) {
             log.warn("Changing Zookeeper storage type or size is not possible. The changes will be ignored.");
             diff = revertStorageChanges(current, desired);
         }

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/operator/resource/StatefulSetDiffTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/operator/resource/StatefulSetDiffTest.java
@@ -5,15 +5,18 @@
 package io.strimzi.controller.cluster.operator.resource;
 
 import io.fabric8.kubernetes.api.model.ConfigMapVolumeSourceBuilder;
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.VolumeBuilder;
 import io.fabric8.kubernetes.api.model.extensions.StatefulSet;
 import io.fabric8.kubernetes.api.model.extensions.StatefulSetBuilder;
 import org.junit.Test;
 
+import java.util.Collections;
+
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class StatefulSetDiffTest {
-
     @Test
     public void testSpecVolumesIgnored() {
         StatefulSet ss1 = new StatefulSetBuilder()
@@ -47,5 +50,50 @@ public class StatefulSetDiffTest {
             .endSpec()
             .build();
         assertFalse(new StatefulSetDiff(ss1, ss2).changesSpecTemplateSpec());
+    }
+
+    @Test
+    public void testInitContainersDiff() {
+        StatefulSet ss1 = new StatefulSetBuilder()
+                .withNewMetadata()
+                .withNamespace("test")
+                .withName("foo")
+                .endMetadata()
+                .withNewSpec().
+                    withNewTemplate()
+                        .withNewSpec()
+                            .withInitContainers(new ContainerBuilder().withName("init1").withImage("image1").build())
+                        .endSpec()
+                    .endTemplate()
+                .endSpec()
+                .build();
+        StatefulSet ss2 = new StatefulSetBuilder()
+                .withNewMetadata()
+                .withNamespace("test")
+                .withName("foo")
+                .endMetadata()
+                .withNewSpec()
+                    .withNewTemplate()
+                        .withNewSpec()
+                            .withInitContainers(new ContainerBuilder().withName("init2").withImage("image2").build())
+                        .endSpec()
+                    .endTemplate()
+                .endSpec()
+                .build();
+        StatefulSet ss3 = new StatefulSetBuilder()
+                .withNewMetadata()
+                .withNamespace("test")
+                .withName("foo")
+                .endMetadata()
+                .withNewSpec()
+                    .withNewTemplate()
+                        .withNewSpec()
+                            .withInitContainers(Collections.emptyList())
+                        .endSpec()
+                    .endTemplate()
+                .endSpec()
+                .build();
+        assertTrue(new StatefulSetDiff(ss1, ss2).changesSpecTemplateSpecInitContainers());
+        assertTrue(new StatefulSetDiff(ss1, ss3).changesSpecTemplateSpecInitContainers());
     }
 }


### PR DESCRIPTION
### Type of change

- Bugfix
- ~~Enhancement / new feature~~
- ~~Refactoring~~

### Description

When storage type change is tried for a running cluster, we should revert also the SecurityContext and the Init containers. In the past we reverted only the volumes.