### PR TITLE
Use consistent timeout for operations, fixes #374

### DIFF
--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/Main.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/Main.java
@@ -57,8 +57,8 @@ public class Main {
 
     static CompositeFuture run(Vertx vertx, KubernetesClient client, boolean isOpenShift, ClusterControllerConfig config) {
         ServiceOperator serviceOperations = new ServiceOperator(vertx, client);
-        ZookeeperSetOperator zookeeperSetOperations = new ZookeeperSetOperator(vertx, client);
-        KafkaSetOperator kafkaSetOperations = new KafkaSetOperator(vertx, client);
+        ZookeeperSetOperator zookeeperSetOperations = new ZookeeperSetOperator(vertx, client, config.getOperationTimeoutMs());
+        KafkaSetOperator kafkaSetOperations = new KafkaSetOperator(vertx, client, config.getOperationTimeoutMs());
         ConfigMapOperator configMapOperations = new ConfigMapOperator(vertx, client);
         PvcOperator pvcOperations = new PvcOperator(vertx, client);
         DeploymentOperator deploymentOperations = new DeploymentOperator(vertx, client);

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operator/resource/KafkaSetOperator.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operator/resource/KafkaSetOperator.java
@@ -24,8 +24,8 @@ public class KafkaSetOperator extends StatefulSetOperator<Boolean> {
      * @param vertx  The Vertx instance
      * @param client The Kubernetes client
      */
-    public KafkaSetOperator(Vertx vertx, KubernetesClient client) {
-        super(vertx, client);
+    public KafkaSetOperator(Vertx vertx, KubernetesClient client, long operationTimeoutMs) {
+        super(vertx, client, operationTimeoutMs);
     }
 
     @Override

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operator/resource/ZookeeperSetOperator.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operator/resource/ZookeeperSetOperator.java
@@ -24,8 +24,8 @@ public class ZookeeperSetOperator extends StatefulSetOperator<Boolean> {
      * @param vertx  The Vertx instance
      * @param client The Kubernetes client
      */
-    public ZookeeperSetOperator(Vertx vertx, KubernetesClient client) {
-        super(vertx, client);
+    public ZookeeperSetOperator(Vertx vertx, KubernetesClient client, long operationTimeoutMs) {
+        super(vertx, client, operationTimeoutMs);
     }
 
     @Override

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/operator/assembly/KafkaAssemblyOperatorMockIT.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/operator/assembly/KafkaAssemblyOperatorMockIT.java
@@ -192,8 +192,8 @@ public class KafkaAssemblyOperatorMockIT {
     private KafkaAssemblyOperator createCluster(TestContext context) {
         ConfigMapOperator cmops = new ConfigMapOperator(vertx, mockClient);
         ServiceOperator svcops = new ServiceOperator(vertx, mockClient);
-        KafkaSetOperator ksops = new KafkaSetOperator(vertx, mockClient);
-        ZookeeperSetOperator zksops = new ZookeeperSetOperator(vertx, mockClient);
+        KafkaSetOperator ksops = new KafkaSetOperator(vertx, mockClient, 60_000L);
+        ZookeeperSetOperator zksops = new ZookeeperSetOperator(vertx, mockClient, 60_000L);
         DeploymentOperator depops = new DeploymentOperator(vertx, mockClient);
         PvcOperator pvcops = new PvcOperator(vertx, mockClient);
         KafkaAssemblyOperator kco = new KafkaAssemblyOperator(vertx, true, 2_000,

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/operator/resource/StatefulSetOperatorTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/operator/resource/StatefulSetOperatorTest.java
@@ -58,7 +58,7 @@ public class StatefulSetOperatorTest<P>
 
     @Override
     protected StatefulSetOperator createResourceOperations(Vertx vertx, KubernetesClient mockClient) {
-        return new StatefulSetOperator(vertx, mockClient) {
+        return new StatefulSetOperator(vertx, mockClient, 60_000L) {
             @Override
             public Future<Void> readiness(String namespace, String name, long pollIntervalMs, long timeoutMs) {
                 return Future.succeededFuture();


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Fixes #374 using the `STRIMZI_OPERATION_TIMEOUT_MS` for the timeout in the StatefulSetOperator. No other hard-coded timeouts were found in the cluster controller.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging

