### PR TITLE
Enhanced configuration for Kafka broker

### DIFF
--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/AbstractConfiguration.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/AbstractConfiguration.java
@@ -1,0 +1,84 @@
+package io.strimzi.controller.cluster.model;
+
+import io.strimzi.controller.cluster.operator.resource.StatefulSetDiff;
+import io.vertx.core.json.JsonObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Spliterators;
+
+public abstract class AbstractConfiguration {
+    private static final Logger log = LoggerFactory.getLogger(AbstractConfiguration.class.getName());
+
+    private Map<String, Object> options;
+
+    public AbstractConfiguration(String configurationFile, List<String> FORBIDDEN_OPTIONS) {
+        Map<String, Object> options = new HashMap<String, Object>();
+        String[] lines = configurationFile.split("\n");
+
+        for (String line : lines)   {
+            String key = line.substring(0, line.indexOf("=")).trim();
+            String value = line.substring(line.indexOf("=") + 1).trim();
+            options.put(key, value);
+        }
+
+        this.options = filterForbidden(options, FORBIDDEN_OPTIONS);
+    }
+
+    public AbstractConfiguration(JsonObject jsonOptions, List<String> FORBIDDEN_OPTIONS) {
+        this.options = filterForbidden(jsonOptions.getMap(), FORBIDDEN_OPTIONS);
+    }
+
+    private Map<String, Object> filterForbidden(Map<String, Object> options, List<String> FORBIDDEN_OPTIONS)   {
+        Map<String, Object> filtered = new HashMap<>();
+
+        outer: for (Map.Entry<String, Object> entry : options.entrySet()) {
+            String key = entry.getKey();
+
+            for (String forbiddenKey : FORBIDDEN_OPTIONS) {
+                if (key.toLowerCase().startsWith(forbiddenKey)) {
+                    log.warn("Configuration option \"{}\" is forbidden and will be ignored", key);
+                    continue outer;
+                }
+            }
+
+            log.trace("Configuration option \"{}\" is allowed and will be passed to Kafka", key);
+            filtered.put(entry.getKey(), entry.getValue());
+        }
+
+        return filtered;
+    }
+
+    public String getConfigurationFile() {
+        String configuration = "";
+        final Charset charset = StandardCharsets.UTF_8;
+
+        try {
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            PrintStream printStream = new PrintStream(outputStream, true, charset.name());
+
+            for (Map.Entry<String, Object> entry : options.entrySet()) {
+                printStream.format("%s=%s%n", entry.getKey(), entry.getValue().toString());
+            }
+
+            configuration = new String(outputStream.toByteArray(), charset);
+            printStream.close();
+            outputStream.close();
+        } catch (UnsupportedEncodingException e)    {
+            log.error("Encoding {} is not supported", charset.name(), e);
+        } catch (IOException e)    {
+            log.error("Failed to close stream", e);
+        }
+
+        return configuration;
+    }
+}

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/AbstractConfiguration.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/AbstractConfiguration.java
@@ -60,7 +60,7 @@ public abstract class AbstractConfiguration {
             Object value = json.getValue(key);
 
             if (value instanceof String)    {
-                map.put(key, (String)value);
+                map.put(key, (String) value);
             } else if (value instanceof Integer || value instanceof Long || value instanceof Boolean || value instanceof Double || value instanceof Float)    {
                 map.put(key, String.valueOf(value));
             } else  {

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/AbstractModel.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/AbstractModel.java
@@ -84,6 +84,8 @@ public abstract class AbstractModel {
 
     protected Storage storage;
 
+    protected AbstractConfiguration configuration;
+
     protected String mountPath;
     public static final String VOLUME_NAME = "data";
     protected String metricsConfigVolumeName;
@@ -201,6 +203,14 @@ public abstract class AbstractModel {
 
     protected void setStorage(Storage storage) {
         this.storage = storage;
+    }
+
+    public AbstractConfiguration getConfiguration() {
+        return configuration;
+    }
+
+    protected void setConfiguration(AbstractConfiguration configuration) {
+        this.configuration = configuration;
     }
 
     public String getVolumeName() {

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/AbstractModel.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/AbstractModel.java
@@ -205,10 +205,20 @@ public abstract class AbstractModel {
         this.storage = storage;
     }
 
+    /**
+     * Returns the Configuration object which is passed to the cluster as EnvVar
+     *
+     * @return  Configuration object with cluster configuration
+     */
     public AbstractConfiguration getConfiguration() {
         return configuration;
     }
 
+    /**
+     * Set the configuration object which might be passed to the cluster as EnvVar
+     *
+     * @param configuration Configuration object with cluster configuration
+     */
     protected void setConfiguration(AbstractConfiguration configuration) {
         this.configuration = configuration;
     }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/KafkaCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/KafkaCluster.java
@@ -37,9 +37,6 @@ public class KafkaCluster extends AbstractModel {
 
     // Kafka configuration
     private String zookeeperConnect = DEFAULT_KAFKA_ZOOKEEPER_CONNECT;
-    private int defaultReplicationFactor = DEFAULT_KAFKA_DEFAULT_REPLICATION_FACTOR;
-    private int offsetsTopicReplicationFactor = DEFAULT_KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR;
-    private int transactionStateLogReplicationFactor = DEFAULT_KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR;
 
     // Configuration defaults
     private static final String DEFAULT_IMAGE =
@@ -52,24 +49,20 @@ public class KafkaCluster extends AbstractModel {
 
     // Kafka configuration defaults
     private static final String DEFAULT_KAFKA_ZOOKEEPER_CONNECT = "zookeeper:2181";
-    private static final int DEFAULT_KAFKA_DEFAULT_REPLICATION_FACTOR = 3;
-    private static final int DEFAULT_KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR = 3;
-    private static final int DEFAULT_KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR = 3;
 
-    // Configuration keys
+    // Configuration keys (in ConfigMap)
     public static final String KEY_IMAGE = "kafka-image";
     public static final String KEY_REPLICAS = "kafka-nodes";
     public static final String KEY_HEALTHCHECK_DELAY = "kafka-healthcheck-delay";
     public static final String KEY_HEALTHCHECK_TIMEOUT = "kafka-healthcheck-timeout";
     public static final String KEY_METRICS_CONFIG = "kafka-metrics-config";
     public static final String KEY_STORAGE = "kafka-storage";
+    public static final String KEY_KAFKA_CONFIG = "kafka-config";
 
-    // Kafka configuration keys
+    // Kafka configuration keys (EnvVariables)
     public static final String KEY_KAFKA_ZOOKEEPER_CONNECT = "KAFKA_ZOOKEEPER_CONNECT";
-    public static final String KEY_KAFKA_DEFAULT_REPLICATION_FACTOR = "KAFKA_DEFAULT_REPLICATION_FACTOR";
-    public static final String KEY_KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR = "KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR";
-    public static final String KEY_KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR = "KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR";
     private static final String KEY_KAFKA_METRICS_ENABLED = "KAFKA_METRICS_ENABLED";
+    private static final String KEY_KAFKA_USER_CONFIGURATION = "KAFKA_USER_CONFIGURATION";
 
     /**
      * Constructor
@@ -129,9 +122,6 @@ public class KafkaCluster extends AbstractModel {
         kafka.setHealthCheckTimeout(Integer.parseInt(data.getOrDefault(KEY_HEALTHCHECK_TIMEOUT, String.valueOf(DEFAULT_HEALTHCHECK_TIMEOUT))));
 
         kafka.setZookeeperConnect(data.getOrDefault(KEY_KAFKA_ZOOKEEPER_CONNECT, kafkaClusterCm.getMetadata().getName() + "-zookeeper:2181"));
-        kafka.setDefaultReplicationFactor(Integer.parseInt(data.getOrDefault(KEY_KAFKA_DEFAULT_REPLICATION_FACTOR, String.valueOf(DEFAULT_KAFKA_DEFAULT_REPLICATION_FACTOR))));
-        kafka.setOffsetsTopicReplicationFactor(Integer.parseInt(data.getOrDefault(KEY_KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR, String.valueOf(DEFAULT_KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR))));
-        kafka.setTransactionStateLogReplicationFactor(Integer.parseInt(data.getOrDefault(KEY_KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR, String.valueOf(DEFAULT_KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR))));
 
         String metricsConfig = data.get(KEY_METRICS_CONFIG);
         kafka.setMetricsEnabled(metricsConfig != null);
@@ -141,6 +131,11 @@ public class KafkaCluster extends AbstractModel {
 
         String storageConfig = data.get(KEY_STORAGE);
         kafka.setStorage(Storage.fromJson(new JsonObject(storageConfig)));
+
+        String kafkaConfig = data.get(KEY_KAFKA_CONFIG);
+        if (kafkaConfig != null) {
+            kafka.setConfiguration(new KafkaConfiguration(new JsonObject(kafkaConfig)));
+        }
 
         return kafka;
     }
@@ -166,9 +161,6 @@ public class KafkaCluster extends AbstractModel {
         Map<String, String> vars = containerEnvVars(container);
 
         kafka.setZookeeperConnect(vars.getOrDefault(KEY_KAFKA_ZOOKEEPER_CONNECT, ss.getMetadata().getName() + "-zookeeper:2181"));
-        kafka.setDefaultReplicationFactor(Integer.parseInt(vars.getOrDefault(KEY_KAFKA_DEFAULT_REPLICATION_FACTOR, String.valueOf(DEFAULT_KAFKA_DEFAULT_REPLICATION_FACTOR))));
-        kafka.setOffsetsTopicReplicationFactor(Integer.parseInt(vars.getOrDefault(KEY_KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR, String.valueOf(DEFAULT_KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR))));
-        kafka.setTransactionStateLogReplicationFactor(Integer.parseInt(vars.getOrDefault(KEY_KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR, String.valueOf(DEFAULT_KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR))));
 
         kafka.setMetricsEnabled(Boolean.parseBoolean(vars.getOrDefault(KEY_KAFKA_METRICS_ENABLED, String.valueOf(DEFAULT_KAFKA_METRICS_ENABLED))));
         if (kafka.isMetricsEnabled()) {
@@ -187,6 +179,8 @@ public class KafkaCluster extends AbstractModel {
             Storage storage = new Storage(Storage.StorageType.EPHEMERAL);
             kafka.setStorage(storage);
         }
+
+        kafka.setConfiguration(new KafkaConfiguration(vars.getOrDefault(KEY_KAFKA_USER_CONFIGURATION, "")));
 
         return kafka;
     }
@@ -295,27 +289,13 @@ public class KafkaCluster extends AbstractModel {
     protected List<EnvVar> getEnvVars() {
         List<EnvVar> varList = new ArrayList<>();
         varList.add(buildEnvVar(KEY_KAFKA_ZOOKEEPER_CONNECT, zookeeperConnect));
-        varList.add(buildEnvVar(KEY_KAFKA_DEFAULT_REPLICATION_FACTOR, String.valueOf(defaultReplicationFactor)));
-        varList.add(buildEnvVar(KEY_KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR, String.valueOf(offsetsTopicReplicationFactor)));
-        varList.add(buildEnvVar(KEY_KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR, String.valueOf(transactionStateLogReplicationFactor)));
         varList.add(buildEnvVar(KEY_KAFKA_METRICS_ENABLED, String.valueOf(isMetricsEnabled)));
+        varList.add(buildEnvVar(KEY_KAFKA_USER_CONFIGURATION, configuration.getConfigurationFile()));
 
         return varList;
     }
 
     protected void setZookeeperConnect(String zookeeperConnect) {
         this.zookeeperConnect = zookeeperConnect;
-    }
-
-    protected void setDefaultReplicationFactor(int defaultReplicationFactor) {
-        this.defaultReplicationFactor = defaultReplicationFactor;
-    }
-
-    protected void setOffsetsTopicReplicationFactor(int offsetsTopicReplicationFactor) {
-        this.offsetsTopicReplicationFactor = offsetsTopicReplicationFactor;
-    }
-
-    protected void setTransactionStateLogReplicationFactor(int transactionStateLogReplicationFactor) {
-        this.transactionStateLogReplicationFactor = transactionStateLogReplicationFactor;
     }
 }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/KafkaCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/KafkaCluster.java
@@ -62,7 +62,7 @@ public class KafkaCluster extends AbstractModel {
     // Kafka configuration keys (EnvVariables)
     public static final String KEY_KAFKA_ZOOKEEPER_CONNECT = "KAFKA_ZOOKEEPER_CONNECT";
     private static final String KEY_KAFKA_METRICS_ENABLED = "KAFKA_METRICS_ENABLED";
-    private static final String KEY_KAFKA_USER_CONFIGURATION = "KAFKA_USER_CONFIGURATION";
+    protected static final String KEY_KAFKA_USER_CONFIGURATION = "KAFKA_USER_CONFIGURATION";
 
     /**
      * Constructor
@@ -290,7 +290,10 @@ public class KafkaCluster extends AbstractModel {
         List<EnvVar> varList = new ArrayList<>();
         varList.add(buildEnvVar(KEY_KAFKA_ZOOKEEPER_CONNECT, zookeeperConnect));
         varList.add(buildEnvVar(KEY_KAFKA_METRICS_ENABLED, String.valueOf(isMetricsEnabled)));
-        varList.add(buildEnvVar(KEY_KAFKA_USER_CONFIGURATION, configuration.getConfigurationFile()));
+
+        if (configuration != null) {
+            varList.add(buildEnvVar(KEY_KAFKA_USER_CONFIGURATION, configuration.getConfiguration()));
+        }
 
         return varList;
     }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/KafkaConfiguration.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/KafkaConfiguration.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2017-2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
 package io.strimzi.controller.cluster.model;
 
 import io.vertx.core.json.JsonObject;
@@ -6,6 +11,9 @@ import java.util.List;
 
 import static java.util.Arrays.asList;
 
+/**
+ * Class for handling Kafka configuration passed by the user
+ */
 public class KafkaConfiguration extends AbstractConfiguration {
     private static final List<String> FORBIDDEN_OPTIONS;
 
@@ -24,10 +32,23 @@ public class KafkaConfiguration extends AbstractConfiguration {
                 "super.user");
     }
 
-    public KafkaConfiguration(String configurationFile) {
-        super(configurationFile, FORBIDDEN_OPTIONS);
+    /**
+     * Constructor used to instantiate this class from String configuration. Should be used to create configuration
+     * from the Assembly.
+     *
+     * @param configuration Configuration in String format. Should contain zero or more lines with with key=value
+     *                      pairs.
+     */
+    public KafkaConfiguration(String configuration) {
+        super(configuration, FORBIDDEN_OPTIONS);
     }
 
+    /**
+     * Constructor used to instantiate this class from JsonObject. Should be used to create configuration from
+     * ConfigMap / CRD.
+     *
+     * @param jsonOptions     Json object with configuration options as key ad value pairs.
+     */
     public KafkaConfiguration(JsonObject jsonOptions) {
         super(jsonOptions, FORBIDDEN_OPTIONS);
     }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/KafkaConfiguration.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/KafkaConfiguration.java
@@ -1,0 +1,34 @@
+package io.strimzi.controller.cluster.model;
+
+import io.vertx.core.json.JsonObject;
+
+import java.util.List;
+
+import static java.util.Arrays.asList;
+
+public class KafkaConfiguration extends AbstractConfiguration {
+    private static final List<String> FORBIDDEN_OPTIONS;
+
+    static {
+        FORBIDDEN_OPTIONS = asList(
+                "listeners",
+                "advertised.listeners",
+                "broker.id",
+                "listener.",
+                "inter.broker.listener.name",
+                "sasl.",
+                "ssl.",
+                "log.dirs",
+                "zookeeper.connect",
+                "authorizer.",
+                "super.user");
+    }
+
+    public KafkaConfiguration(String configurationFile) {
+        super(configurationFile, FORBIDDEN_OPTIONS);
+    }
+
+    public KafkaConfiguration(JsonObject jsonOptions) {
+        super(jsonOptions, FORBIDDEN_OPTIONS);
+    }
+}

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/KafkaConfiguration.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/KafkaConfiguration.java
@@ -20,14 +20,20 @@ public class KafkaConfiguration extends AbstractConfiguration {
     static {
         FORBIDDEN_OPTIONS = asList(
                 "listeners",
-                "advertised.listeners",
-                "broker.id",
+                "advertised.",
+                "broker.",
                 "listener.",
+                "host.name",
+                "port",
                 "inter.broker.listener.name",
                 "sasl.",
                 "ssl.",
-                "log.dirs",
+                "security.",
+                "password.",
+                "principal.builder.class",
+                "log.dir",
                 "zookeeper.connect",
+                "zookeeper.set.acl",
                 "authorizer.",
                 "super.user");
     }

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/ResourceUtils.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/ResourceUtils.java
@@ -52,19 +52,31 @@ public class ResourceUtils {
      * @return
      */
     public static ConfigMap createKafkaClusterConfigMap(String clusterCmNamespace, String clusterCmName, int replicas,
-                                                        String image, int healthDelay, int healthTimeout, String metricsCmJson) {
-        return createKafkaClusterConfigMap(clusterCmNamespace, clusterCmName, replicas, image, healthDelay, healthTimeout, metricsCmJson,
+                                                        String image, int healthDelay, int healthTimeout,
+                                                        String metricsCmJson) {
+        return createKafkaClusterConfigMap(clusterCmNamespace, clusterCmName, replicas, image, healthDelay,
+                healthTimeout, metricsCmJson, "",
                 "{\"type\": \"ephemeral\"}", null);
     }
     public static ConfigMap createKafkaClusterConfigMap(String clusterCmNamespace, String clusterCmName, int replicas,
-                                                        String image, int healthDelay, int healthTimeout, String metricsCmJson, String storage) {
-        return createKafkaClusterConfigMap(clusterCmNamespace, clusterCmName, replicas, image, healthDelay, healthTimeout, metricsCmJson,
+                                                        String image, int healthDelay, int healthTimeout,
+                                                        String metricsCmJson, String kafkaConfigurationJson) {
+        return createKafkaClusterConfigMap(clusterCmNamespace, clusterCmName, replicas, image, healthDelay,
+                healthTimeout, metricsCmJson, kafkaConfigurationJson,
+                "{\"type\": \"ephemeral\"}", null);
+    }
+    public static ConfigMap createKafkaClusterConfigMap(String clusterCmNamespace, String clusterCmName, int replicas,
+                                                        String image, int healthDelay, int healthTimeout,
+                                                        String metricsCmJson, String kafkaConfigurationJson,
+                                                        String storage) {
+        return createKafkaClusterConfigMap(clusterCmNamespace, clusterCmName, replicas, image, healthDelay,
+                healthTimeout, metricsCmJson, kafkaConfigurationJson,
                 storage, null);
     }
 
     public static ConfigMap createKafkaClusterConfigMap(String clusterCmNamespace, String clusterCmName, int replicas,
                                                         String image, int healthDelay, int healthTimeout, String metricsCmJson,
-                                                        String storage, String topicController) {
+                                                        String kafkaConfigurationJson, String storage, String topicController) {
         Map<String, String> cmData = new HashMap<>();
         cmData.put(KafkaCluster.KEY_REPLICAS, Integer.toString(replicas));
         cmData.put(KafkaCluster.KEY_IMAGE, image);
@@ -72,6 +84,7 @@ public class ResourceUtils {
         cmData.put(KafkaCluster.KEY_HEALTHCHECK_TIMEOUT, Integer.toString(healthTimeout));
         cmData.put(KafkaCluster.KEY_STORAGE, storage);
         cmData.put(KafkaCluster.KEY_METRICS_CONFIG, metricsCmJson);
+        cmData.put(KafkaCluster.KEY_KAFKA_CONFIG, kafkaConfigurationJson);
         cmData.put(ZookeeperCluster.KEY_REPLICAS, Integer.toString(replicas));
         cmData.put(ZookeeperCluster.KEY_IMAGE, image + "-zk");
         cmData.put(ZookeeperCluster.KEY_HEALTHCHECK_DELAY, Integer.toString(healthDelay));

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/model/KafkaClusterTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/model/KafkaClusterTest.java
@@ -5,13 +5,10 @@
 package io.strimzi.controller.cluster.model;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
-import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.extensions.StatefulSet;
 import io.strimzi.controller.cluster.ResourceUtils;
 import org.junit.Test;
-
-import java.util.List;
 
 import static io.strimzi.controller.cluster.ResourceUtils.labels;
 import static org.junit.Assert.assertEquals;
@@ -105,19 +102,7 @@ public class KafkaClusterTest {
         assertEquals(new Integer(healthDelay), ss.getSpec().getTemplate().getSpec().getContainers().get(0).getLivenessProbe().getInitialDelaySeconds());
         assertEquals(new Integer(healthTimeout), ss.getSpec().getTemplate().getSpec().getContainers().get(0).getReadinessProbe().getTimeoutSeconds());
         assertEquals(new Integer(healthDelay), ss.getSpec().getTemplate().getSpec().getContainers().get(0).getReadinessProbe().getInitialDelaySeconds());
-        assertEquals("foo=bar\n", findEnvVar(ss, KafkaCluster.KEY_KAFKA_USER_CONFIGURATION));
-    }
-
-    private String findEnvVar(StatefulSet ss, String envVarName) {
-        List<EnvVar> env = ss.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv();
-
-        for (EnvVar envVar : env)   {
-            if (envVar.getName().equals(envVarName))    {
-                return envVar.getValue();
-            }
-        }
-
-        return null;
+        assertEquals("foo=bar\n", AbstractModel.containerEnvVars(ss.getSpec().getTemplate().getSpec().getContainers().get(0)).get(KafkaCluster.KEY_KAFKA_USER_CONFIGURATION));
     }
 
     /**

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/model/KafkaClusterTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/model/KafkaClusterTest.java
@@ -5,10 +5,13 @@
 package io.strimzi.controller.cluster.model;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.extensions.StatefulSet;
 import io.strimzi.controller.cluster.ResourceUtils;
 import org.junit.Test;
+
+import java.util.List;
 
 import static io.strimzi.controller.cluster.ResourceUtils.labels;
 import static org.junit.Assert.assertEquals;
@@ -22,7 +25,8 @@ public class KafkaClusterTest {
     private final int healthDelay = 120;
     private final int healthTimeout = 30;
     private final String metricsCmJson = "{\"animal\":\"wombat\"}";
-    private final ConfigMap cm = ResourceUtils.createKafkaClusterConfigMap(namespace, cluster, replicas, image, healthDelay, healthTimeout, metricsCmJson);
+    private final String configurationJson = "{\"foo\":\"bar\"}";
+    private final ConfigMap cm = ResourceUtils.createKafkaClusterConfigMap(namespace, cluster, replicas, image, healthDelay, healthTimeout, metricsCmJson, configurationJson);
     private final KafkaCluster kc = KafkaCluster.fromConfigMap(cm);
 
     @Test
@@ -101,6 +105,19 @@ public class KafkaClusterTest {
         assertEquals(new Integer(healthDelay), ss.getSpec().getTemplate().getSpec().getContainers().get(0).getLivenessProbe().getInitialDelaySeconds());
         assertEquals(new Integer(healthTimeout), ss.getSpec().getTemplate().getSpec().getContainers().get(0).getReadinessProbe().getTimeoutSeconds());
         assertEquals(new Integer(healthDelay), ss.getSpec().getTemplate().getSpec().getContainers().get(0).getReadinessProbe().getInitialDelaySeconds());
+        assertEquals("foo=bar\n", findEnvVar(ss, KafkaCluster.KEY_KAFKA_USER_CONFIGURATION));
+    }
+
+    private String findEnvVar(StatefulSet ss, String envVarName) {
+        List<EnvVar> env = ss.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv();
+
+        for (EnvVar envVar : env)   {
+            if (envVar.getName().equals(envVarName))    {
+                return envVar.getValue();
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/model/KafkaConfigurationTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/model/KafkaConfigurationTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2017-2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.strimzi.controller.cluster.model;
+
+import io.vertx.core.json.JsonObject;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class KafkaConfigurationTest {
+    @Test
+    public void testEmptyConfigurationString() {
+        String configuration = "";
+        AbstractConfiguration config = new KafkaConfiguration(configuration);
+        assertTrue(config.getConfiguration().isEmpty());
+    }
+
+    @Test
+    public void testEmptyJson() {
+        JsonObject configuration = new JsonObject();
+        AbstractConfiguration config = new KafkaConfiguration(configuration);
+        assertTrue(config.getConfiguration().isEmpty());
+    }
+
+    @Test
+    public void testNonEmptyConfigurationString() {
+        String configuration = "var1=aaa\n" +
+                               "var2=bbb\n" +
+                               "var3=ccc\n";
+        String expectedConfiguration = "var3=ccc\n" +
+                               "var2=bbb\n" +
+                               "var1=aaa\n";
+
+        AbstractConfiguration config = new KafkaConfiguration(configuration);
+        assertEquals(expectedConfiguration, config.getConfiguration());
+    }
+
+    @Test
+    public void testNonEmptyJson() {
+        JsonObject configuration = new JsonObject().put("var1", "aaa").put("var2", "bbb").put("var3", "ccc");
+        String expectedConfiguration = "var3=ccc\n" +
+                "var2=bbb\n" +
+                "var1=aaa\n";
+
+        AbstractConfiguration config = new KafkaConfiguration(configuration);
+        assertEquals(expectedConfiguration, config.getConfiguration());
+    }
+
+    @Test
+    public void testConfigurationStringWithDuplicates() {
+        String configuration = "var1=aaa\n" +
+                "var2=bbb\n" +
+                "var3=ccc\n" +
+                "var2=ddd\n";
+        String expectedConfiguration = "var3=ccc\n" +
+                "var2=ddd\n" +
+                "var1=aaa\n";
+
+        AbstractConfiguration config = new KafkaConfiguration(configuration);
+        assertEquals(expectedConfiguration, config.getConfiguration());
+    }
+
+    @Test
+    public void testJsonWithDuplicates() {
+        JsonObject configuration = new JsonObject().put("var1", "aaa").put("var2", "bbb").put("var3", "ccc").put("var2", "ddd");
+        String expectedConfiguration = "var3=ccc\n" +
+                "var2=ddd\n" +
+                "var1=aaa\n";
+
+        AbstractConfiguration config = new KafkaConfiguration(configuration);
+        assertEquals(expectedConfiguration, config.getConfiguration());
+    }
+
+    @Test
+    public void testConfigurationStringWithForbiddenKeys() {
+        String configuration = "var1=aaa\n" +
+                "var2=bbb\n" +
+                "var3=ccc\n" +
+                "advertised.listeners=ddd\n";
+        String expectedConfiguration = "var3=ccc\n" +
+                "var2=bbb\n" +
+                "var1=aaa\n";
+
+        AbstractConfiguration config = new KafkaConfiguration(configuration);
+        assertEquals(expectedConfiguration, config.getConfiguration());
+    }
+
+    @Test
+    public void testJsonWithForbiddenKeys() {
+        JsonObject configuration = new JsonObject().put("var1", "aaa").put("var2", "bbb").put("var3", "ccc").put("advertised.listeners", "ddd");
+        String expectedConfiguration = "var3=ccc\n" +
+                "var2=bbb\n" +
+                "var1=aaa\n";
+
+        AbstractConfiguration config = new KafkaConfiguration(configuration);
+        assertEquals(expectedConfiguration, config.getConfiguration());
+    }
+
+    @Test
+    public void testJsonWithDifferentTypes() {
+        JsonObject configuration = new JsonObject().put("var1", 1).put("var2", "bbb").put("var3", new JsonObject().put("xxx", "yyy"));
+        String expectedConfiguration = "var2=bbb\n" +
+                "var1=1\n";
+
+        AbstractConfiguration config = new KafkaConfiguration(configuration);
+        assertEquals(expectedConfiguration, config.getConfiguration());
+    }
+}

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/model/KafkaConfigurationTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/model/KafkaConfigurationTest.java
@@ -90,6 +90,20 @@ public class KafkaConfigurationTest {
     }
 
     @Test
+    public void testConfigurationStringWithForbiddenKeysInUpperCase() {
+        String configuration = "var1=aaa\n" +
+                "var2=bbb\n" +
+                "var3=ccc\n" +
+                "HOST.NAME=ddd\n";
+        String expectedConfiguration = "var3=ccc\n" +
+                "var2=bbb\n" +
+                "var1=aaa\n";
+
+        AbstractConfiguration config = new KafkaConfiguration(configuration);
+        assertEquals(expectedConfiguration, config.getConfiguration());
+    }
+
+    @Test
     public void testJsonWithForbiddenKeys() {
         JsonObject configuration = new JsonObject().put("var1", "aaa").put("var2", "bbb").put("var3", "ccc").put("advertised.listeners", "ddd");
         String expectedConfiguration = "var3=ccc\n" +

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/model/TopicControllerTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/model/TopicControllerTest.java
@@ -26,6 +26,7 @@ public class TopicControllerTest {
     private final int healthDelay = 120;
     private final int healthTimeout = 30;
     private final String metricsCmJson = "{\"animal\":\"wombat\"}";
+    private final String kafkaJson = "{\"foo\":\"bar\"}";
     private final String storageJson = "{\"type\": \"ephemeral\"}";
 
     private final String tcWatchedNamespace = "my-topic-namespace";
@@ -42,7 +43,7 @@ public class TopicControllerTest {
             "\"topicMetadataMaxAttempts\":" + tcTopicMetadataMaxAttempts +
             " }";
 
-    private final ConfigMap cm = ResourceUtils.createKafkaClusterConfigMap(namespace, cluster, replicas, image, healthDelay, healthTimeout, metricsCmJson, storageJson, topicControllerJson);
+    private final ConfigMap cm = ResourceUtils.createKafkaClusterConfigMap(namespace, cluster, replicas, image, healthDelay, healthTimeout, metricsCmJson, kafkaJson, storageJson, topicControllerJson);
     private final TopicController tc = TopicController.fromConfigMap(cm);
 
     private List<EnvVar> getExpectedEnvVars() {
@@ -70,7 +71,7 @@ public class TopicControllerTest {
     @Test
     public void testFromConfigMapDefaultConfig() {
 
-        ConfigMap cm = ResourceUtils.createKafkaClusterConfigMap(namespace, cluster, replicas, image, healthDelay, healthTimeout, metricsCmJson, storageJson, "{ }");
+        ConfigMap cm = ResourceUtils.createKafkaClusterConfigMap(namespace, cluster, replicas, image, healthDelay, healthTimeout, metricsCmJson, kafkaJson, storageJson, "{ }");
         TopicController tc = TopicController.fromConfigMap(cm);
 
         assertEquals(TopicController.DEFAULT_IMAGE, tc.getImage());

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -70,6 +70,7 @@ public class KafkaAssemblyOperatorTest {
     public static final String METRICS_CONFIG = "{\"foo\":\"bar\"}";
     private final boolean openShift;
     private final boolean metrics;
+    private final String kafkaConfig;
     private final String storage;
     private final String tcConfig;
     private final boolean deleteClaim;
@@ -77,12 +78,14 @@ public class KafkaAssemblyOperatorTest {
     public static class Params {
         private final boolean openShift;
         private final boolean metrics;
+        private final String kafkaConfig;
         private final String storage;
         private final String tcConfig;
 
-        public Params(boolean openShift, boolean metrics, String storage, String tcConfig) {
+        public Params(boolean openShift, boolean metrics, String kafkaConfig, String storage, String tcConfig) {
             this.openShift = openShift;
             this.metrics = metrics;
+            this.kafkaConfig = kafkaConfig;
             this.storage = storage;
             this.tcConfig = tcConfig;
         }
@@ -90,6 +93,7 @@ public class KafkaAssemblyOperatorTest {
         public String toString() {
             return "openShift=" + openShift +
                     ",metrics=" + metrics +
+                    ",kafkaConfig=" + kafkaConfig +
                     ",storage=" + storage +
                     ",tcConfig=" + tcConfig;
         }
@@ -109,6 +113,11 @@ public class KafkaAssemblyOperatorTest {
                     "\"size\": \"123\", " +
                     "\"class\": \"foo\"}"
         };
+        String[] kafkaConfigs = {
+            null,
+            "{ }",
+            "{\"foo\": \"bar\"}"
+        };
         String[] tcConfigs = {
             null,
             "{ }",
@@ -118,9 +127,11 @@ public class KafkaAssemblyOperatorTest {
         List<Params> result = new ArrayList();
         for (boolean shift: shiftiness) {
             for (boolean metric: metrics) {
-                for (String storage: storageConfigs) {
-                    for (String tcConfig: tcConfigs) {
-                        result.add(new Params(shift, metric, storage, tcConfig));
+                for (String kafkaConfig: kafkaConfigs) {
+                    for (String storage : storageConfigs) {
+                        for (String tcConfig : tcConfigs) {
+                            result.add(new Params(shift, metric, kafkaConfig, storage, tcConfig));
+                        }
                     }
                 }
             }
@@ -131,6 +142,7 @@ public class KafkaAssemblyOperatorTest {
     public KafkaAssemblyOperatorTest(Params params) {
         this.openShift = params.openShift;
         this.metrics = params.metrics;
+        this.kafkaConfig = params.kafkaConfig;
         this.storage = params.storage;
         this.tcConfig = params.tcConfig;
         this.deleteClaim = Storage.fromJson(new JsonObject(params.storage)).isDeleteClaim();
@@ -371,7 +383,7 @@ public class KafkaAssemblyOperatorTest {
         int healthDelay = 120;
         int healthTimeout = 30;
         String metricsCmJson = metrics ? METRICS_CONFIG : null;
-        return ResourceUtils.createKafkaClusterConfigMap(clusterCmNamespace, clusterCmName, replicas, image, healthDelay, healthTimeout, metricsCmJson, storage, tcConfig);
+        return ResourceUtils.createKafkaClusterConfigMap(clusterCmNamespace, clusterCmName, replicas, image, healthDelay, healthTimeout, metricsCmJson, kafkaConfig, storage, tcConfig);
     }
 
     private static <T> Set<T> set(T... elements) {

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/operator/resource/KafkaSetOperatorTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/operator/resource/KafkaSetOperatorTest.java
@@ -16,9 +16,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static io.strimzi.controller.cluster.model.AbstractModel.containerEnvVars;
-import static io.strimzi.controller.cluster.model.KafkaCluster.KEY_KAFKA_DEFAULT_REPLICATION_FACTOR;
-import static io.strimzi.controller.cluster.model.KafkaCluster.KEY_KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR;
-import static io.strimzi.controller.cluster.model.KafkaCluster.KEY_KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR;
 import static io.strimzi.controller.cluster.model.KafkaCluster.KEY_KAFKA_ZOOKEEPER_CONNECT;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -97,30 +94,6 @@ public class KafkaSetOperatorTest {
     @Test
     public void testNeedsRollingUpdateEnvZkConnect() {
         String envVar = KEY_KAFKA_ZOOKEEPER_CONNECT;
-        a.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv().add(new EnvVar(envVar,
-                containerEnvVars(a.getSpec().getTemplate().getSpec().getContainers().get(0)).get(envVar) + "-foo", null));
-        assertTrue(KafkaSetOperator.needsRollingUpdate(diff()));
-    }
-
-    @Test
-    public void testNeedsRollingUpdateEnvDefaultRepFactor() {
-        String envVar = KEY_KAFKA_DEFAULT_REPLICATION_FACTOR;
-        a.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv().add(new EnvVar(envVar,
-                containerEnvVars(a.getSpec().getTemplate().getSpec().getContainers().get(0)).get(envVar) + "-foo", null));
-        assertTrue(KafkaSetOperator.needsRollingUpdate(diff()));
-    }
-
-    @Test
-    public void testNeedsRollingUpdateEnvOffsetsRepFactor() {
-        String envVar = KEY_KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR;
-        a.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv().add(new EnvVar(envVar,
-                containerEnvVars(a.getSpec().getTemplate().getSpec().getContainers().get(0)).get(envVar) + "-foo", null));
-        assertTrue(KafkaSetOperator.needsRollingUpdate(diff()));
-    }
-
-    @Test
-    public void testNeedsRollingUpdateEnvTxnRepFactor() {
-        String envVar = KEY_KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR;
         a.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv().add(new EnvVar(envVar,
                 containerEnvVars(a.getSpec().getTemplate().getSpec().getContainers().get(0)).get(envVar) + "-foo", null));
         assertTrue(KafkaSetOperator.needsRollingUpdate(diff()));

--- a/docker-images/kafka/scripts/kafka_config_generator.sh
+++ b/docker-images/kafka/scripts/kafka_config_generator.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+CONFIG_FILE=$1
+
+# Write the config file
+cat > ${CONFIG_FILE:-/tmp/strimzi.properties} <<EOF
+broker.id=${KAFKA_BROKER_ID}
+# Listeners
+listeners=CLIENT://0.0.0.0:9092,REPLICATION://0.0.0.0:9091
+advertised.listeners=CLIENT://$(hostname -f):9092,REPLICATION://$(hostname -f):9091
+listener.security.protocol.map=CLIENT:PLAINTEXT,REPLICATION:PLAINTEXT
+inter.broker.listener.name=REPLICATION
+# Zookeeper
+zookeeper.connect=${KAFKA_ZOOKEEPER_CONNECT:-zookeeper:2181}
+zookeeper.connection.timeout.ms=6000
+# Logs
+log.dirs=${KAFKA_LOG_DIRS}
+# User provided settings
+${KAFKA_USER_CONFIGURATION}
+EOF

--- a/docker-images/kafka/scripts/kafka_run.sh
+++ b/docker-images/kafka/scripts/kafka_run.sh
@@ -34,37 +34,8 @@ fi
 # directory avoids trying to create it (and logging a permission denied error)
 export LOG_DIR="$KAFKA_HOME"
 
-# Write the config file
-cat > /tmp/strimzi.properties <<EOF
-broker.id=${KAFKA_BROKER_ID}
-# Listeners
-listeners=CLIENT://0.0.0.0:9092,REPLICATION://0.0.0.0:9091
-advertised.listeners=CLIENT://$(hostname -f):9092,REPLICATION://$(hostname -f):9091
-listener.security.protocol.map=CLIENT:PLAINTEXT,REPLICATION:PLAINTEXT
-inter.broker.listener.name=REPLICATION
-# Zookeeper
-zookeeper.connect=${KAFKA_ZOOKEEPER_CONNECT:-zookeeper:2181}
-zookeeper.connection.timeout.ms=6000
-# Logs
-log.dirs=${KAFKA_LOG_DIRS}
-num.partitions=1
-num.recovery.threads.per.data.dir=1
-default.replication.factor=${KAFKA_DEFAULT_REPLICATION_FACTOR:-1}
-offsets.topic.replication.factor=${KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR:-3}
-transaction.state.log.replication.factor=${KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR:-3}
-transaction.state.log.min.isr=1
-log.retention.hours=168
-log.segment.bytes=1073741824
-log.retention.check.interval.ms=300000
-# Network
-num.network.threads=3
-num.io.threads=8
-socket.send.buffer.bytes=102400
-socket.receive.buffer.bytes=102400
-socket.request.max.bytes=104857600
-# Other
-group.initial.rebalance.delay.ms=0
-EOF
+# Generate the config file
+./kafka_config_generator.sh /tmp/strimzi.properties
 
 echo "Starting Kafka with configuration:"
 cat /tmp/strimzi.properties

--- a/documentation/adoc/cluster-controller.adoc
+++ b/documentation/adoc/cluster-controller.adoc
@@ -74,14 +74,11 @@ Default is determined by the value of the
 environment variable of the Cluster Controller.
 * `zookeeper-healthcheck-delay`: the initial delay for the liveness and readiness probes for each Zookeeper node. Default is 15
 * `zookeeper-healthcheck-timeout`: the timeout on the liveness and readiness probes for each Zookeeper node. Default is 5
-* `KAFKA_DEFAULT_REPLICATION_FACTOR`: the default replication factors for automatically created topics. It sets the 
-`default.replication.factor` property in the properties configuration file used by Kafka broker nodes on startup. Default is 3
-* `KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR`: the replication factor for the offsets topic. It sets the  
-`offsets.topic.replication.factor` property in the properties configuration file used by Kafka broker nodes on startup. Default is 3
-* `KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR`: the replication factor for the transaction topic. It sets the 
-`transaction.state.log.replication.factor` property in the properties configuration file used by Kafka broker nodes on startup. Default is 3
-* `kafka-storage`: a JSON string representing the storage configuration for the Kafka broker nodes. See related section
-* `zookeeper-storage`: a JSON string representing the storage configuration for the Zookeeper nodes. See related section
+* `kafka-config`: a JSON string with Kafka configuration. See section <<kafka_configuration_json_config>> for more details.
+* `kafka-storage`: a JSON string representing the storage configuration for the Kafka broker nodes. See section
+<<storage_configuration_json_config>> for more details.
+* `zookeeper-storage`: a JSON string representing the storage configuration for the Zookeeper nodes. See section
+<<storage_configuration_json_config>> for more details.
 * `kafka-metrics-config`: a JSON string representing the JMX exporter configuration for exposing metrics from Kafka broker nodes.
  Removing this field means having no metrics exposed.
 * `zookeeper-metrics-config`: a JSON string representing the JMX exporter configuration for exposing metrics from Zookeeper nodes.
@@ -110,9 +107,24 @@ data:
   zookeeper-image: "strimzi/zookeeper:latest"
   zookeeper-healthcheck-delay: "15"
   zookeeper-healthcheck-timeout: "5"
-  KAFKA_DEFAULT_REPLICATION_FACTOR: "3"
-  KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: "3"
-  KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: "3"
+  kafka-config: |-
+    {
+      "num.partitions": 1,
+      "num.recovery.threads.per.data.dir": 1,
+      "default.replication.factor": 3,
+      "offsets.topic.replication.factor": 3,
+      "transaction.state.log.replication.factor": 3,
+      "transaction.state.log.min.isr": 1,
+      "log.retention.hours": 168,
+      "log.segment.bytes": 1073741824,
+      "log.retention.check.interval.ms": 300000,
+      "num.network.threads": 3,
+      "num.io.threads": 8,
+      "socket.send.buffer.bytes": 102400,
+      "socket.receive.buffer.bytes": 102400,
+      "socket.request.max.bytes": 104857600,
+      "group.initial.rebalance.delay.ms": 0
+    }
   kafka-storage: |-
     { "type": "ephemeral" }
   zookeeper-storage: |-
@@ -154,6 +166,79 @@ a volume by the Zookeeper node pods
 * `[cluster-name]-kafka-metrics-config` ConfigMap which contains the Kafka metrics configuration and mounted as
 a volume by the Kafka broker pods
 
+[[kafka_configuration_json_config]]
+===== Kafka Configuration
+
+`kafka-config` field allows detailed configuration of Apache Kafka. This field should contain a JSON object with Kafka
+configuration options as keys. The values could be in one of the following types:
+
+* String
+* Integer
+* Long
+* Double
+* Float
+* Boolean
+
+The `kafka-config` field supports all Kafka configuration options with the exception of options related to:
+
+* Security (Encryption, Authentication and Authorization)
+* Listener configuration
+* Broker ID configuration
+* Configuration of log data directories
+* Inter-broker communication
+* Zookeeper connectivity
+
+Specifically, all configuration options with keys starting with one of the following strings will be ignored:
+
+* `listeners`
+* `advertised.`
+* `broker.`
+* `listener.`
+* `host.name`
+* `port`
+* `inter.broker.listener.name`
+* `sasl.`
+* `ssl.`
+* `security.`
+* `password.`
+* `principal.builder.class`
+* `log.dir`
+* `zookeeper.connect`
+* `zookeeper.set.acl`
+* `authorizer.`
+* `super.user`
+
+All other options will be passed to Kafka. List of all available options can be found on the
+http://kafka.apache.org/documentation/#brokerconfigs[Kafka website]. An example of `kafka-config` field is provided
+below.
+
+.Example Kafka configuration
+[source,json]
+----
+{
+  "num.partitions": 1,
+  "num.recovery.threads.per.data.dir": 1,
+  "default.replication.factor": 3,
+  "offsets.topic.replication.factor": 3,
+  "transaction.state.log.replication.factor": 3,
+  "transaction.state.log.min.isr": 1,
+  "log.retention.hours": 168,
+  "log.segment.bytes": 1073741824,
+  "log.retention.check.interval.ms": 300000,
+  "num.network.threads": 3,
+  "num.io.threads": 8,
+  "socket.send.buffer.bytes": 102400,
+  "socket.receive.buffer.bytes": 102400,
+  "socket.request.max.bytes": 104857600,
+  "group.initial.rebalance.delay.ms": 0
+}
+----
+
+NOTE:: Strimzi doesn't validate the configuration provided by the user. When invalid configuration is provided, the
+Kafka cluster might not start or might become unstable. In such cases, the configuration in the `kafka-config` field
+should be fixed and the cluster controller will roll out the new configuration to all Kafka brokers.
+
+[[storage_configuration_json_config]]
 ===== Storage
 
 Both Kafka and Zookeeper save data to files.
@@ -173,7 +258,6 @@ The "ephemeral" storage is really simple to configure and the related JSON strin
 [source,json]
 ----
 { "type": "ephemeral" }
-
 ----
 
 WARNING: If the Zookeeper cluster is deployed using "ephemeral" storage, the Kafka brokers can have problems dealing with

--- a/documentation/adoc/cluster-controller.adoc
+++ b/documentation/adoc/cluster-controller.adoc
@@ -67,6 +67,11 @@ Default is determined by the value of the
 environment variable of the Cluster Controller.
 * `kafka-healthcheck-delay`: the initial delay for the liveness and readiness probes for each Kafka broker node. Default is 15
 * `kafka-healthcheck-timeout`: the timeout on the liveness and readiness probes for each Kafka broker node. Default is 5
+* `kafka-config`: a JSON string with Kafka configuration. See section <<kafka_configuration_json_config>> for more details.
+* `kafka-storage`: a JSON string representing the storage configuration for the Kafka broker nodes. See section
+<<storage_configuration_json_config>> for more details.
+* `kafka-metrics-config`: a JSON string representing the JMX exporter configuration for exposing metrics from Kafka broker nodes.
+ Removing this field means having no metrics exposed.
 * `zookeeper-nodes`: number of Zookeeper nodes
 * `zookeeper-image`: the Docker image to use for the Zookeeper nodes.
 Default is determined by the value of the
@@ -74,13 +79,8 @@ Default is determined by the value of the
 environment variable of the Cluster Controller.
 * `zookeeper-healthcheck-delay`: the initial delay for the liveness and readiness probes for each Zookeeper node. Default is 15
 * `zookeeper-healthcheck-timeout`: the timeout on the liveness and readiness probes for each Zookeeper node. Default is 5
-* `kafka-config`: a JSON string with Kafka configuration. See section <<kafka_configuration_json_config>> for more details.
-* `kafka-storage`: a JSON string representing the storage configuration for the Kafka broker nodes. See section
-<<storage_configuration_json_config>> for more details.
 * `zookeeper-storage`: a JSON string representing the storage configuration for the Zookeeper nodes. See section
 <<storage_configuration_json_config>> for more details.
-* `kafka-metrics-config`: a JSON string representing the JMX exporter configuration for exposing metrics from Kafka broker nodes.
- Removing this field means having no metrics exposed.
 * `zookeeper-metrics-config`: a JSON string representing the JMX exporter configuration for exposing metrics from Zookeeper nodes.
  Removing this field means having no metrics exposed.
 * `topic-controller-config`: a JSON string representing the topic controller configuration. See the <<topic_controller_json_config>>
@@ -234,7 +234,7 @@ below.
 }
 ----
 
-NOTE:: Strimzi doesn't validate the configuration provided by the user. When invalid configuration is provided, the
+NOTE:: The cluster controller doesn't validate the configuration provided by the user. When invalid configuration is provided, the
 Kafka cluster might not start or might become unstable. In such cases, the configuration in the `kafka-config` field
 should be fixed and the cluster controller will roll out the new configuration to all Kafka brokers.
 

--- a/examples/configmaps/cluster-controller/kafka-ephemeral.yaml
+++ b/examples/configmaps/cluster-controller/kafka-ephemeral.yaml
@@ -16,24 +16,21 @@ data:
   zookeeper-healthcheck-timeout: "5"
   kafka-config: |-
     {
-      "advertised.listeners": "PLAINTEXT://:1234",
-      "inter.broker.listener.name": "PLAINTEXT",
-      "zookeeper.connection.timeout.ms": "6000",
       "num.partitions": 1,
       "num.recovery.threads.per.data.dir": 1,
       "default.replication.factor": 3,
       "offsets.topic.replication.factor": 3,
       "transaction.state.log.replication.factor": 3,
       "transaction.state.log.min.isr": 1,
-      "log.retention.hours": "168",
-      "log.segment.bytes": "1073741824",
-      "log.retention.check.interval.ms": "300000",
-      "num.network.threads": "3",
-      "num.io.threads": "8",
-      "socket.send.buffer.bytes": "102400",
-      "socket.receive.buffer.bytes": "102400",
-      "socket.request.max.bytes": "104857600",
-      "group.initial.rebalance.delay.ms": "0"
+      "log.retention.hours": 168,
+      "log.segment.bytes": 1073741824,
+      "log.retention.check.interval.ms": 300000,
+      "num.network.threads": 3,
+      "num.io.threads": 8,
+      "socket.send.buffer.bytes": 102400,
+      "socket.receive.buffer.bytes": 102400,
+      "socket.request.max.bytes": 104857600,
+      "group.initial.rebalance.delay.ms": 0
     }
   kafka-storage: |-
     { "type": "ephemeral" }

--- a/examples/configmaps/cluster-controller/kafka-ephemeral.yaml
+++ b/examples/configmaps/cluster-controller/kafka-ephemeral.yaml
@@ -14,9 +14,27 @@ data:
   zookeeper-image: "strimzi/zookeeper:latest"
   zookeeper-healthcheck-delay: "15"
   zookeeper-healthcheck-timeout: "5"
-  KAFKA_DEFAULT_REPLICATION_FACTOR: "3"
-  KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: "3"
-  KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: "3"
+  kafka-config: |-
+    {
+      "advertised.listeners": "PLAINTEXT://:1234",
+      "inter.broker.listener.name": "PLAINTEXT",
+      "zookeeper.connection.timeout.ms": "6000",
+      "num.partitions": 1,
+      "num.recovery.threads.per.data.dir": 1,
+      "default.replication.factor": 3,
+      "offsets.topic.replication.factor": 3,
+      "transaction.state.log.replication.factor": 3,
+      "transaction.state.log.min.isr": 1,
+      "log.retention.hours": "168",
+      "log.segment.bytes": "1073741824",
+      "log.retention.check.interval.ms": "300000",
+      "num.network.threads": "3",
+      "num.io.threads": "8",
+      "socket.send.buffer.bytes": "102400",
+      "socket.receive.buffer.bytes": "102400",
+      "socket.request.max.bytes": "104857600",
+      "group.initial.rebalance.delay.ms": "0"
+    }
   kafka-storage: |-
     { "type": "ephemeral" }
   zookeeper-storage: |-

--- a/examples/configmaps/cluster-controller/kafka-persistent.yaml
+++ b/examples/configmaps/cluster-controller/kafka-persistent.yaml
@@ -14,9 +14,24 @@ data:
   zookeeper-image: "strimzi/zookeeper:latest"
   zookeeper-healthcheck-delay: "15"
   zookeeper-healthcheck-timeout: "5"
-  KAFKA_DEFAULT_REPLICATION_FACTOR: "3"
-  KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: "3"
-  KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: "3"
+  kafka-config: |-
+    {
+      "num.partitions": 1,
+      "num.recovery.threads.per.data.dir": 1,
+      "default.replication.factor": 3,
+      "offsets.topic.replication.factor": 3,
+      "transaction.state.log.replication.factor": 3,
+      "transaction.state.log.min.isr": 1,
+      "log.retention.hours": 168,
+      "log.segment.bytes": 1073741824,
+      "log.retention.check.interval.ms": 300000,
+      "num.network.threads": 3,
+      "num.io.threads": 8,
+      "socket.send.buffer.bytes": 102400,
+      "socket.receive.buffer.bytes": 102400,
+      "socket.request.max.bytes": 104857600,
+      "group.initial.rebalance.delay.ms": 0
+    }
   kafka-storage: |-
     { "type": "persistent-claim", "size": "1Gi", "delete-claim": false }
   zookeeper-storage: |-

--- a/examples/templates/cluster-controller/ephemeral-template.yaml
+++ b/examples/templates/cluster-controller/ephemeral-template.yaml
@@ -95,9 +95,24 @@ objects:
     zookeeper-image: "${IMAGE_REPO_NAME}/${ZOOKEEPER_IMAGE_NAME}:${ZOOKEEPER_IMAGE_TAG}"
     zookeeper-healthcheck-delay: "${ZOOKEEPER_HEALTHCHECK_DELAY}"
     zookeeper-healthcheck-timeout: "${ZOOKEEPER_HEALTHCHECK_TIMEOUT}"
-    KAFKA_DEFAULT_REPLICATION_FACTOR: "${KAFKA_DEFAULT_REPLICATION_FACTOR}"
-    KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: "${KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR}"
-    KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: "${KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR}"
+    kafka-config: |-
+      {
+        "num.partitions": 1,
+        "num.recovery.threads.per.data.dir": 1,
+        "default.replication.factor": ${KAFKA_DEFAULT_REPLICATION_FACTOR},
+        "offsets.topic.replication.factor": ${KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR},
+        "transaction.state.log.replication.factor": ${KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR},
+        "transaction.state.log.min.isr": 1,
+        "log.retention.hours": 168,
+        "log.segment.bytes": 1073741824,
+        "log.retention.check.interval.ms": 300000,
+        "num.network.threads": 3,
+        "num.io.threads": 8,
+        "socket.send.buffer.bytes": 102400,
+        "socket.receive.buffer.bytes": 102400,
+        "socket.request.max.bytes": 104857600,
+        "group.initial.rebalance.delay.ms": 0
+      }
     kafka-storage: |-
       { "type": "ephemeral" }
     zookeeper-storage: |-

--- a/examples/templates/cluster-controller/persistent-template.yaml
+++ b/examples/templates/cluster-controller/persistent-template.yaml
@@ -101,9 +101,24 @@ objects:
     zookeeper-image: "${IMAGE_REPO_NAME}/${ZOOKEEPER_IMAGE_NAME}:${ZOOKEEPER_IMAGE_TAG}"
     zookeeper-healthcheck-delay: "${ZOOKEEPER_HEALTHCHECK_DELAY}"
     zookeeper-healthcheck-timeout: "${ZOOKEEPER_HEALTHCHECK_TIMEOUT}"
-    KAFKA_DEFAULT_REPLICATION_FACTOR: "${KAFKA_DEFAULT_REPLICATION_FACTOR}"
-    KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: "${KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR}"
-    KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: "${KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR}"
+    kafka-config: |-
+      {
+        "num.partitions": 1,
+        "num.recovery.threads.per.data.dir": 1,
+        "default.replication.factor": ${KAFKA_DEFAULT_REPLICATION_FACTOR},
+        "offsets.topic.replication.factor": ${KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR},
+        "transaction.state.log.replication.factor": ${KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR},
+        "transaction.state.log.min.isr": 1,
+        "log.retention.hours": 168,
+        "log.segment.bytes": 1073741824,
+        "log.retention.check.interval.ms": 300000,
+        "num.network.threads": 3,
+        "num.io.threads": 8,
+        "socket.send.buffer.bytes": 102400,
+        "socket.receive.buffer.bytes": 102400,
+        "socket.request.max.bytes": 104857600,
+        "group.initial.rebalance.delay.ms": 0
+      }
     kafka-storage: |-
       { "type": "persistent-claim", "size": "${KAFKA_VOLUME_CAPACITY}", "delete-claim": false }
     zookeeper-storage: |-

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
@@ -293,7 +293,7 @@ public class KafkaClusterIT extends AbstractClusterIT {
         LOGGER.info("Verified CM and Testing kafka pods");
         for (int i = 0; i < expectedKafkaPods; i++) {
             String kafkaPodJson = oc.getResourceAsJson("pod", kafkaPodName(clusterName, i));
-            assertEquals("{\"offsets.topic.replication.factor\": 2,\"default.replication.factor\": 2,\"transaction.state.log.replication.factor\": 2}", getValueFromJson(kafkaPodJson,
+            assertEquals("offsets.topic.replication.factor=2\ndefault.replication.factor=2\ntransaction.state.log.replication.factor=2", getValueFromJson(kafkaPodJson,
                     globalVariableJsonPathBuilder("KAFKA_USER_CONFIGURATION")));
             String initialDelaySecondsPath = "$.spec.containers[*].livenessProbe.initialDelaySeconds";
             assertEquals("23", getValueFromJson(kafkaPodJson, initialDelaySecondsPath));

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
@@ -194,9 +194,7 @@ public class KafkaClusterIT extends AbstractClusterIT {
             @CmData(key = "zookeeper-healthcheck-timeout", value = "10"),
             @CmData(key = "kafka-healthcheck-delay", value = "30"),
             @CmData(key = "kafka-healthcheck-timeout", value = "10"),
-            @CmData(key = "KAFKA_DEFAULT_REPLICATION_FACTOR", value = "2"),
-            @CmData(key = "KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR", value = "5"),
-            @CmData(key = "KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR", value = "5")
+            @CmData(key = "kafka-config", value = "{\"default.replication.factor\": 1,\"offsets.topic.replication.factor\": 1,\"transaction.state.log.replication.factor\": 1}")
     })
     public void testClusterWithCustomParameters() {
         // kafka cluster already deployed via annotation
@@ -208,9 +206,7 @@ public class KafkaClusterIT extends AbstractClusterIT {
         assertThat(jsonString, valueOfCmEquals("zookeeper-healthcheck-timeout", "10"));
         assertThat(jsonString, valueOfCmEquals("kafka-healthcheck-delay", "30"));
         assertThat(jsonString, valueOfCmEquals("kafka-healthcheck-timeout", "10"));
-        assertThat(jsonString, valueOfCmEquals("KAFKA_DEFAULT_REPLICATION_FACTOR", "2"));
-        assertThat(jsonString, valueOfCmEquals("KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR", "5"));
-        assertThat(jsonString, valueOfCmEquals("KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR", "5"));
+        assertThat(jsonString, valueOfCmEquals("kafka-config", "{\"default.replication.factor\": 1,\"offsets.topic.replication.factor\": 1,\"transaction.state.log.replication.factor\": 1}"));
     }
 
     @Test
@@ -221,11 +217,8 @@ public class KafkaClusterIT extends AbstractClusterIT {
         @CmData(key = "zookeeper-healthcheck-timeout", value = "15"),
         @CmData(key = "kafka-healthcheck-delay", value = "30"),
         @CmData(key = "kafka-healthcheck-timeout", value = "15"),
-        @CmData(key = "KAFKA_DEFAULT_REPLICATION_FACTOR", value = "2"),
-        @CmData(key = "KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR", value = "5"),
-        @CmData(key = "KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR", value = "5")
+        @CmData(key = "kafka-config", value = "{\"default.replication.factor\": 1,\"offsets.topic.replication.factor\": 1,\"transaction.state.log.replication.factor\": 1}")
     })
-    @OpenShiftOnly
     public void testDeployKafkaOnPersistentStorage() {
         String clusterName = "my-cluster-persistent";
         int expectedZKPods = 2;
@@ -250,21 +243,16 @@ public class KafkaClusterIT extends AbstractClusterIT {
         assertThat(configMap, valueOfCmEquals("zookeeper-healthcheck-timeout", "15"));
         assertThat(configMap, valueOfCmEquals("kafka-healthcheck-delay", "30"));
         assertThat(configMap, valueOfCmEquals("kafka-healthcheck-timeout", "15"));
-        assertThat(configMap, valueOfCmEquals("KAFKA_DEFAULT_REPLICATION_FACTOR", "2"));
-        assertThat(configMap, valueOfCmEquals("KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR", "5"));
-        assertThat(configMap, valueOfCmEquals("KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR", "5"));
+        assertThat(configMap, valueOfCmEquals("kafka-config", "{\"default.replication.factor\": 1,\"offsets.topic.replication.factor\": 1,\"transaction.state.log.replication.factor\": 1}"));
     }
 
     @Test
-    @OpenShiftOnly
     @KafkaCluster(name = "my-cluster", kafkaNodes = 2, zkNodes = 2, config = {
             @CmData(key = "zookeeper-healthcheck-delay", value = "30"),
             @CmData(key = "zookeeper-healthcheck-timeout", value = "10"),
             @CmData(key = "kafka-healthcheck-delay", value = "30"),
             @CmData(key = "kafka-healthcheck-timeout", value = "10"),
-            @CmData(key = "KAFKA_DEFAULT_REPLICATION_FACTOR", value = "1"),
-            @CmData(key = "KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR", value = "1"),
-            @CmData(key = "KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR", value = "1")
+            @CmData(key = "kafka-config", value = "{\"default.replication.factor\": 1,\"offsets.topic.replication.factor\": 1,\"transaction.state.log.replication.factor\": 1}")
     })
     public void testForUpdateValuesInConfigMap() {
         String clusterName = "my-cluster";
@@ -283,9 +271,7 @@ public class KafkaClusterIT extends AbstractClusterIT {
         replaceCm(clusterName, "zookeeper-healthcheck-timeout", "24");
         replaceCm(clusterName, "kafka-healthcheck-delay", "23");
         replaceCm(clusterName, "kafka-healthcheck-timeout", "20");
-        replaceCm(clusterName, "KAFKA_DEFAULT_REPLICATION_FACTOR", "2");
-        replaceCm(clusterName, "KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR", "2");
-        replaceCm(clusterName, "KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR", "2");
+        replaceCm(clusterName, "kafka-config", "{\"default.replication.factor\": 2,\"offsets.topic.replication.factor\": 2,\"transaction.state.log.replication.factor\": 2}");
 
         for (int i = 0; i < expectedZKPods; i++) {
             kubeClient.waitForResourceUpdate("pod", zookeeperPodName(clusterName, i), zkPodStartTime.get(i));
@@ -300,19 +286,13 @@ public class KafkaClusterIT extends AbstractClusterIT {
         assertThat(configMap, valueOfCmEquals("zookeeper-healthcheck-timeout", "24"));
         assertThat(configMap, valueOfCmEquals("kafka-healthcheck-delay", "23"));
         assertThat(configMap, valueOfCmEquals("kafka-healthcheck-timeout", "20"));
-        assertThat(configMap, valueOfCmEquals("KAFKA_DEFAULT_REPLICATION_FACTOR", "2"));
-        assertThat(configMap, valueOfCmEquals("KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR", "2"));
-        assertThat(configMap, valueOfCmEquals("KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR", "2"));
+        assertThat(configMap, valueOfCmEquals("kafka-config", "{\"default.replication.factor\": 1,\"offsets.topic.replication.factor\": 1,\"transaction.state.log.replication.factor\": 1}"));
 
         LOGGER.info("Verified CM and Testing kafka pods");
         for (int i = 0; i < expectedKafkaPods; i++) {
             String kafkaPodJson = oc.getResourceAsJson("pod", kafkaPodName(clusterName, i));
-            assertEquals("2", getValueFromJson(kafkaPodJson,
-                    globalVariableJsonPathBuilder("KAFKA_DEFAULT_REPLICATION_FACTOR")));
-            assertEquals("2", getValueFromJson(kafkaPodJson,
-                    globalVariableJsonPathBuilder("KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR")));
-            assertEquals("2", getValueFromJson(kafkaPodJson,
-                    globalVariableJsonPathBuilder("KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR")));
+            assertEquals("{\"offsets.topic.replication.factor\": 1,\"default.replication.factor\": 1,\"transaction.state.log.replication.factor\": 1}", getValueFromJson(kafkaPodJson,
+                    globalVariableJsonPathBuilder("KAFKA_USER_CONFIGURATION")));
             String initialDelaySecondsPath = "$.spec.containers[*].livenessProbe.initialDelaySeconds";
             assertEquals("23", getValueFromJson(kafkaPodJson, initialDelaySecondsPath));
             String kafkaHealthcheckTimeout = "$.spec.containers[*].livenessProbe.timeoutSeconds";

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
@@ -288,12 +288,12 @@ public class KafkaClusterIT extends AbstractClusterIT {
         assertThat(configMap, valueOfCmEquals("zookeeper-healthcheck-timeout", "24"));
         assertThat(configMap, valueOfCmEquals("kafka-healthcheck-delay", "23"));
         assertThat(configMap, valueOfCmEquals("kafka-healthcheck-timeout", "20"));
-        assertThat(configMap, valueOfCmEquals("kafka-config", "{\"default.replication.factor\": 1,\"offsets.topic.replication.factor\": 1,\"transaction.state.log.replication.factor\": 1}"));
+        assertThat(configMap, valueOfCmEquals("kafka-config", "{\"default.replication.factor\": 2,\"offsets.topic.replication.factor\": 2,\"transaction.state.log.replication.factor\": 2}"));
 
         LOGGER.info("Verified CM and Testing kafka pods");
         for (int i = 0; i < expectedKafkaPods; i++) {
             String kafkaPodJson = oc.getResourceAsJson("pod", kafkaPodName(clusterName, i));
-            assertEquals("{\"offsets.topic.replication.factor\": 1,\"default.replication.factor\": 1,\"transaction.state.log.replication.factor\": 1}", getValueFromJson(kafkaPodJson,
+            assertEquals("{\"offsets.topic.replication.factor\": 2,\"default.replication.factor\": 2,\"transaction.state.log.replication.factor\": 2}", getValueFromJson(kafkaPodJson,
                     globalVariableJsonPathBuilder("KAFKA_USER_CONFIGURATION")));
             String initialDelaySecondsPath = "$.spec.containers[*].livenessProbe.initialDelaySeconds";
             assertEquals("23", getValueFromJson(kafkaPodJson, initialDelaySecondsPath));

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
@@ -210,6 +210,7 @@ public class KafkaClusterIT extends AbstractClusterIT {
     }
 
     @Test
+    @OpenShiftOnly
     @KafkaCluster(name = "my-cluster-persistent", kafkaNodes = 2, zkNodes = 2, config = {
         @CmData(key = "kafka-storage", value = "{ \"type\": \"persistent-claim\", \"size\": \"1Gi\", \"delete-claim\": false }"),
         @CmData(key = "zookeeper-storage", value = "{ \"type\": \"persistent-claim\", \"size\": \"1Gi\", \"delete-claim\": false }"),
@@ -247,6 +248,7 @@ public class KafkaClusterIT extends AbstractClusterIT {
     }
 
     @Test
+    @OpenShiftOnly
     @KafkaCluster(name = "my-cluster", kafkaNodes = 2, zkNodes = 2, config = {
             @CmData(key = "zookeeper-healthcheck-delay", value = "30"),
             @CmData(key = "zookeeper-healthcheck-timeout", value = "10"),


### PR DESCRIPTION
### Type of change

- ~~Bugfix~~
- Enhancement / new feature
- ~~Refactoring~~

### Description

This PR is part of #27. It delivers enhanced configuration possibilities for Apache Kafka. Configuration for Kafka Connect and Zookeeper will be delivered in separate PRs.

This PR adds new field `kafka-config` to the Kafka cluster CM. This field should contain a JSON with configuration options. These options are passed to the Kafka broker pods in environment variables. The generation of Kafka configuration is handled by a separate script which is called within the same Docker image / pod. Separate script has been used in order to be able to easily move this to the init pod later once needed.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging

