### PR TITLE
Limit request

### DIFF
--- a/.checkstyle/checkstyle.xml
+++ b/.checkstyle/checkstyle.xml
@@ -102,6 +102,13 @@
         <module name="ClassFanOutComplexity">
             <!-- default is 20 -->
             <property name="max" value="40"/>
+            <property name="excludedClasses" value="IllegalStateException, Set, StringBuilder, HashMap, ArrayList,
+            String, float, SortedSet, long, RuntimeException, NullPointerException, TreeSet, List, Boolean, Void,
+            Queue, Short, IllegalArgumentException, UnsupportedOperationException, HashSet, void, Character,
+            IndexOutOfBoundsException, byte, double, SecurityException, TreeMap, Double, Deque, int, Exception,
+            LinkedList, Integer, Float, StringBuffer, boolean, Byte, SortedMap, char, Long, short, Throwable,
+            Object, Class, ArrayIndexOutOfBoundsException, Map,
+            Logger, LoggerFactory"/>
         </module>
         <module name="CyclomaticComplexity">
             <!-- default is 10-->

--- a/.checkstyle/checkstyle.xml
+++ b/.checkstyle/checkstyle.xml
@@ -101,14 +101,7 @@
 
         <module name="ClassFanOutComplexity">
             <!-- default is 20 -->
-            <property name="max" value="40"/>
-            <property name="excludedClasses" value="IllegalStateException, Set, StringBuilder, HashMap, ArrayList,
-            String, float, SortedSet, long, RuntimeException, NullPointerException, TreeSet, List, Boolean, Void,
-            Queue, Short, IllegalArgumentException, UnsupportedOperationException, HashSet, void, Character,
-            IndexOutOfBoundsException, byte, double, SecurityException, TreeMap, Double, Deque, int, Exception,
-            LinkedList, Integer, Float, StringBuffer, boolean, Byte, SortedMap, char, Long, short, Throwable,
-            Object, Class, ArrayIndexOutOfBoundsException, Map,
-            Logger, LoggerFactory"/>
+            <property name="max" value="45"/>
         </module>
         <module name="CyclomaticComplexity">
             <!-- default is 10-->

--- a/cluster-controller/pom.xml
+++ b/cluster-controller/pom.xml
@@ -27,6 +27,14 @@
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterController.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/ClusterController.java
@@ -156,7 +156,7 @@ public class ClusterController extends AbstractVerticle {
                                     if (result.succeeded()) {
                                         log.info("{}: assembly reconciled", reconciliation);
                                     } else {
-                                        log.error("{}: Failed to reconcile", reconciliation);
+                                        log.error("{}: Failed to reconcile", reconciliation, result.cause());
                                     }
                                 });
                                 break;

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/JsonUtils.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/JsonUtils.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.controller.cluster.model;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+
+import java.io.IOException;
+
+class JsonUtils {
+    static <T> T fromJson(String json, Class<T> c) {
+        if (json == null) {
+            return null;
+        }
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            return mapper.readValue(json, c);
+        } catch (InvalidFormatException e) {
+            throw new IllegalArgumentException(e);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static String toJson(Object o) {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.enable(SerializationFeature.INDENT_OUTPUT);
+        try {
+            return mapper.writeValueAsString(o);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/JsonUtils.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/JsonUtils.java
@@ -4,9 +4,7 @@
  */
 package io.strimzi.controller.cluster.model;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 
 import java.io.IOException;
@@ -26,13 +24,4 @@ class JsonUtils {
         }
     }
 
-    static String toJson(Object o) {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.enable(SerializationFeature.INDENT_OUTPUT);
-        try {
-            return mapper.writeValueAsString(o);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
-    }
 }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/JvmOptions.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/JvmOptions.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.controller.cluster.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class JvmOptions {
+
+    private String xmx;
+    private String xms;
+
+    @JsonProperty("-Xmx")
+    public String getXmx() {
+        return xmx;
+    }
+
+    public void setXmx(String xmx) {
+        this.xmx = xmx;
+    }
+
+    @JsonProperty("-Xms")
+    public String getXms() {
+        return xms;
+    }
+
+    public void setXms(String xms) {
+        this.xms = xms;
+    }
+
+    public static JvmOptions fromJson(String json) {
+        return JsonUtils.fromJson(json, JvmOptions.class);
+    }
+}
+

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/KafkaCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/KafkaCluster.java
@@ -62,7 +62,12 @@ public class KafkaCluster extends AbstractModel {
     // Kafka configuration keys (EnvVariables)
     public static final String KEY_KAFKA_ZOOKEEPER_CONNECT = "KAFKA_ZOOKEEPER_CONNECT";
     private static final String KEY_KAFKA_METRICS_ENABLED = "KAFKA_METRICS_ENABLED";
+    public static final String KEY_JVM_OPTIONS = "kafka-jvmOptions";
+    public static final String KEY_RESOURCES = "kafka-resources";
+
+    // Kafka configuration keys
     protected static final String KEY_KAFKA_USER_CONFIGURATION = "KAFKA_USER_CONFIGURATION";
+    public static final String KEY_KAFKA_HEAP_OPTS = "KAFKA_HEAP_OPTS";
 
     /**
      * Constructor
@@ -136,6 +141,8 @@ public class KafkaCluster extends AbstractModel {
         if (kafkaConfig != null) {
             kafka.setConfiguration(new KafkaConfiguration(new JsonObject(kafkaConfig)));
         }
+        kafka.setResources(Resources.fromJson(data.get(KEY_RESOURCES)));
+        kafka.setJvmOptions(JvmOptions.fromJson(data.get(KEY_JVM_OPTIONS)));
 
         return kafka;
     }
@@ -226,6 +233,7 @@ public class KafkaCluster extends AbstractModel {
                 getVolumeMounts(),
                 createExecProbe(healthCheckPath, healthCheckInitialDelay, healthCheckTimeout),
                 createExecProbe(healthCheckPath, healthCheckInitialDelay, healthCheckTimeout),
+                resources(),
                 isOpenShift);
     }
 
@@ -290,6 +298,7 @@ public class KafkaCluster extends AbstractModel {
         List<EnvVar> varList = new ArrayList<>();
         varList.add(buildEnvVar(KEY_KAFKA_ZOOKEEPER_CONNECT, zookeeperConnect));
         varList.add(buildEnvVar(KEY_KAFKA_METRICS_ENABLED, String.valueOf(isMetricsEnabled)));
+        varList.add(buildEnvVar(KEY_KAFKA_HEAP_OPTS, javaHeapOptions(5 * 1024 * 1024 * 1024, 0.5)));
 
         if (configuration != null) {
             varList.add(buildEnvVar(KEY_KAFKA_USER_CONFIGURATION, configuration.getConfiguration()));

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/KafkaCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/KafkaCluster.java
@@ -298,7 +298,7 @@ public class KafkaCluster extends AbstractModel {
         List<EnvVar> varList = new ArrayList<>();
         varList.add(buildEnvVar(KEY_KAFKA_ZOOKEEPER_CONNECT, zookeeperConnect));
         varList.add(buildEnvVar(KEY_KAFKA_METRICS_ENABLED, String.valueOf(isMetricsEnabled)));
-        varList.add(buildEnvVar(KEY_KAFKA_HEAP_OPTS, javaHeapOptions(5 * 1024 * 1024 * 1024, 0.5)));
+        kafkaHeapOptions(varList, 0.5, 5 * 1024 * 1024 * 1024);
 
         if (configuration != null) {
             varList.add(buildEnvVar(KEY_KAFKA_USER_CONFIGURATION, configuration.getConfiguration()));

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/KafkaCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/KafkaCluster.java
@@ -298,7 +298,7 @@ public class KafkaCluster extends AbstractModel {
         List<EnvVar> varList = new ArrayList<>();
         varList.add(buildEnvVar(KEY_KAFKA_ZOOKEEPER_CONNECT, zookeeperConnect));
         varList.add(buildEnvVar(KEY_KAFKA_METRICS_ENABLED, String.valueOf(isMetricsEnabled)));
-        kafkaHeapOptions(varList, 0.5, 5 * 1024 * 1024 * 1024);
+        kafkaHeapOptions(varList, 0.5, 5L * 1024L * 1024L * 1024L);
 
         if (configuration != null) {
             varList.add(buildEnvVar(KEY_KAFKA_USER_CONFIGURATION, configuration.getConfiguration()));

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/KafkaConnectCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/KafkaConnectCluster.java
@@ -61,6 +61,8 @@ public class KafkaConnectCluster extends AbstractModel {
     public static final String KEY_REPLICAS = "nodes";
     public static final String KEY_HEALTHCHECK_DELAY = "healthcheck-delay";
     public static final String KEY_HEALTHCHECK_TIMEOUT = "healthcheck-timeout";
+    public static final String KEY_JVM_OPTIONS = "jvmOptions";
+    public static final String KEY_RESOURCES = "resources";
 
     // Kafka Connect configuration keys
     public static final String KEY_BOOTSTRAP_SERVERS = "KAFKA_CONNECT_BOOTSTRAP_SERVERS";
@@ -72,6 +74,7 @@ public class KafkaConnectCluster extends AbstractModel {
     public static final String KEY_CONFIG_STORAGE_REPLICATION_FACTOR = "KAFKA_CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR";
     public static final String KEY_OFFSET_STORAGE_REPLICATION_FACTOR = "KAFKA_CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR";
     public static final String KEY_STATUS_STORAGE_REPLICATION_FACTOR = "KAFKA_CONNECT_STATUS_STORAGE_REPLICATION_FACTOR";
+    public static final String KEY_KAFKA_HEAP_OPTS = "KAFKA_HEAP_OPTS";
 
     public static String kafkaConnectClusterName(String cluster) {
         return cluster + KafkaConnectCluster.NAME_SUFFIX;
@@ -107,6 +110,8 @@ public class KafkaConnectCluster extends AbstractModel {
         Map<String, String> data = cm.getData();
         kafkaConnect.setReplicas(Integer.parseInt(data.getOrDefault(KEY_REPLICAS, String.valueOf(DEFAULT_REPLICAS))));
         kafkaConnect.setImage(data.getOrDefault(KEY_IMAGE, DEFAULT_IMAGE));
+        kafkaConnect.setResources(Resources.fromJson(data.get(KEY_RESOURCES)));
+        kafkaConnect.setJvmOptions(JvmOptions.fromJson(data.get(KEY_JVM_OPTIONS)));
         kafkaConnect.setHealthCheckInitialDelay(Integer.parseInt(data.getOrDefault(KEY_HEALTHCHECK_DELAY, String.valueOf(DEFAULT_HEALTHCHECK_DELAY))));
         kafkaConnect.setHealthCheckTimeout(Integer.parseInt(data.getOrDefault(KEY_HEALTHCHECK_TIMEOUT, String.valueOf(DEFAULT_HEALTHCHECK_TIMEOUT))));
 
@@ -182,7 +187,8 @@ public class KafkaConnectCluster extends AbstractModel {
                 createHttpProbe(healthCheckPath, REST_API_PORT_NAME, healthCheckInitialDelay, healthCheckTimeout),
                 updateStrategy,
                 Collections.emptyMap(),
-                Collections.emptyMap()
+                Collections.emptyMap(),
+                resources()
                 );
     }
 
@@ -198,7 +204,7 @@ public class KafkaConnectCluster extends AbstractModel {
         varList.add(buildEnvVar(KEY_CONFIG_STORAGE_REPLICATION_FACTOR, String.valueOf(configStorageReplicationFactor)));
         varList.add(buildEnvVar(KEY_OFFSET_STORAGE_REPLICATION_FACTOR, String.valueOf(offsetStorageReplicationFactor)));
         varList.add(buildEnvVar(KEY_STATUS_STORAGE_REPLICATION_FACTOR, String.valueOf(statusStorageReplicationFactor)));
-
+        varList.add(buildEnvVar(KEY_KAFKA_HEAP_OPTS, javaHeapOptions(0, 1.0)));
         return varList;
     }
 

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/KafkaConnectCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/KafkaConnectCluster.java
@@ -203,7 +203,7 @@ public class KafkaConnectCluster extends AbstractModel {
         varList.add(buildEnvVar(KEY_CONFIG_STORAGE_REPLICATION_FACTOR, String.valueOf(configStorageReplicationFactor)));
         varList.add(buildEnvVar(KEY_OFFSET_STORAGE_REPLICATION_FACTOR, String.valueOf(offsetStorageReplicationFactor)));
         varList.add(buildEnvVar(KEY_STATUS_STORAGE_REPLICATION_FACTOR, String.valueOf(statusStorageReplicationFactor)));
-        kafkaHeapOptions(varList, 1.0, 0);
+        kafkaHeapOptions(varList, 1.0, 0L);
         return varList;
     }
 

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/KafkaConnectCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/KafkaConnectCluster.java
@@ -74,7 +74,6 @@ public class KafkaConnectCluster extends AbstractModel {
     public static final String KEY_CONFIG_STORAGE_REPLICATION_FACTOR = "KAFKA_CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR";
     public static final String KEY_OFFSET_STORAGE_REPLICATION_FACTOR = "KAFKA_CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR";
     public static final String KEY_STATUS_STORAGE_REPLICATION_FACTOR = "KAFKA_CONNECT_STATUS_STORAGE_REPLICATION_FACTOR";
-    public static final String KEY_KAFKA_HEAP_OPTS = "KAFKA_HEAP_OPTS";
 
     public static String kafkaConnectClusterName(String cluster) {
         return cluster + KafkaConnectCluster.NAME_SUFFIX;
@@ -204,7 +203,7 @@ public class KafkaConnectCluster extends AbstractModel {
         varList.add(buildEnvVar(KEY_CONFIG_STORAGE_REPLICATION_FACTOR, String.valueOf(configStorageReplicationFactor)));
         varList.add(buildEnvVar(KEY_OFFSET_STORAGE_REPLICATION_FACTOR, String.valueOf(offsetStorageReplicationFactor)));
         varList.add(buildEnvVar(KEY_STATUS_STORAGE_REPLICATION_FACTOR, String.valueOf(statusStorageReplicationFactor)));
-        varList.add(buildEnvVar(KEY_KAFKA_HEAP_OPTS, javaHeapOptions(0, 1.0)));
+        kafkaHeapOptions(varList, 1.0, 0);
         return varList;
     }
 

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/KafkaConnectS2ICluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/KafkaConnectS2ICluster.java
@@ -62,6 +62,8 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
         Map<String, String> data = cm.getData();
         kafkaConnect.setReplicas(Integer.parseInt(data.getOrDefault(KEY_REPLICAS, String.valueOf(DEFAULT_REPLICAS))));
         kafkaConnect.setImage(data.getOrDefault(KEY_IMAGE, DEFAULT_IMAGE));
+        kafkaConnect.setResources(Resources.fromJson(data.get(KEY_RESOURCES)));
+        kafkaConnect.setJvmOptions(JvmOptions.fromJson(data.get(KEY_JVM_OPTIONS)));
         kafkaConnect.setHealthCheckInitialDelay(Integer.parseInt(data.getOrDefault(KEY_HEALTHCHECK_DELAY, String.valueOf(DEFAULT_HEALTHCHECK_DELAY))));
         kafkaConnect.setHealthCheckTimeout(Integer.parseInt(data.getOrDefault(KEY_HEALTHCHECK_TIMEOUT, String.valueOf(DEFAULT_HEALTHCHECK_TIMEOUT))));
 

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/MemoryDeserializer.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/MemoryDeserializer.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.controller.cluster.model;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonTokenId;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer;
+
+import java.io.IOException;
+
+/**
+ * Converts Strings in Kubernetes memory syntax to/from bytes expressed as a long.
+ * @see <a href="https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-memory">Kubernetes docs</a>
+ */
+public class MemoryDeserializer extends StdScalarDeserializer<Long> {
+
+    private static final long serialVersionUID = 1L;
+
+    public MemoryDeserializer() {
+        this(Long.class);
+    }
+
+    protected MemoryDeserializer(Class vc) {
+        super(vc);
+    }
+
+    protected MemoryDeserializer(JavaType valueType) {
+        super(valueType);
+    }
+
+    protected MemoryDeserializer(StdScalarDeserializer src) {
+        super(src);
+    }
+
+    @Override
+    public Long deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+        switch (p.getCurrentTokenId()) {
+            case JsonTokenId.ID_NUMBER_INT:
+                switch (p.getNumberType()) {
+                    case INT:
+                    case LONG:
+                        return p.getLongValue();
+                }
+                break;
+            case JsonTokenId.ID_STRING:
+                String text = p.getText().trim();
+                try {
+                    return parse(text);
+                } catch (IllegalArgumentException e) {
+                    return (Long) ctxt.handleWeirdStringValue(_valueClass, text,
+                            "not a valid representation");
+                }
+        }
+        return (Long) ctxt.handleUnexpectedToken(_valueClass, p);
+    }
+
+    /**
+     * Parse a K8S-style representation of a quantity of memory, such as {@code 512Mi},
+     * into the equivalent number of bytes represented as a long.
+     * @param memory The String representation of the quantity of memory.
+     * @return The equivalent number of bytes.
+     */
+    public static long parse(String memory) {
+        boolean seenE = false;
+        long factor = 1L;
+        int end = memory.length();
+        for (int i = 0; i < memory.length(); i++) {
+            char ch = memory.charAt(i);
+            if (ch == 'e') {
+                seenE = true;
+            } else if (ch < '0' || '9' < ch) {
+                end = i;
+                factor = factor(memory.substring(i));
+                break;
+            }
+        }
+        long result;
+        if (seenE) {
+            result = (long) Double.parseDouble(memory);
+        } else {
+            result = Long.parseLong(memory.substring(0, end)) * factor;
+        }
+        return result;
+    }
+
+    private static long factor(String suffix) {
+        long factor;
+        switch (suffix) {
+            case "E":
+                factor = 1_000L * 1_000L * 1_000L * 1_000 * 1_000L;
+                break;
+            case "T":
+                factor = 1_000L * 1_000L * 1_000L * 1_000;
+                break;
+            case "G":
+                factor = 1_000L * 1_000L * 1_000L;
+                break;
+            case "M":
+                factor = 1_000L * 1_000L;
+                break;
+            case "K":
+                factor = 1_000L;
+                break;
+            case "Ei":
+                factor = 1_024L * 1_024L * 1_024L * 1_024L * 1_024L;
+                break;
+            case "Ti":
+                factor = 1_024L * 1_024L * 1_024L * 1_024L;
+                break;
+            case "Gi":
+                factor = 1_024L * 1_024L * 1_024L;
+                break;
+            case "Mi":
+                factor = 1_024L * 1_024L;
+                break;
+            case "Ki":
+                factor = 1_024L;
+                break;
+            default:
+                throw new IllegalArgumentException("Invalid memory suffix: " + suffix);
+        }
+        return factor;
+    }
+
+    static String format(long bytes) {
+        if (bytes == 0) {
+            return "0";
+        }
+        long x;
+        int i;
+        x = bytes;
+        i = -1;
+        while ((x % 1000L) == 0L && i < 4) {
+            i++;
+            x = x / 1000L;
+        }
+        if (i >= 0) {
+            return x + new String[] {"k", "M", "G", "T", "E"}[i];
+        }
+        x = bytes;
+        i = -1;
+        while ((x % 1024L) == 0L && i < 4) {
+            i++;
+            x = x / 1024L;
+        }
+        if (i >= 0) {
+            return x + new String[]{"ki", "Mi", "Gi", "Ti", "Ei"}[i];
+        }
+        return Long.toString(bytes);
+    }
+}
+

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/MilliCpuDeserializer.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/MilliCpuDeserializer.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.controller.cluster.model;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonTokenId;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer;
+
+import java.io.IOException;
+
+/**
+ * Converts Strings in Kubernetes cpu syntax to/from "millicpus" expressed as an int.
+ * Keeping the quantity as millicpus internally avoids the need for floating point arithmetic.
+ * @see <a href="https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-cpu">Kubernetes docs</a>
+ */
+public class MilliCpuDeserializer extends StdScalarDeserializer<Integer> {
+
+    private static final long serialVersionUID = 1L;
+
+    public MilliCpuDeserializer() {
+        this(Long.class);
+    }
+
+    protected MilliCpuDeserializer(Class vc) {
+        super(vc);
+    }
+
+    protected MilliCpuDeserializer(JavaType valueType) {
+        super(valueType);
+    }
+
+    protected MilliCpuDeserializer(StdScalarDeserializer src) {
+        super(src);
+    }
+
+    @Override
+    public Integer deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+        switch (p.getCurrentTokenId()) {
+            case JsonTokenId.ID_NUMBER_INT:
+                switch (p.getNumberType()) {
+                    case INT:
+                        return p.getIntValue();
+                }
+                break;
+            case JsonTokenId.ID_STRING:
+                String text = p.getText().trim();
+                try {
+                    return parse(text);
+                } catch (IllegalArgumentException e) {
+                    return (Integer) ctxt.handleWeirdStringValue(_valueClass, text,
+                            "not a valid representation");
+                }
+        }
+        return (Integer) ctxt.handleUnexpectedToken(_valueClass, p);
+    }
+
+    /**
+     * Parse a K8S-style representation of a quantity of cpu, such as {@code 1000m},
+     * into the equivalent number of "millicpus" represented as an int.
+     * @param cpu The String representation of the quantity of cpu.
+     * @return The equivalent number of "millicpus".
+     */
+    public static int parse(String cpu) {
+        int suffixIndex = cpu.length();
+        int factor = 1000;
+        for (int i = 0; i < cpu.length(); i++) {
+            char ch = cpu.charAt(i);
+            if (ch < '0' || '9' < ch) {
+                suffixIndex = i;
+                if ("m".equals(cpu.substring(i))) {
+                    factor = 1;
+                    break;
+                } else if (cpu.substring(i).startsWith(".")) {
+                    return (int) (Double.parseDouble(cpu) * 1000L);
+                } else {
+                    throw new IllegalArgumentException();
+                }
+            }
+        }
+        return factor * Integer.parseInt(cpu.substring(0, suffixIndex));
+    }
+
+    public static String format(int milliCpu) {
+        if (milliCpu % 1000 == 0) {
+            return Long.toString(milliCpu / 1000L);
+        } else {
+            return Long.toString(milliCpu) + "m";
+        }
+    }
+}

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/MilliCpuDeserializer.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/MilliCpuDeserializer.java
@@ -44,7 +44,8 @@ public class MilliCpuDeserializer extends StdScalarDeserializer<Integer> {
             case JsonTokenId.ID_NUMBER_INT:
                 switch (p.getNumberType()) {
                     case INT:
-                        return p.getIntValue();
+                        // interpret a json int as that many cpus, not millicpus
+                        return p.getIntValue() * 1000;
                 }
                 break;
             case JsonTokenId.ID_STRING:

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/Resources.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/Resources.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.controller.cluster.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+public class Resources {
+
+    public Resources() {
+    }
+
+    public Resources(CpuMemory limits, CpuMemory requests) {
+        this.limits = limits;
+        this.requests = requests;
+    }
+
+    public static class CpuMemory {
+        private long memory;
+        private int milliCpu;
+
+        public CpuMemory() {
+        }
+
+        public CpuMemory(long memory, int milliCpu) {
+            this.memory = memory;
+            this.milliCpu = milliCpu;
+        }
+
+        @JsonDeserialize(using = MemoryDeserializer.class)
+        public long getMemory() {
+            return memory;
+        }
+
+        public void setMemory(long memory) {
+            this.memory = memory;
+        }
+
+        /** The memory in Kubernetes syntax. */
+        @JsonIgnore
+        public String getMemoryFormatted() {
+            return MemoryDeserializer.format(getMemory());
+        }
+
+        /** The CPUs in "millicpus". */
+        @JsonDeserialize(using = MilliCpuDeserializer.class)
+        @JsonProperty("cpu")
+        public int getMilliCpu() {
+            return milliCpu;
+        }
+
+        public void setMilliCpu(int milliCpu) {
+            this.milliCpu = milliCpu;
+        }
+
+        /** The CPUs formatted using Kubernetes syntax. */
+        @JsonIgnore
+        public String getCpuFormatted() {
+            return MilliCpuDeserializer.format(getMilliCpu());
+        }
+    }
+
+    private CpuMemory limits;
+
+    private CpuMemory requests;
+
+    public CpuMemory getLimits() {
+        return limits;
+    }
+
+    public void setLimits(CpuMemory limits) {
+        this.limits = limits;
+    }
+
+    public CpuMemory getRequests() {
+        return requests;
+    }
+
+    public void setRequests(CpuMemory requests) {
+        this.requests = requests;
+    }
+
+    public static Resources fromJson(String json) {
+        return JsonUtils.fromJson(json, Resources.class);
+    }
+
+    public String toString() {
+        return JsonUtils.toJson(this);
+    }
+}

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/Resources.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/Resources.java
@@ -87,7 +87,4 @@ public class Resources {
         return JsonUtils.fromJson(json, Resources.class);
     }
 
-    public String toString() {
-        return JsonUtils.toJson(this);
-    }
 }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/TcConfig.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/TcConfig.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.controller.cluster.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class TcConfig {
+    private String watchedNamespace;
+    private String image = TopicController.DEFAULT_IMAGE;
+    private String reconciliationInterval = TopicController.DEFAULT_FULL_RECONCILIATION_INTERVAL_MS;
+    private String zookeeperSessionTimeout = TopicController.DEFAULT_ZOOKEEPER_SESSION_TIMEOUT_MS;
+    private int topicMetadataMaxAttempts = TopicController.DEFAULT_TOPIC_METADATA_MAX_ATTEMPTS;
+    private Resources resources;
+
+    public String getWatchedNamespace() {
+        return watchedNamespace;
+    }
+
+    public void setWatchedNamespace(String watchedNamespace) {
+        this.watchedNamespace = watchedNamespace;
+    }
+
+    public String getImage() {
+        return image;
+    }
+
+    public void setImage(String image) {
+        this.image = image;
+    }
+
+    public String getReconciliationInterval() {
+        return reconciliationInterval;
+    }
+
+    public void setReconciliationInterval(String reconciliationInterval) {
+        this.reconciliationInterval = reconciliationInterval;
+    }
+
+    public String getZookeeperSessionTimeout() {
+        return zookeeperSessionTimeout;
+    }
+
+    public void setZookeeperSessionTimeout(String zookeeperSessionTimeout) {
+        this.zookeeperSessionTimeout = zookeeperSessionTimeout;
+    }
+
+    public int getTopicMetadataMaxAttempts() {
+        return topicMetadataMaxAttempts;
+    }
+
+    public void setTopicMetadataMaxAttempts(int topicMetadataMaxAttempts) {
+        this.topicMetadataMaxAttempts = topicMetadataMaxAttempts;
+    }
+
+    public Resources getResources() {
+        return resources;
+    }
+
+    public void setResources(Resources resources) {
+        this.resources = resources;
+    }
+
+    public static TcConfig fromJson(String json) {
+        return JsonUtils.fromJson(json, TcConfig.class);
+    }
+}

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/TopicController.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/TopicController.java
@@ -181,7 +181,7 @@ public class TopicController extends AbstractModel {
                     kafkaClusterCm.getMetadata().getName(),
                     Labels.fromResource(kafkaClusterCm));
 
-            TcConfig tcConfig = TcConfig.fromJson(config);
+            TopicControllerConfig tcConfig = TopicControllerConfig.fromJson(config);
 
             topicController.setImage(tcConfig.getImage());
             topicController.setWatchedNamespace(tcConfig.getWatchedNamespace() != null ? tcConfig.getWatchedNamespace() : namespace);

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/TopicControllerConfig.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/TopicControllerConfig.java
@@ -7,7 +7,7 @@ package io.strimzi.controller.cluster.model;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class TcConfig {
+public class TopicControllerConfig {
     private String watchedNamespace;
     private String image = TopicController.DEFAULT_IMAGE;
     private String reconciliationInterval = TopicController.DEFAULT_FULL_RECONCILIATION_INTERVAL_MS;
@@ -63,7 +63,7 @@ public class TcConfig {
         this.resources = resources;
     }
 
-    public static TcConfig fromJson(String json) {
-        return JsonUtils.fromJson(json, TcConfig.class);
+    public static TopicControllerConfig fromJson(String json) {
+        return JsonUtils.fromJson(json, TopicControllerConfig.class);
     }
 }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/ZookeeperCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/ZookeeperCluster.java
@@ -56,10 +56,13 @@ public class ZookeeperCluster extends AbstractModel {
     public static final String KEY_HEALTHCHECK_TIMEOUT = "zookeeper-healthcheck-timeout";
     public static final String KEY_METRICS_CONFIG = "zookeeper-metrics-config";
     public static final String KEY_STORAGE = "zookeeper-storage";
+    public static final String KEY_JVM_OPTIONS = "zookeeper-jvmOptions";
+    public static final String KEY_RESOURCES = "zookeeper-resources";
 
     // Zookeeper configuration keys
     private static final String KEY_ZOOKEEPER_NODE_COUNT = "ZOOKEEPER_NODE_COUNT";
     public static final String KEY_ZOOKEEPER_METRICS_ENABLED = "ZOOKEEPER_METRICS_ENABLED";
+    public static final String KEY_KAFKA_HEAP_OPTS = "KAFKA_HEAP_OPTS";
 
     public static String zookeeperClusterName(String cluster) {
         return cluster + ZookeeperCluster.NAME_SUFFIX;
@@ -127,6 +130,9 @@ public class ZookeeperCluster extends AbstractModel {
         String storageConfig = data.get(KEY_STORAGE);
         zk.setStorage(Storage.fromJson(new JsonObject(storageConfig)));
 
+        zk.setResources(Resources.fromJson(data.get(KEY_RESOURCES)));
+        zk.setJvmOptions(JvmOptions.fromJson(data.get(KEY_JVM_OPTIONS)));
+
         return zk;
     }
 
@@ -190,6 +196,7 @@ public class ZookeeperCluster extends AbstractModel {
                 getVolumeMounts(),
                 createExecProbe(healthCheckPath, healthCheckInitialDelay, healthCheckTimeout),
                 createExecProbe(healthCheckPath, healthCheckInitialDelay, healthCheckTimeout),
+                resources(),
                 isOpenShift);
     }
 
@@ -208,7 +215,7 @@ public class ZookeeperCluster extends AbstractModel {
         List<EnvVar> varList = new ArrayList<>();
         varList.add(buildEnvVar(KEY_ZOOKEEPER_NODE_COUNT, Integer.toString(replicas)));
         varList.add(buildEnvVar(KEY_ZOOKEEPER_METRICS_ENABLED, String.valueOf(isMetricsEnabled)));
-
+        varList.add(buildEnvVar(KEY_KAFKA_HEAP_OPTS, javaHeapOptions(2 * 1024 * 1024 * 1024, 0.75)));
         return varList;
     }
 

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/ZookeeperCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/ZookeeperCluster.java
@@ -215,7 +215,7 @@ public class ZookeeperCluster extends AbstractModel {
         List<EnvVar> varList = new ArrayList<>();
         varList.add(buildEnvVar(KEY_ZOOKEEPER_NODE_COUNT, Integer.toString(replicas)));
         varList.add(buildEnvVar(KEY_ZOOKEEPER_METRICS_ENABLED, String.valueOf(isMetricsEnabled)));
-        varList.add(buildEnvVar(KEY_KAFKA_HEAP_OPTS, javaHeapOptions(2 * 1024 * 1024 * 1024, 0.75)));
+        kafkaHeapOptions(varList, 0.75, 2 * 1024 * 1024 * 1024);
         return varList;
     }
 

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/ZookeeperCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/ZookeeperCluster.java
@@ -215,7 +215,7 @@ public class ZookeeperCluster extends AbstractModel {
         List<EnvVar> varList = new ArrayList<>();
         varList.add(buildEnvVar(KEY_ZOOKEEPER_NODE_COUNT, Integer.toString(replicas)));
         varList.add(buildEnvVar(KEY_ZOOKEEPER_METRICS_ENABLED, String.valueOf(isMetricsEnabled)));
-        kafkaHeapOptions(varList, 0.75, 2 * 1024 * 1024 * 1024);
+        kafkaHeapOptions(varList, 0.75, 2L * 1024L * 1024L * 1024L);
         return varList;
     }
 

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operator/assembly/AbstractAssemblyOperator.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operator/assembly/AbstractAssemblyOperator.java
@@ -186,7 +186,7 @@ public abstract class AbstractAssemblyOperator {
                 if (result.succeeded()) {
                     log.info("{}: Assembly reconciled", reconciliation);
                 } else {
-                    log.error("{}: Failed to reconcile", reconciliation);
+                    log.error("{}: Failed to reconcile", reconciliation, result.cause());
                 }
                 latch.countDown();
             });

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/model/AbstractModelTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/model/AbstractModelTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.controller.cluster.model;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class AbstractModelTest {
+
+    private static JvmOptions jvmOptions(String xmx, String xms) {
+        JvmOptions result = new JvmOptions();
+        result.setXms(xms);
+        result.setXmx(xmx);
+        return result;
+    }
+
+    @Test
+    public void testJvmMemoryOptionsExplicit() {
+        AbstractModel am = new AbstractModel(null, null, Labels.forCluster("foo")) { };
+        am.setJvmOptions(jvmOptions("4", "4"));
+        assertEquals("-Xms4 -Xmx4", am.javaHeapOptions(5_000_000_000L, 0.5));
+    }
+
+    @Test
+    public void testJvmMemoryOptionsDefault() {
+        AbstractModel am = new AbstractModel(null, null, Labels.forCluster("foo")) { };
+        am.setJvmOptions(jvmOptions(null, "4"));
+        assertEquals("-Xms4 " +
+                        "-XX:+UnlockExperimentalVMOptions " +
+                        "-XX:+UseCGroupMemoryLimitForHeap " +
+                        "-XX:MaxRAMFraction=2",
+                am.javaHeapOptions(5_000_000_000L, 0.5));
+        assertEquals("-Xms4 " +
+                        "-XX:+UnlockExperimentalVMOptions " +
+                        "-XX:+UseCGroupMemoryLimitForHeap " +
+                        "-XX:MaxRAMFraction=2",
+                am.javaHeapOptions(5_000_000_000L, 0.7));
+        assertEquals("-Xms4 " +
+                        "-XX:+UnlockExperimentalVMOptions " +
+                        "-XX:+UseCGroupMemoryLimitForHeap " +
+                        "-XX:MaxRAMFraction=1",
+                am.javaHeapOptions(5_000_000_000L, 1.0));
+    }
+
+    @Test
+    public void testJvmMemoryOptionsMemoryRequest() {
+        AbstractModel am = new AbstractModel(null, null, Labels.forCluster("foo")) { };
+        am.setJvmOptions(jvmOptions(null, null));
+
+        am.setResources(new Resources(null, new Resources.CpuMemory(4_000_000_000L, 0)));
+        assertEquals("-XX:MaxRAM=2000000000",
+                am.javaHeapOptions(5_000_000_000L, 0.5));
+        am.setResources(new Resources(null, new Resources.CpuMemory(5_000_000_000L, 0)));
+        assertEquals("-XX:MaxRAM=2500000000",
+                am.javaHeapOptions(5_000_000_000L, 0.5));
+        am.setResources(new Resources(null, new Resources.CpuMemory(10_000_000_000L, 0)));
+        assertEquals("-XX:MaxRAM=5000000000",
+                am.javaHeapOptions(5_000_000_000L, 0.5));
+        am.setResources(new Resources(null, new Resources.CpuMemory(12_000_000_000L, 0)));
+        assertEquals("-XX:MaxRAM=5000000000",
+                am.javaHeapOptions(5_000_000_000L, 0.5));
+        am.setResources(new Resources(null, new Resources.CpuMemory(100_000_000_000L, 0)));
+        assertEquals("-XX:MaxRAM=5000000000",
+                am.javaHeapOptions(5_000_000_000L, 0.5));
+    }
+}

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/model/KafkaConnectClusterTest.java
@@ -51,7 +51,7 @@ public class KafkaConnectClusterTest {
         expected.add(new EnvVarBuilder().withName(kc.KEY_CONFIG_STORAGE_REPLICATION_FACTOR).withValue(Integer.toString(configReplicationFactor)).build());
         expected.add(new EnvVarBuilder().withName(kc.KEY_OFFSET_STORAGE_REPLICATION_FACTOR).withValue(Integer.toString(offsetReplicationFactor)).build());
         expected.add(new EnvVarBuilder().withName(kc.KEY_STATUS_STORAGE_REPLICATION_FACTOR).withValue(Integer.toString(statusReplicationFactor)).build());
-
+        expected.add(new EnvVarBuilder().withName(kc.KEY_KAFKA_HEAP_OPTS).withValue("-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:MaxRAMFraction=1").build());
         return expected;
     }
 

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/model/KafkaConnectClusterTest.java
@@ -51,7 +51,7 @@ public class KafkaConnectClusterTest {
         expected.add(new EnvVarBuilder().withName(kc.KEY_CONFIG_STORAGE_REPLICATION_FACTOR).withValue(Integer.toString(configReplicationFactor)).build());
         expected.add(new EnvVarBuilder().withName(kc.KEY_OFFSET_STORAGE_REPLICATION_FACTOR).withValue(Integer.toString(offsetReplicationFactor)).build());
         expected.add(new EnvVarBuilder().withName(kc.KEY_STATUS_STORAGE_REPLICATION_FACTOR).withValue(Integer.toString(statusReplicationFactor)).build());
-        expected.add(new EnvVarBuilder().withName(kc.KEY_KAFKA_HEAP_OPTS).withValue("-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:MaxRAMFraction=1").build());
+        expected.add(new EnvVarBuilder().withName(AbstractModel.ENV_VAR_DYNAMIC_HEAP_FRACTION).withValue("1.0").build());
         return expected;
     }
 

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/model/KafkaConnectS2IClusterTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/model/KafkaConnectS2IClusterTest.java
@@ -55,7 +55,7 @@ public class KafkaConnectS2IClusterTest {
         expected.add(new EnvVarBuilder().withName(kc.KEY_CONFIG_STORAGE_REPLICATION_FACTOR).withValue(Integer.toString(configReplicationFactor)).build());
         expected.add(new EnvVarBuilder().withName(kc.KEY_OFFSET_STORAGE_REPLICATION_FACTOR).withValue(Integer.toString(offsetReplicationFactor)).build());
         expected.add(new EnvVarBuilder().withName(kc.KEY_STATUS_STORAGE_REPLICATION_FACTOR).withValue(Integer.toString(statusReplicationFactor)).build());
-
+        expected.add(new EnvVarBuilder().withName(kc.KEY_KAFKA_HEAP_OPTS).withValue("-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:MaxRAMFraction=1").build());
         return expected;
     }
 

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/model/KafkaConnectS2IClusterTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/model/KafkaConnectS2IClusterTest.java
@@ -55,7 +55,7 @@ public class KafkaConnectS2IClusterTest {
         expected.add(new EnvVarBuilder().withName(kc.KEY_CONFIG_STORAGE_REPLICATION_FACTOR).withValue(Integer.toString(configReplicationFactor)).build());
         expected.add(new EnvVarBuilder().withName(kc.KEY_OFFSET_STORAGE_REPLICATION_FACTOR).withValue(Integer.toString(offsetReplicationFactor)).build());
         expected.add(new EnvVarBuilder().withName(kc.KEY_STATUS_STORAGE_REPLICATION_FACTOR).withValue(Integer.toString(statusReplicationFactor)).build());
-        expected.add(new EnvVarBuilder().withName(kc.KEY_KAFKA_HEAP_OPTS).withValue("-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:MaxRAMFraction=1").build());
+        expected.add(new EnvVarBuilder().withName(AbstractModel.ENV_VAR_DYNAMIC_HEAP_FRACTION).withValue("1.0").build());
         return expected;
     }
 

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/model/MemoryDeserializerTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/model/MemoryDeserializerTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.controller.cluster.model;
+
+import org.junit.Test;
+
+import static io.strimzi.controller.cluster.model.MemoryDeserializer.format;
+import static io.strimzi.controller.cluster.model.MemoryDeserializer.parse;
+import static org.junit.Assert.assertEquals;
+
+public class MemoryDeserializerTest {
+
+    @Test
+    public void testParse() {
+        assertEquals(1234, parse("1234"));
+        assertEquals(0, parse("0"));
+        assertEquals(1000, parse("1K"));
+        assertEquals(1024, parse("1Ki"));
+        assertEquals(512 * 1024, parse("512Ki"));
+        assertEquals(1_000_000, parse("1e6"));
+
+        assertEquals(0, parse("0"));
+        assertEquals(0, parse("0K"));
+        assertEquals(0, parse("0e6"));
+
+        try {
+            parse("-1K");
+        } catch (IllegalArgumentException e) {
+
+        }
+
+        try {
+            parse("K");
+        } catch (IllegalArgumentException e) {
+
+        }
+
+        try {
+            parse("1Kb");
+        } catch (IllegalArgumentException e) {
+
+        }
+
+        try {
+            parse("foo");
+        } catch (IllegalArgumentException e) {
+
+        }
+    }
+
+    @Test
+    public void testFormat() {
+        assertEquals("0", format(0));
+        assertEquals("1", format(1));
+        assertEquals("1023", format(1023));
+        assertEquals("1ki", format(1024));
+        assertEquals("1k", format(1000));
+        assertEquals("2ki", format(2048));
+        assertEquals("2k", format(2000));
+        assertEquals("2Mi", format(2048 * 1024));
+        assertEquals("4096k", format(2048 * 2000));
+        assertEquals("4M", format(2000 * 2000));
+        assertEquals("1E", format(1_000_000_000_000_000L));
+        assertEquals("1000E", format(1_000_000_000_000_000_000L));
+        assertEquals("1Ei", format(parse("1Ei")));
+        assertEquals("1024Ei", format(parse("1024Ei")));
+    }
+}

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/model/MilliCpuDeserializerTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/model/MilliCpuDeserializerTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.controller.cluster.model;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class MilliCpuDeserializerTest {
+    @Test
+    public void testParse() {
+        assertEquals(1000, MilliCpuDeserializer.parse("1"));
+        assertEquals(1, MilliCpuDeserializer.parse("1m"));
+        assertEquals(500, MilliCpuDeserializer.parse("0.5"));
+        assertEquals(0, MilliCpuDeserializer.parse("0"));
+        assertEquals(0, MilliCpuDeserializer.parse("0m"));
+        assertEquals(0, MilliCpuDeserializer.parse("0.0"));
+        assertEquals(0, MilliCpuDeserializer.parse("0.000001"));
+
+        try {
+            MilliCpuDeserializer.parse("0.0m");
+            fail();
+        } catch (NumberFormatException e) { }
+
+        try {
+            MilliCpuDeserializer.parse("0.1m");
+            fail();
+        } catch (NumberFormatException e) { }
+    }
+
+    @Test
+    public void testFormat() {
+        assertEquals("1", MilliCpuDeserializer.format(1000));
+        assertEquals("500m", MilliCpuDeserializer.format(500));
+        assertEquals("1m", MilliCpuDeserializer.format(1));
+    }
+}

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/model/MilliCpuDeserializerTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/model/MilliCpuDeserializerTest.java
@@ -6,35 +6,44 @@ package io.strimzi.controller.cluster.model;
 
 import org.junit.Test;
 
+import static io.strimzi.controller.cluster.model.MilliCpuDeserializer.format;
+import static io.strimzi.controller.cluster.model.MilliCpuDeserializer.parse;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 public class MilliCpuDeserializerTest {
     @Test
     public void testParse() {
-        assertEquals(1000, MilliCpuDeserializer.parse("1"));
-        assertEquals(1, MilliCpuDeserializer.parse("1m"));
-        assertEquals(500, MilliCpuDeserializer.parse("0.5"));
-        assertEquals(0, MilliCpuDeserializer.parse("0"));
-        assertEquals(0, MilliCpuDeserializer.parse("0m"));
-        assertEquals(0, MilliCpuDeserializer.parse("0.0"));
-        assertEquals(0, MilliCpuDeserializer.parse("0.000001"));
+        assertEquals(1000, parse("1"));
+        assertEquals(1, parse("1m"));
+        assertEquals(500, parse("0.5"));
+        assertEquals(0, parse("0"));
+        assertEquals(0, parse("0m"));
+        assertEquals(0, parse("0.0"));
+        assertEquals(0, parse("0.000001"));
 
         try {
-            MilliCpuDeserializer.parse("0.0m");
+            parse("0.0m");
             fail();
         } catch (NumberFormatException e) { }
 
         try {
-            MilliCpuDeserializer.parse("0.1m");
+            parse("0.1m");
             fail();
         } catch (NumberFormatException e) { }
     }
 
     @Test
     public void testFormat() {
-        assertEquals("1", MilliCpuDeserializer.format(1000));
-        assertEquals("500m", MilliCpuDeserializer.format(500));
-        assertEquals("1m", MilliCpuDeserializer.format(1));
+        assertEquals("1", format(1000));
+        assertEquals("500m", format(500));
+        assertEquals("1m", format(1));
+    }
+
+    @Test
+    public void testRt() {
+        assertEquals("1", format(parse("1")));
+        assertEquals("500m", format(parse("500m")));
+        assertEquals("1m", format(parse("1m")));
     }
 }

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/model/ResourcesTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/model/ResourcesTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.controller.cluster.model;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ResourcesTest {
+
+    @Test
+    public void testDeserializeSuffixes() {
+        Resources opts = Resources.fromJson("{\"limits\": {\"memory\": \"10Gi\"}, \"requests\": {\"memory\": \"5G\"}}");
+        assertEquals(10737418240L, opts.getLimits().getMemory());
+        assertEquals(5000000000L, opts.getRequests().getMemory());
+    }
+
+    @Test
+    public void testDeserializeInts() {
+        Resources opts = Resources.fromJson("{\"limits\": {\"memory\": 10737418240}, \"requests\": {\"memory\": 5000000000}}");
+        assertEquals(10737418240L, opts.getLimits().getMemory());
+        assertEquals(5000000000L, opts.getRequests().getMemory());
+    }
+
+    @Test
+    public void testDeserializeDefaults() {
+        Resources opts = Resources.fromJson("{\"limits\": {\"memory\": 10737418240}, \"requests\": {} }");
+        assertEquals(10737418240L, opts.getLimits().getMemory());
+        assertEquals(0, opts.getRequests().getMemory());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testDeserializeInvalidMemory() {
+        Resources.fromJson("{\"limits\": {\"memory\": \"foo\"}, \"requests\": {\"memory\": bar}}");
+    }
+}

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/model/ResourcesTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/model/ResourcesTest.java
@@ -12,9 +12,17 @@ public class ResourcesTest {
 
     @Test
     public void testDeserializeSuffixes() {
-        Resources opts = Resources.fromJson("{\"limits\": {\"memory\": \"10Gi\"}, \"requests\": {\"memory\": \"5G\"}}");
+        Resources opts = Resources.fromJson("{\"limits\": {\"memory\": \"10Gi\", \"cpu\": \"1\"}, \"requests\": {\"memory\": \"5G\", \"cpu\": 1}}");
         assertEquals(10737418240L, opts.getLimits().getMemory());
+        assertEquals(1000, opts.getLimits().getMilliCpu());
+        assertEquals("1", opts.getLimits().getCpuFormatted());
         assertEquals(5000000000L, opts.getRequests().getMemory());
+        assertEquals(1000, opts.getLimits().getMilliCpu());
+        assertEquals("1", opts.getLimits().getCpuFormatted());
+        AbstractModel abstractModel = new AbstractModel("", "", Labels.forCluster("")) {
+        };
+        abstractModel.setResources(opts);
+        assertEquals("1", abstractModel.resources().getLimits().get("cpu").getAmount());
     }
 
     @Test

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/model/TopicControllerTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/model/TopicControllerTest.java
@@ -52,8 +52,8 @@ public class TopicControllerTest {
         expected.add(new EnvVarBuilder().withName(TopicController.KEY_KAFKA_BOOTSTRAP_SERVERS).withValue(TopicController.defaultBootstrapServers(cluster)).build());
         expected.add(new EnvVarBuilder().withName(TopicController.KEY_ZOOKEEPER_CONNECT).withValue(TopicController.defaultZookeeperConnect(cluster)).build());
         expected.add(new EnvVarBuilder().withName(TopicController.KEY_WATCHED_NAMESPACE).withValue(tcWatchedNamespace).build());
-        expected.add(new EnvVarBuilder().withName(TopicController.KEY_FULL_RECONCILIATION_INTERVAL_MS).withValue(tcReconciliationInterval).build());
-        expected.add(new EnvVarBuilder().withName(TopicController.KEY_ZOOKEEPER_SESSION_TIMEOUT_MS).withValue(tcZookeeperSessionTimeout).build());
+        expected.add(new EnvVarBuilder().withName(TopicController.KEY_FULL_RECONCILIATION_INTERVAL_MS).withValue(String.valueOf(tcReconciliationInterval)).build());
+        expected.add(new EnvVarBuilder().withName(TopicController.KEY_ZOOKEEPER_SESSION_TIMEOUT_MS).withValue(String.valueOf(tcZookeeperSessionTimeout)).build());
         expected.add(new EnvVarBuilder().withName(TopicController.KEY_TOPIC_METADATA_MAX_ATTEMPTS).withValue(String.valueOf(tcTopicMetadataMaxAttempts)).build());
 
         return expected;

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/operator/assembly/KafkaAssemblyOperatorMockIT.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/operator/assembly/KafkaAssemblyOperatorMockIT.java
@@ -9,6 +9,7 @@ import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaimBuilder;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.extensions.StatefulSet;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -16,6 +17,7 @@ import io.strimzi.controller.cluster.Reconciliation;
 import io.strimzi.controller.cluster.model.AssemblyType;
 import io.strimzi.controller.cluster.model.KafkaCluster;
 import io.strimzi.controller.cluster.model.Labels;
+import io.strimzi.controller.cluster.model.Resources;
 import io.strimzi.controller.cluster.model.Storage;
 import io.strimzi.controller.cluster.model.TopicController;
 import io.strimzi.controller.cluster.model.ZookeeperCluster;
@@ -66,6 +68,7 @@ public class KafkaAssemblyOperatorMockIT {
 
     private final int kafkaReplicas;
     private final JsonObject kafkaStorage;
+    private final Resources resources;
     private KubernetesClient mockClient;
 
     public static class Params {
@@ -75,18 +78,23 @@ public class KafkaAssemblyOperatorMockIT {
         private final int kafkaReplicas;
         private final JsonObject kafkaStorage;
 
-        public Params(int zkReplicas, JsonObject zkStorage, int kafkaReplicas, JsonObject kafkaStorage) {
+        private Resources resources;
+
+        public Params(int zkReplicas, JsonObject zkStorage, int kafkaReplicas, JsonObject kafkaStorage,
+                      Resources resources) {
             this.kafkaReplicas = kafkaReplicas;
             this.kafkaStorage = kafkaStorage;
             this.zkReplicas = zkReplicas;
             this.zkStorage = zkStorage;
+            this.resources = resources;
         }
 
         public String toString() {
             return "zkReplicas=" + zkReplicas +
                     ",zkStorage=" + kafkaStorage +
                     ",kafkaReplicas=" + kafkaReplicas +
-                    ",kafkaStorage=" + kafkaStorage;
+                    ",kafkaStorage=" + kafkaStorage +
+                    ",resources=" + resources;
         }
     }
 
@@ -110,15 +118,22 @@ public class KafkaAssemblyOperatorMockIT {
                     "\"size\": \"123\", " +
                     "\"class\": \"foo\"}")
         };
+        Resources[] resources = {
+            new Resources(
+                    new Resources.CpuMemory(5000, 5000),
+                    new Resources.CpuMemory(5000, 5000))
+        };
         List<KafkaAssemblyOperatorMockIT.Params> result = new ArrayList();
 
         for (int zkReplica : replicas) {
             for (JsonObject zkStorage : storageConfigs) {
                 for (int kafkaReplica : replicas) {
                     for (JsonObject kafkaStorage : storageConfigs) {
-                        result.add(new KafkaAssemblyOperatorMockIT.Params(
-                                zkReplica, zkStorage,
-                                kafkaReplica, kafkaStorage));
+                        for (Resources resource : resources) {
+                            result.add(new KafkaAssemblyOperatorMockIT.Params(
+                                    zkReplica, zkStorage,
+                                    kafkaReplica, kafkaStorage, resource));
+                        }
                     }
                 }
             }
@@ -133,6 +148,8 @@ public class KafkaAssemblyOperatorMockIT {
 
         this.kafkaReplicas = params.kafkaReplicas;
         this.kafkaStorage = params.kafkaStorage;
+
+        this.resources = params.resources;
     }
 
     /** Return the storage type the test cluster initially uses */
@@ -157,6 +174,7 @@ public class KafkaAssemblyOperatorMockIT {
     @Before
     public void before() {
         this.vertx = Vertx.vertx();
+
         this.cluster = new ConfigMapBuilder()
                 .withNewMetadata()
                 .withName(CLUSTER_NAME)
@@ -166,6 +184,7 @@ public class KafkaAssemblyOperatorMockIT {
                 .withData(map(KafkaCluster.KEY_REPLICAS, String.valueOf(kafkaReplicas),
                         KafkaCluster.KEY_STORAGE, kafkaStorage.toString(),
                         KafkaCluster.KEY_METRICS_CONFIG, "{}",
+                        KafkaCluster.KEY_RESOURCES, resources != null ? resources.toString() : null,
                         ZookeeperCluster.KEY_REPLICAS, String.valueOf(zkReplicas),
                         ZookeeperCluster.KEY_STORAGE, zkStorage.toString(),
                         ZookeeperCluster.KEY_METRICS_CONFIG, "{}",
@@ -210,6 +229,7 @@ public class KafkaAssemblyOperatorMockIT {
             context.assertNotNull(mockClient.extensions().deployments().inNamespace(NAMESPACE).withName(TopicController.topicControllerName(CLUSTER_NAME)).get());
             context.assertNotNull(mockClient.configMaps().inNamespace(NAMESPACE).withName(KafkaCluster.metricConfigsName(CLUSTER_NAME)).get());
             context.assertNotNull(mockClient.configMaps().inNamespace(NAMESPACE).withName(ZookeeperCluster.zookeeperMetricsName(CLUSTER_NAME)).get());
+            assertResourceReqirements(context, KafkaCluster.kafkaClusterName(CLUSTER_NAME));
             createAsync.complete();
         });
         createAsync.await();
@@ -565,6 +585,7 @@ public class KafkaAssemblyOperatorMockIT {
             data.put(KafkaCluster.KEY_STORAGE,
                     new JsonObject("{\"type\": \"ephemeral\"}").toString());
         }
+        data.put(KafkaCluster.KEY_RESOURCES, resources != null ? resources.toString() : null);
 
         ConfigMap changedClusterCm = new ConfigMapBuilder(cluster).withData(data).build();
         mockClient.configMaps().inNamespace(NAMESPACE).withName(CLUSTER_NAME).patch(changedClusterCm);
@@ -603,6 +624,24 @@ public class KafkaAssemblyOperatorMockIT {
         List<Container> initContainers = statefulSet.getSpec().getTemplate().getSpec().getInitContainers();
         context.assertEquals(initContainers.size(), originalInitContainers.size());
         context.assertEquals(initContainers, originalInitContainers);
+    }
+
+    private void assertResourceReqirements(TestContext context, String statefulSetName) {
+        StatefulSet statefulSet = mockClient.apps().statefulSets().inNamespace(NAMESPACE).withName(statefulSetName).get();
+        context.assertNotNull(statefulSet);
+        ResourceRequirements resources = statefulSet.getSpec().getTemplate().getSpec().getContainers().get(0).getResources();
+        if (resources != null && this.resources.getRequests() != null) {
+            context.assertEquals(this.resources.getRequests().getCpuFormatted(), resources.getRequests().get("cpu").getAmount());
+        }
+        if (resources != null && this.resources.getRequests() != null) {
+            context.assertEquals(this.resources.getRequests().getMemoryFormatted(), resources.getRequests().get("memory").getAmount());
+        }
+        if (resources != null && this.resources.getLimits() != null) {
+            context.assertEquals(this.resources.getLimits().getCpuFormatted(), resources.getLimits().get("cpu").getAmount());
+        }
+        if (resources != null && this.resources.getLimits() != null) {
+            context.assertEquals(this.resources.getLimits().getMemoryFormatted(), resources.getLimits().get("memory").getAmount());
+        }
     }
 
     /** Test that we can change the deleteClaim flag, and that it's honoured */

--- a/common-test/src/main/java/io/strimzi/test/StrimziRunner.java
+++ b/common-test/src/main/java/io/strimzi/test/StrimziRunner.java
@@ -347,7 +347,8 @@ public class StrimziRunner extends BlockJUnit4ClassRunner {
                 if ("04-deployment.yaml".equals(f.getName())) {
                     String dockerOrg = System.getenv().getOrDefault("DOCKER_ORG", "strimzi");
                     String dockerTag = System.getenv().getOrDefault("DOCKER_TAG", "latest");
-                    JsonNode containerNode = node.get("spec").get("template").get("spec").get("containers").get(0);
+                    ObjectNode containerNode = (ObjectNode) node.get("spec").get("template").get("spec").get("containers").get(0);
+                    containerNode.put("imagePullPolicy", "Always");
                     JsonNode ccImageNode = containerNode.get("image");
                     ((ObjectNode) containerNode).put("image", changeOrgAndTag(ccImageNode.asText(), dockerOrg, dockerTag));
                     for (JsonNode envVar : containerNode.get("env")) {

--- a/common-test/src/main/java/io/strimzi/test/StrimziRunner.java
+++ b/common-test/src/main/java/io/strimzi/test/StrimziRunner.java
@@ -161,7 +161,11 @@ public class StrimziRunner extends BlockJUnit4ClassRunner {
                 statement.evaluate();
             } catch (Throwable e) {
                 if (!(e instanceof VirtualMachineError)) {
-                    onError(e);
+                    try {
+                        onError(e);
+                    } catch (Throwable t) {
+                        e.addSuppressed(t);
+                    }
                 }
                 throw e;
 

--- a/common-test/src/main/java/io/strimzi/test/StrimziRunner.java
+++ b/common-test/src/main/java/io/strimzi/test/StrimziRunner.java
@@ -108,6 +108,7 @@ public class StrimziRunner extends BlockJUnit4ClassRunner {
         statement = withResources(method, statement);
         statement = withTopic(method, statement);
         statement = withNamespaces(method, statement);
+        statement = withLogging(method, statement);
         return statement;
     }
 
@@ -467,6 +468,7 @@ public class StrimziRunner extends BlockJUnit4ClassRunner {
             statement = withResources(testClass, statement);
             statement = withTopic(testClass, statement);
             statement = withNamespaces(testClass, statement);
+            statement = withLogging(testClass, statement);
         }
         return statement;
     }
@@ -526,5 +528,22 @@ public class StrimziRunner extends BlockJUnit4ClassRunner {
             };
         }
         return last;
+    }
+
+
+    private Statement withLogging(Annotatable element, Statement statement) {
+        return new Bracket(statement) {
+            private long t0;
+            @Override
+            protected void before() {
+                t0 = System.currentTimeMillis();
+                LOGGER.info("Starting " + element);
+            }
+
+            @Override
+            protected void after() {
+                LOGGER.info("Finished " + element + ": took " + ((System.currentTimeMillis() - t0) / 1000) + "s");
+            }
+        };
     }
 }

--- a/common-test/src/main/java/io/strimzi/test/StrimziRunner.java
+++ b/common-test/src/main/java/io/strimzi/test/StrimziRunner.java
@@ -217,7 +217,7 @@ public class StrimziRunner extends BlockJUnit4ClassRunner {
         }
     }
 
-    protected KubeClient<?>     kubeClient() {
+    protected KubeClient<?> kubeClient() {
         return clusterResource().client();
     }
 
@@ -537,13 +537,24 @@ public class StrimziRunner extends BlockJUnit4ClassRunner {
             @Override
             protected void before() {
                 t0 = System.currentTimeMillis();
-                LOGGER.info("Starting " + element);
+                LOGGER.info("Starting {}", name(element));
             }
 
             @Override
             protected void after() {
-                LOGGER.info("Finished " + element + ": took " + ((System.currentTimeMillis() - t0) / 1000) + "s");
+                LOGGER.info("Finished {}: took {}",
+                        name(element),
+                        duration(System.currentTimeMillis() - t0));
             }
         };
     }
+
+    private static String duration(long millis) {
+        long ms = millis % 1_000;
+        long time = millis / 1_000;
+        long minutes = time / 60;
+        long seconds = time % 60;
+        return minutes + "m" + seconds + "." + ms + "s";
+    }
+
 }

--- a/docker-images/kafka-base/Dockerfile
+++ b/docker-images/kafka-base/Dockerfile
@@ -34,4 +34,7 @@ RUN curl -O https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_java
     && mv jmx_prometheus_javaagent-${JMX_EXPORTER_VERSION}.jar /opt/prometheus/jmx_prometheus_javaagent.jar \
     && rm -rf jmx_prometheus_javaagent-${JMX_EXPORTER_VERSION}.*
 
+# copy scripts for starting Kafka
+COPY ./scripts/ $KAFKA_HOME
+
 WORKDIR $KAFKA_HOME

--- a/docker-images/kafka-base/scripts/dynamic_heap.sh
+++ b/docker-images/kafka-base/scripts/dynamic_heap.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+function get_heap_size {
+  FRACTION=$1
+  max=$2
+  # Get the max heap used by a jvm which used all the ram available to the container
+  max_possible_heap=$(java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:MaxRAMFraction=1 -XshowSettings:vm -version \
+    |& awk '/Max\. Heap Size \(Estimated\): [0-9KMG]+/{ print $5}' \
+    | gawk -f to_bytes.gawk)
+
+  actual_heap_max=$(echo "${max_possible_heap} ${fraction}" | awk '{ printf "%d", $1 * $2 }')
+
+  if [ ${max} ]; then
+    max=$(echo ${max} | gawk -f to_bytes.gawk)
+    if [ ${max} -lt ${actual_heap_max} ]; then
+      actual_heap_max=$max
+    fi
+  fi
+  echo $actual_heap_max
+}

--- a/docker-images/kafka-base/scripts/dynamic_heap.sh
+++ b/docker-images/kafka-base/scripts/dynamic_heap.sh
@@ -2,19 +2,19 @@
 
 function get_heap_size {
   FRACTION=$1
-  max=$2
+  MAX=$2
   # Get the max heap used by a jvm which used all the ram available to the container
-  max_possible_heap=$(java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:MaxRAMFraction=1 -XshowSettings:vm -version \
+  MAX_POSSIBLE_HEAP=$(java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:MaxRAMFraction=1 -XshowSettings:vm -version \
     |& awk '/Max\. Heap Size \(Estimated\): [0-9KMG]+/{ print $5}' \
     | gawk -f to_bytes.gawk)
 
-  actual_heap_max=$(echo "${max_possible_heap} ${fraction}" | awk '{ printf "%d", $1 * $2 }')
+  ACTUAL_MAX_HEAP=$(echo "${MAX_POSSIBLE_HEAP} ${FRACTION}" | awk '{ printf "%d", $1 * $2 }')
 
-  if [ ${max} ]; then
-    max=$(echo ${max} | gawk -f to_bytes.gawk)
-    if [ ${max} -lt ${actual_heap_max} ]; then
-      actual_heap_max=$max
+  if [ ${MAX} ]; then
+    MAX=$(echo ${MAX} | gawk -f to_bytes.gawk)
+    if [ ${MAX} -lt ${ACTUAL_MAX_HEAP} ]; then
+      ACTUAL_MAX_HEAP=$MAX
     fi
   fi
-  echo $actual_heap_max
+  echo $ACTUAL_MAX_HEAP
 }

--- a/docker-images/kafka-base/scripts/to_bytes.gawk
+++ b/docker-images/kafka-base/scripts/to_bytes.gawk
@@ -1,0 +1,11 @@
+# Use gawk because gnu awk can't extract regexp groups; gawk has `match`
+BEGIN {
+  suffixes[""]=1
+  suffixes["K"]=1024
+  suffixes["M"]=1024**2
+  suffixes["G"]=1024**3
+}
+
+match($0, /([0-9.]*)([kKmMgG]?)/, a) {
+  printf("%d", a[1] * suffixes[toupper(a[2])])
+}

--- a/docker-images/kafka-connect/scripts/kafka_connect_run.sh
+++ b/docker-images/kafka-connect/scripts/kafka_connect_run.sh
@@ -76,5 +76,16 @@ fi
 # directory avoids trying to create it (and logging a permission denied error)
 export LOG_DIR="$KAFKA_HOME"
 
+if [ -z "$KAFKA_HEAP_OPTS" -a -n "${DYNAMIC_HEAP_FRACTION}" ]; then
+    . ./dynamic_resources.sh
+    # Calculate a max heap size based some DYNAMIC_HEAP_FRACTION of the heap
+    # available to a jvm using 100% of the GCroup-aware memory
+    # up to some optional DYNAMIC_HEAP_MAX
+    CALC_MAX_HEAP=$(get_heap_size ${DYNAMIC_HEAP_FRACTION} ${DYNAMIC_HEAP_MAX})
+    if [ -n "$CALC_MAX_HEAP" ]; then
+      export KAFKA_HEAP_OPTS="-Xms${CALC_MAX_HEAP} -Xmx${CALC_MAX_HEAP}"
+    fi
+fi
+
 # starting Kafka server with final configuration
 exec $KAFKA_HOME/bin/connect-distributed.sh /tmp/strimzi-connect.properties

--- a/documentation/adoc/cluster-controller.adoc
+++ b/documentation/adoc/cluster-controller.adoc
@@ -1,3 +1,6 @@
+:k8s-docs-version: v1-7
+:resources-link: https://{k8s-docs-version}.docs.kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+
 == Cluster Controller
 
 The cluster controller is in charge of deploying a Kafka cluster alongside a Zookeeper ensemble. As part of the Kafka cluster,
@@ -72,6 +75,12 @@ environment variable of the Cluster Controller.
 <<storage_configuration_json_config>> for more details.
 * `kafka-metrics-config`: a JSON string representing the JMX exporter configuration for exposing metrics from Kafka broker nodes.
  Removing this field means having no metrics exposed.
+* `kafka-resources`:
+  a JSON string configuring the resource limits and requests for Kafka broker containers.
+  The accepted JSON format is described in the <<resources_json_config>> section.
+* `kafka-jvmOptions`:
+  a JSON string allowing the JVM running Kafka to be configured.
+   The accepted JSON format is described in the <<jvm_json_config>> section.
 * `zookeeper-nodes`: number of Zookeeper nodes
 * `zookeeper-image`: the Docker image to use for the Zookeeper nodes.
 Default is determined by the value of the
@@ -83,6 +92,12 @@ environment variable of the Cluster Controller.
 <<storage_configuration_json_config>> for more details.
 * `zookeeper-metrics-config`: a JSON string representing the JMX exporter configuration for exposing metrics from Zookeeper nodes.
  Removing this field means having no metrics exposed.
+* `zookeeper-resources`:
+  a JSON string configuring the resource limits and requests for Zookeeper broker containers.
+  The accepted JSON format is described in the <<resources_json_config>> section.
+* `zookeeper-jvmOptions`:
+  a JSON string allowing the JVM running Zookeeper to be configured.
+   The accepted JSON format is described in the <<jvm_json_config>> section.
 * `topic-controller-config`: a JSON string representing the topic controller configuration. See the <<topic_controller_json_config>>
 documentation for further details. More info about the topic controller in the related <<Topic Controller>> documentation page.
  
@@ -317,6 +332,7 @@ are generated :
 * `data-[cluster-name]-zookeeper-[idx]` Persistent Volume Claim for the volume used for storing data for the
 Zookeeper node pod `[idx]`
 
+[[metrics_json_config]]
 ===== Metrics
 
 Because Strimzi uses the [JMX exporter](https://github.com/prometheus/jmx_exporter) in order to expose metrics
@@ -324,6 +340,97 @@ on each node, the JSON string used for metrics configuration in the cluster Conf
 configuration file. For this reason, you can find more information on how to use it in the corresponding GitHub repo.
 
 For more information about using the metrics with Prometheus and Grafana, see <<_metrics>>
+
+[[resources_json_config]]
+===== Resource limits and requests
+
+It is possible to configure {resources-link}[Kubernetes resource limits and requests] on several containers using a JSON object.
+The object may have a `requests` and a `limits` property, each having the same schema, consisting of  `cpu` and `memory` properties.
+The same syntax as Kubernetes' is used for the values of `cpu` and `memory`.
+
+.Example Resource limits and requests JSON configuration
+[source,json]
+----
+{
+  "requests": {
+    "cpu": "1",
+    "memory": "2Gi"
+  },
+  "limits": {
+    "cpu": "1",
+    "memory": "2Gi"
+  }
+}
+----
+
+`requests/memory`::
+the memory request for the container, corresponding directly to Kubernetes' {resources-link}[`spec.containers[\].resources.requests.memory`] setting.
+Optional with no default.
+`requests/cpu`::
+the cpu request for the container, corresponding directly to Kubernetes' {resources-link}[`spec.containers[\].resources.requests.cpu`] setting.
+Optional with no default.
+`limits/memory`::
+the memory request for the container, corresponding directly to Kubernetes' {resources-link}[`spec.containers[\].resources.limits.memory`] setting.
+Optional with no default.
+`limits/cpu`::
+the cpu request for the container, corresponding directly to Kubernetes' {resources-link}[`spec.containers[\].resources.limits.cpu`] setting.
+Optional with no default.
+
+[[jvm_json_config]]
+===== JVM Options
+
+It is possible to configure a subset of available JVM options on Kafka, Zookeeper and Topic Controller containers using a JSON object.
+The object has a property for each JVM (`java`) option which can be configured:
+
+`-Xmx`::
+The maximum heap size. See the <<setting_xmx>> section for further details.
+
+`-Xms`::
+The initial heap size.
+Setting the same value for initial and maximum (`-Xmx`) heap sizes avoids the JVM having to allocate memory after startup, at the cost of possibly allocating more heap than is really needed.
+For Kafka and Zookeeper pods such allocation could cause unwanted latency.
+For Kafka Connect avoiding over allocation may be the more important concern, especially in distributed mode where the effects of over-allocation will be multiplied by the number of consumers.
+
+NOTE: The units accepted by JVM settings such as `-Xmx` and `-Xms` are those accepted by the OpenJDK `java` binary in the corresponding image.
+Accordingly, `1g` or `1G` means 1,073,741,824 bytes.
+This is in contrast to the units used for <<resources_json_config,memory limits and requests>>, which follow the Kubernetes convention where `1G` means 1,000,000,000 bytes, and `1Gi` means 1,073,741,824 bytes
+
+.Example Resource limits and requests JSON configuration
+[source,json]
+----
+{
+  "-Xmx": "2g",
+  "-Xms": "2g"
+}
+----
+
+In the above example, the JVM will use 2 GiB (=2,147,483,648 bytes) for its heap.
+Its total memory usage will be approximately 8GiB.
+
+[[setting_xmx]]
+====== Setting `-Xmx`
+
+The default value used for `-Xmx` depends on whether there is a <<resources_json_config,memory request>> for the container:
+
+* If there is a memory request, the JVM's maximum memory will be limited according to the kind of pod (Kafka, Zookeeper, TopicController) to an appropriate value less than the request.
+* Otherwise, when there is no memory request, the JVM's maximum memory will be limited according to the kind of pod and the RAM available to the container.
+
+[IMPORTANT]
+====
+Setting `-Xmx` explicitly is requires some care:
+
+* The JVM's overall memory usage will be approximately 4 × the maximum heap as configured by `-Xmx`.
+
+* If `-Xmx` is set without also setting an appropriate Kubernetes
+memory request, it is possible that the container will be killed should the Kubernetes node
+experience memory pressure (from other Pods running on it).
+====
+
+When `-Xmx` is set explicitly, it is recommended use a memory request that is at least 4.5 × the request heap memory when setting `-Xmx`.
+
+Furthermore, containers doing lots of disk I/O (such as Kafka broker containers) will need to leave some memory available for use as OS page cache.
+On such containers, the request memory should be substantially more than the memory used by the JVM.
+
 
 [[topic_controller_json_config]]
 ===== Topic controller
@@ -350,6 +457,9 @@ Default is the namespace where the topic controller is running
 `topicMetadataMaxAttempts`:: The number of attempts for getting topics metadata from Kafka. The time between each attempt
  is defined as an exponential back-off. You might want to increase this value when topic creation could take more time due
  to its larger size (i.e. many partitions/replicas). Default `6`.
+`resources`::
+  an object configuring the resource limits and requests for the topic controller container.
+  The accepted JSON format is described in the <<resources_json_config>> section.
 
 .Example Topic Controller JSON configuration
 [source,json]
@@ -373,6 +483,12 @@ environment variable of the Cluster Controller.
 If S2I is used (only on OpenShift), then it should be the related S2I image.
 * `healthcheck-delay`: the initial delay for the liveness and readiness probes for each Kafka Connect worker node. Default is 60
 * `healthcheck-timeout`: the timeout on the liveness and readiness probes for each Kafka Connect worker node. Default is 5
+* `resources`:
+a JSON string configuring the resource limits and requests for Kafka Connect containers.
+The accepted JSON format is described in the <<resources_json_config>> section.
+* `jvmOptions`:
+a JSON string allowing the JVM running Kafka Connect to be configured.
+The accepted JSON format is described in the <<jvm_json_config>> section.
 * `KAFKA_CONNECT_BOOTSTRAP_SERVERS`: a list of host/port pairs to use for establishing the initial connection to the Kafka cluster.
 It sets the `bootstrap.servers` property in the properties configuration file used by Kafka Connect worker nodes on startup.
 Default is `my-cluster-kafka:9092`

--- a/documentation/adoc/cluster-controller.adoc
+++ b/documentation/adoc/cluster-controller.adoc
@@ -379,7 +379,7 @@ Optional with no default.
 [[jvm_json_config]]
 ===== JVM Options
 
-It is possible to configure a subset of available JVM options on Kafka, Zookeeper and Topic Controller containers using a JSON object.
+It is possible to configure a subset of available JVM options on Kafka, Zookeeper and Kafka Connect containers using a JSON object.
 The object has a property for each JVM (`java`) option which can be configured:
 
 `-Xmx`::
@@ -428,7 +428,7 @@ experience memory pressure (from other Pods running on it).
 
 When `-Xmx` is set explicitly, it is recommended use a memory request that is at least 4.5 × the request heap memory when setting `-Xmx`.
 
-Furthermore, containers doing lots of disk I/O (such as Kafka broker containers) will need to leave some memory available for use as OS page cache.
+Furthermore, containers doing lots of disk I/O (such as Kafka broker containers) will need to leave some memory available for use as operating system page cache.
 On such containers, the request memory should be substantially more than the memory used by the JVM.
 
 

--- a/documentation/adoc/cluster-controller.adoc
+++ b/documentation/adoc/cluster-controller.adoc
@@ -410,23 +410,32 @@ Its total memory usage will be approximately 8GiB.
 [[setting_xmx]]
 ====== Setting `-Xmx`
 
-The default value used for `-Xmx` depends on whether there is a <<resources_json_config,memory request>> for the container:
+The default value used for `-Xmx` depends on whether there is a <<resources_json_config,memory limit>> for the container:
 
-* If there is a memory request, the JVM's maximum memory will be limited according to the kind of pod (Kafka, Zookeeper, TopicController) to an appropriate value less than the request.
-* Otherwise, when there is no memory request, the JVM's maximum memory will be limited according to the kind of pod and the RAM available to the container.
+* If there is a memory limit, the JVM's maximum memory will be limited according to the kind of pod (Kafka, Zookeeper, TopicController) to an appropriate value less than the limit.
+* Otherwise, when there is no memory limit, the JVM's maximum memory will be set according to the kind of pod and the RAM available to the container.
 
 [IMPORTANT]
 ====
 Setting `-Xmx` explicitly is requires some care:
 
-* The JVM's overall memory usage will be approximately 4 × the maximum heap as configured by `-Xmx`.
+* The JVM's overall memory usage will be approximately 4 × the maximum heap, as configured by `-Xmx`.
 
 * If `-Xmx` is set without also setting an appropriate Kubernetes
-memory request, it is possible that the container will be killed should the Kubernetes node
+memory limit, it is possible that the container will be killed should the Kubernetes node
 experience memory pressure (from other Pods running on it).
+
+* If `-Xmx` is set without also setting an appropriate Kubernetes
+memory request, it is possible that the container will scheduled to a node with insufficient memory.
+In this case the container will start but crash (immediately if `-Xms` is set to `-Xmx`, or some later time if not).
+
 ====
 
-When `-Xmx` is set explicitly, it is recommended use a memory request that is at least 4.5 × the request heap memory when setting `-Xmx`.
+When setting `-Xmx` explicitly, it is recommended to:
+
+* set the memory request and the memory limit to the same value,
+* use a memory request that is at least 4.5 × the `-Xmx`,
+* consider setting `-Xms` to the same value as `-Xms`.
 
 Furthermore, containers doing lots of disk I/O (such as Kafka broker containers) will need to leave some memory available for use as operating system page cache.
 On such containers, the request memory should be substantially more than the memory used by the JVM.

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
         <junit.version>4.12</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
         <fasterxml.jackson.version>2.9.3</fasterxml.jackson.version>
+        <fasterxml.jackson-annotations.version>2.9.0</fasterxml.jackson-annotations.version>
         <kafka.version>1.0.1</kafka.version>
         <scala-library.version>2.12.3</scala-library.version>
         <zookeeper.version>3.4.10</zookeeper.version>
@@ -115,13 +116,18 @@
                 <version>${fasterxml.jackson.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.fasterxml.jackson.dataformat</groupId>
-                <artifactId>jackson-dataformat-yaml</artifactId>
-                <version>${fasterxml.jackson.version}</version>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>${fasterxml.jackson-annotations.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
+                <version>${fasterxml.jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-yaml</artifactId>
                 <version>${fasterxml.jackson.version}</version>
             </dependency>
             <dependency>

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractClusterIT.java
@@ -188,9 +188,11 @@ public class AbstractClusterIT {
                             + timeout + "; kill %1").out();
     }
 
-    protected void assertResources(String podName, String memoryLimit, String cpuLimit, String memoryRequest, String cpuRequest) {
-        Pod po = client.pods().withName(podName).get();
-        assertNotNull("Expected a pod called " + podName, po);
+    protected void assertResources(String namespace, String podName, String memoryLimit, String cpuLimit, String memoryRequest, String cpuRequest) {
+        Pod po = client.pods().inNamespace(namespace).withName(podName).get();
+        assertNotNull("Expected a pod called " + podName + " but found " +
+            client.pods().list().getItems().stream().map(p -> p.getMetadata().getName()).collect(Collectors.toList()),
+            po);
         Container container = po.getSpec().getContainers().get(0);
         Map<String, Quantity> limits = container.getResources().getLimits();
         assertEquals(memoryLimit, limits.get("memory").getAmount());

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectClusterIT.java
@@ -64,7 +64,7 @@ public class ConnectClusterIT extends AbstractClusterIT {
         })
     public void testJvmAndResources() {
         String podName = kubeClient.list("Pod").stream().filter(n -> n.startsWith("jvm-resource-connect-")).findFirst().get();
-        assertResources(podName,
+        assertResources(NAMESPACE, podName,
                 "400M", "2", "300M", "1");
         assertExpectedJavaOpts(podName,
                 "-Xmx200m", "-Xms200m");

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectClusterIT.java
@@ -5,6 +5,7 @@
 package io.strimzi.systemtest;
 
 import io.strimzi.test.ClusterController;
+import io.strimzi.test.CmData;
 import io.strimzi.test.ConnectCluster;
 import io.strimzi.test.IgnoreIfDef;
 import io.strimzi.test.KafkaCluster;
@@ -51,6 +52,22 @@ public class ConnectClusterIT extends AbstractClusterIT {
     @ConnectCluster(name = "my-cluster", bootstrapServers = BOOTSTRAP_SERVERS)
     public void testDeployUndeploy() {
         LOGGER.info("Looks like the connect cluster my-cluster deployed OK");
+    }
+
+    @Test
+    @ConnectCluster(name = "jvm-resource", bootstrapServers = BOOTSTRAP_SERVERS,
+        nodes = 1,
+        config = {
+                @CmData(key = "resources", value = "{ \"limits\": {\"memory\": \"400M\", \"cpu\": 2}, " +
+                        "\"requests\": {\"memory\": \"300M\", \"cpu\": 1} }"),
+                @CmData(key = "jvmOptions", value = "{\"-Xmx\": \"200m\", \"-Xms\": \"200m\"}")
+        })
+    public void testJvmAndResources() {
+        String podName = kubeClient.list("Pod").stream().filter(n -> n.startsWith("jvm-resource-connect-")).findFirst().get();
+        assertResources(podName,
+                "400M", "2", "300M", "1");
+        assertExpectedJavaOpts(podName,
+                "-Xmx200m", "-Xms200m");
     }
 
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
@@ -17,7 +17,6 @@ import io.strimzi.test.Resources;
 import io.strimzi.test.StrimziRunner;
 import io.strimzi.test.k8s.Oc;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
@@ -318,19 +318,19 @@ public class KafkaClusterIT extends AbstractClusterIT {
     })
     @Test
     public void testJvmAndResources() {
-        assertResources("jvm-resource-cluster-kafka-0",
+        assertResources(NAMESPACE, "jvm-resource-cluster-kafka-0",
                 "2Gi", "400m", "2Gi", "400m");
         assertExpectedJavaOpts("jvm-resource-cluster-kafka-0",
                 "-Xmx1g", "-Xms1G");
 
-        assertResources("jvm-resource-cluster-zookeeper-0",
+        assertResources(NAMESPACE, "jvm-resource-cluster-zookeeper-0",
                 "1G", "300m", "1G", "300m");
         assertExpectedJavaOpts("jvm-resource-cluster-zookeeper-0",
                 "-Xmx600m", "-Xms300m");
 
         String podName = client.pods().list().getItems().stream().filter(p -> p.getMetadata().getName().startsWith("jvm-resource-cluster-topic-controller-")).findFirst().get().getMetadata().getName();
 
-        assertResources(podName,
+        assertResources(NAMESPACE, podName,
                 "500M", "300m", "500M", "300m");
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
@@ -306,7 +306,7 @@ public class KafkaClusterIT extends AbstractClusterIT {
                     value = "{ \"limits\": {\"memory\": \"2Gi\", \"cpu\": 2}, " +
                             "\"requests\": {\"memory\": \"2Gi\", \"cpu\": 2}}"),
             @CmData(key = "kafka-jvmOptions",
-                    value = "{\"-Xmx\": \"512m\", \"-Xms\": \"256m\"}"),
+                    value = "{\"-Xmx\": \"1g\", \"-Xms\": \"1G\"}"),
             @CmData(key = "zookeeper-resources",
                     value = "{ \"limits\": {\"memory\": \"1G\", \"cpu\": 1}, " +
                             "\"requests\": {\"memory\": \"1G\", \"cpu\": 1} }"),
@@ -321,7 +321,7 @@ public class KafkaClusterIT extends AbstractClusterIT {
         assertResources("jvm-resource-cluster-kafka-0",
                 "2Gi", "2", "2Gi", "2");
         assertExpectedJavaOpts("jvm-resource-cluster-kafka-0",
-                "-Xmx512m", "-Xms256m");
+                "-Xmx1g", "-Xms1G");
 
         assertResources("jvm-resource-cluster-zookeeper-0",
                 "1G", "1", "1G", "1");

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
@@ -17,6 +17,7 @@ import io.strimzi.test.Resources;
 import io.strimzi.test.StrimziRunner;
 import io.strimzi.test.k8s.Oc;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
@@ -64,6 +65,7 @@ public class KafkaClusterIT extends AbstractClusterIT {
         //cluster.client().waitForDeployment("strimzi-cluster-controller");
     }
 
+    @Ignore("TODO This test should be disabled for CI, but not for ST")
     @Test
     @IgnoreIfDef("TRAVIS")
     @OpenShiftOnly
@@ -189,6 +191,7 @@ public class KafkaClusterIT extends AbstractClusterIT {
         // TODO Check logs for errors
     }
 
+    @Ignore("TODO This test should be disabled for CI, but not for ST")
     @Test
     @IgnoreIfDef("TRAVIS")
     @KafkaCluster(name = "my-cluster", kafkaNodes = 2, zkNodes = 2, config = {

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
@@ -303,34 +303,34 @@ public class KafkaClusterIT extends AbstractClusterIT {
         zkNodes = 1,
         config = {
             @CmData(key = "kafka-resources",
-                    value = "{ \"limits\": {\"memory\": \"2Gi\", \"cpu\": \"2\"}, " +
-                            "\"requests\": {\"memory\": \"2Gi\", \"cpu\": \"2\"}}"),
+                    value = "{ \"limits\": {\"memory\": \"2Gi\", \"cpu\": \"400m\"}, " +
+                            "\"requests\": {\"memory\": \"2Gi\", \"cpu\": \"400m\"}}"),
             @CmData(key = "kafka-jvmOptions",
                     value = "{\"-Xmx\": \"1g\", \"-Xms\": \"1G\"}"),
             @CmData(key = "zookeeper-resources",
-                    value = "{ \"limits\": {\"memory\": \"1G\", \"cpu\": \"1\"}, " +
-                            "\"requests\": {\"memory\": \"1G\", \"cpu\": \"1\"} }"),
+                    value = "{ \"limits\": {\"memory\": \"1G\", \"cpu\": \"300m\"}, " +
+                            "\"requests\": {\"memory\": \"1G\", \"cpu\": \"300m\"} }"),
             @CmData(key = "zookeeper-jvmOptions",
                     value = "{\"-Xmx\": \"600m\", \"-Xms\": \"300m\"}"),
             @CmData(key = "topic-controller-config",
-                    value = "{\"resources\": { \"limits\": {\"memory\": \"500M\", \"cpu\": \"1\"}, " +
-                            "\"requests\": {\"memory\": \"500M\", \"cpu\": \"1\"} } }")
+                    value = "{\"resources\": { \"limits\": {\"memory\": \"500M\", \"cpu\": \"300m\"}, " +
+                            "\"requests\": {\"memory\": \"500M\", \"cpu\": \"300m\"} } }")
     })
     @Test
     public void testJvmAndResources() {
         assertResources("jvm-resource-cluster-kafka-0",
-                "2Gi", "2", "2Gi", "2");
+                "2Gi", "400m", "2Gi", "400m");
         assertExpectedJavaOpts("jvm-resource-cluster-kafka-0",
                 "-Xmx1g", "-Xms1G");
 
         assertResources("jvm-resource-cluster-zookeeper-0",
-                "1G", "1", "1G", "1");
+                "1G", "300m", "1G", "300m");
         assertExpectedJavaOpts("jvm-resource-cluster-zookeeper-0",
                 "-Xmx600m", "-Xms300m");
 
         String podName = client.pods().list().getItems().stream().filter(p -> p.getMetadata().getName().startsWith("jvm-resource-cluster-topic-controller-")).findFirst().get().getMetadata().getName();
 
         assertResources(podName,
-                "500M", "1", "500M", "1");
+                "500M", "300m", "500M", "300m");
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
@@ -65,7 +65,6 @@ public class KafkaClusterIT extends AbstractClusterIT {
         //cluster.client().waitForDeployment("strimzi-cluster-controller");
     }
 
-    @Ignore("TODO This test should be disabled for CI, but not for ST")
     @Test
     @IgnoreIfDef("TRAVIS")
     @OpenShiftOnly
@@ -191,7 +190,6 @@ public class KafkaClusterIT extends AbstractClusterIT {
         // TODO Check logs for errors
     }
 
-    @Ignore("TODO This test should be disabled for CI, but not for ST")
     @Test
     @IgnoreIfDef("TRAVIS")
     @KafkaCluster(name = "my-cluster", kafkaNodes = 2, zkNodes = 2, config = {

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
@@ -303,18 +303,18 @@ public class KafkaClusterIT extends AbstractClusterIT {
         zkNodes = 1,
         config = {
             @CmData(key = "kafka-resources",
-                    value = "{ \"limits\": {\"memory\": \"2Gi\", \"cpu\": 2}, " +
-                            "\"requests\": {\"memory\": \"2Gi\", \"cpu\": 2}}"),
+                    value = "{ \"limits\": {\"memory\": \"2Gi\", \"cpu\": \"2\"}, " +
+                            "\"requests\": {\"memory\": \"2Gi\", \"cpu\": \"2\"}}"),
             @CmData(key = "kafka-jvmOptions",
                     value = "{\"-Xmx\": \"1g\", \"-Xms\": \"1G\"}"),
             @CmData(key = "zookeeper-resources",
-                    value = "{ \"limits\": {\"memory\": \"1G\", \"cpu\": 1}, " +
-                            "\"requests\": {\"memory\": \"1G\", \"cpu\": 1} }"),
+                    value = "{ \"limits\": {\"memory\": \"1G\", \"cpu\": \"1\"}, " +
+                            "\"requests\": {\"memory\": \"1G\", \"cpu\": \"1\"} }"),
             @CmData(key = "zookeeper-jvmOptions",
                     value = "{\"-Xmx\": \"600m\", \"-Xms\": \"300m\"}"),
             @CmData(key = "topic-controller-config",
-                    value = "{\"resources\": { \"limits\": {\"memory\": \"500M\", \"cpu\": 1}, " +
-                            "\"requests\": {\"memory\": \"500M\", \"cpu\": 1} } }")
+                    value = "{\"resources\": { \"limits\": {\"memory\": \"500M\", \"cpu\": \"1\"}, " +
+                            "\"requests\": {\"memory\": \"500M\", \"cpu\": \"1\"} } }")
     })
     @Test
     public void testJvmAndResources() {

--- a/systemtest/src/test/java/io/strimzi/systemtest/RecoveryClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/RecoveryClusterIT.java
@@ -10,7 +10,6 @@ import io.strimzi.test.IgnoreIfDef;
 import io.strimzi.test.KafkaCluster;
 import io.strimzi.test.Namespace;
 import io.strimzi.test.StrimziRunner;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;

--- a/systemtest/src/test/java/io/strimzi/systemtest/RecoveryClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/RecoveryClusterIT.java
@@ -21,7 +21,6 @@ import static io.strimzi.test.k8s.BaseKubeClient.DEPLOYMENT;
 import static io.strimzi.test.k8s.BaseKubeClient.SERVICE;
 import static io.strimzi.test.k8s.BaseKubeClient.STATEFUL_SET;
 
-@Ignore("TODO This test should be disabled for CI, but not for ST")
 @RunWith(StrimziRunner.class)
 @IgnoreIfDef("TRAVIS")
 @Namespace(RecoveryClusterIT.NAMESPACE)

--- a/systemtest/src/test/java/io/strimzi/systemtest/RecoveryClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/RecoveryClusterIT.java
@@ -10,6 +10,7 @@ import io.strimzi.test.IgnoreIfDef;
 import io.strimzi.test.KafkaCluster;
 import io.strimzi.test.Namespace;
 import io.strimzi.test.StrimziRunner;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
@@ -20,6 +21,7 @@ import static io.strimzi.test.k8s.BaseKubeClient.DEPLOYMENT;
 import static io.strimzi.test.k8s.BaseKubeClient.SERVICE;
 import static io.strimzi.test.k8s.BaseKubeClient.STATEFUL_SET;
 
+@Ignore("TODO This test should be disabled for CI, but not for ST")
 @RunWith(StrimziRunner.class)
 @IgnoreIfDef("TRAVIS")
 @Namespace(RecoveryClusterIT.NAMESPACE)


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR fixes #325, #327 and #328. It allows users to set in the Kafka cluster CM the resource limits for Kafka, Zookeeper and TC containers, and in the Connect CM the resource limits for the Connect container (#325, #327). Is also allow users to set JVM max and initial heap in Kafka, Zookeeper and Kafka Connect containers (#328).

### Checklist

- [ ] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging

