### PR TITLE
Added OpenShift dashboard route for Grafana

### DIFF
--- a/documentation/adoc/appendix_metrics.adoc
+++ b/documentation/adoc/appendix_metrics.adoc
@@ -71,6 +71,13 @@ The Prometheus data source, and the above dashboard, can be set up in Grafana by
 
 NOTE: If your cluster is running using `minikube` or `minishift`, you can use the `port-forward` command for forwarding traffic from the Grafana pod to the host. For example, you can access the Grafana UI by running `oc port-forward grafana-1-fbl7s 3000:3000` (or using `kubectl` instead of `oc`) and then pointing a browser to `http://localhost:3000`.
 
+If the deployment is running on OpenShift, you can expose the Grafana dashboard through a Route with the following command:
+
+[source]
+oc apply -f https://raw.githubusercontent.com/strimzi/strimzi/master/metrics/examples/grafana/openshift-route.yaml
+
+WARNING: There is no specific security provided with the Grafana dashboard. It's accessible just using the default `admin/admin` credentials.
+
 . Access to the Grafana UI using `admin/admin` credentials.
 +
 image::grafana_login.png[Grafana login]

--- a/metrics/examples/grafana/openshift-route.yaml
+++ b/metrics/examples/grafana/openshift-route.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Route
+metadata:
+  name: grafana
+  labels:
+    name: grafana
+spec:
+  to:
+    kind: Service
+    name: grafana
+  port:
+    targetPort: grafana


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

This PR just adds a Route for the Grafana dashboard when the cluster is deployed on OpenShift.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging

