### PR TITLE
Removed JMX port 9404 already exposed by the base image

### DIFF
--- a/docker-images/kafka-base/Dockerfile
+++ b/docker-images/kafka-base/Dockerfile
@@ -38,7 +38,4 @@ RUN curl -O https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_java
     && mv jmx_prometheus_javaagent-${JMX_EXPORTER_VERSION}.jar /opt/prometheus/jmx_prometheus_javaagent.jar \
     && rm -rf jmx_prometheus_javaagent-${JMX_EXPORTER_VERSION}.*
 
-# exposed port for the JMX exporter
-EXPOSE 9404
-
 WORKDIR $KAFKA_HOME

--- a/docker-images/kafka/Dockerfile
+++ b/docker-images/kafka/Dockerfile
@@ -1,6 +1,7 @@
 FROM strimzi/kafka-base:latest
 
-EXPOSE 9091 9092
+# exposing Kafka ports and the one for JMX exporter
+EXPOSE 9091 9092 9404
 
 # copy configuration files
 COPY ./config/ $KAFKA_HOME/config/

--- a/docker-images/zookeeper/Dockerfile
+++ b/docker-images/zookeeper/Dockerfile
@@ -1,6 +1,7 @@
 FROM strimzi/kafka-base:latest
 
-EXPOSE 2181 2888 3888
+# exposing Zookeeper ports and the one for JMX exporter
+EXPOSE 2181 2888 3888 9404
 
 # copy configuration files
 COPY ./config/ $KAFKA_HOME/config/

--- a/docker-images/zookeeper/Dockerfile
+++ b/docker-images/zookeeper/Dockerfile
@@ -1,6 +1,6 @@
 FROM strimzi/kafka-base:latest
 
-EXPOSE 2181 2888 3888 9404
+EXPOSE 2181 2888 3888
 
 # copy configuration files
 COPY ./config/ $KAFKA_HOME/config/


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

Remove the JMX port 9404 from Zookeeper Dockerfile because already exposed by the base image. It's not really a bugfix but a really trivial change just to be polite.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging

