### PR TITLE
Always build the images using the :latest tag, to match FROM

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -15,7 +15,6 @@ echo "Login into Docker Hub ..."
 docker login -u $DOCKER_USER -p $DOCKER_PASS
 
 export DOCKER_TAG=$BRANCH
-export DOCKER_BUILD_TAG=$COMMIT
 echo "Pushing to docker org $DOCKER_ORG under tag $DOCKER_TAG"
 make docker_push
 

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -11,19 +11,18 @@ DOCKERFILE_DIR     ?= ./
 DOCKER_REGISTRY    ?= docker.io
 DOCKER_ORG         ?= $(USER)
 DOCKER_TAG         ?= latest
-DOCKER_BUILD_TAG   ?= $(DOCKER_TAG)
 DOCKER_VERSION_ARG ?= latest
 
 all: docker_build docker_push
 
 docker_build:
-	echo "Building Docker image ..."
-	docker build --build-arg version=$(DOCKER_VERSION_ARG) -t strimzi/$(PROJECT_NAME):$(DOCKER_TAG) $(DOCKERFILE_DIR)
+	# Build Docker image ...
+	docker build --build-arg version=$(DOCKER_VERSION_ARG) -t strimzi/$(PROJECT_NAME):latest $(DOCKERFILE_DIR)
 
 docker_tag:
-	echo "Tagging strimzi/$(PROJECT_NAME):$(DOCKER_BUILD_TAG) to $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG) ..."
-	docker tag strimzi/$(PROJECT_NAME):$(DOCKER_BUILD_TAG) $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)
+	# Tag the "latest" image we built with the given tag
+	docker tag strimzi/$(PROJECT_NAME):latest $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)
 
 docker_push: docker_tag
-	echo "Pushing $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG) ..."
+	# Push the tagged image to the registry
 	docker push $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix: Fixes #375

### Description

The FROM line in the Dockerfiles cannot be parameterized, so
(absent templating the Dockerfiles – yuk) we have to use the same fixed
tag when building the images. But that's OK, because we the tag and push
with the given tags.

I considered using some tag other than `latest` (`latest` is kind-of meaningless, but confuses people who don't know that) and would be happy to change to something else if we agree to avoid using latest.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging

