### PR TITLE
Improve logging around rolling updates

### DIFF
--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/operator/resource/StatefulSetOperator.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/operator/resource/StatefulSetOperator.java
@@ -197,10 +197,10 @@ public class StatefulSetOperator<P> extends AbstractScalableResourceOperator<Kub
         @Override
         public void onClose(KubernetesClientException e) {
             if (e != null && !deleted.isComplete()) {
-                log.error("Rolling update watcher has been closed with exception!", e);
+                log.error("Rolling update watcher has been closed with exception", e);
                 deleted.fail(e);
             } else {
-                log.debug("Rolling update watcher has been closed!");
+                log.debug("Rolling update watcher has been closed");
             }
         }
     }


### PR DESCRIPTION
### Type of change

- ~~Bugfix~~
- Enhancement / new feature
- ~~Refactoring~~

### Description

The current logging around rolling updates seems to be overly verbose and some messages might be hard to understand to users. This PR changes the logs on default log level from:

```
2018-04-20 17:23:21 INFO  StatefulSetOperator:121 - Roll myproject/my-cluster-kafka: Rolling pod my-cluster-kafka-0
2018-04-20 17:23:21 INFO  StatefulSetOperator:186 - Ignored action ADDED on pod my-cluster-kafka-0 while waiting for Pod deletion
2018-04-20 17:23:21 INFO  StatefulSetOperator:186 - Ignored action MODIFIED on pod my-cluster-kafka-0 while waiting for Pod deletion
2018-04-20 17:23:25 INFO  StatefulSetOperator:186 - Ignored action MODIFIED on pod my-cluster-kafka-0 while waiting for Pod deletion
2018-04-20 17:23:26 INFO  StatefulSetOperator:186 - Ignored action MODIFIED on pod my-cluster-kafka-0 while waiting for Pod deletion
2018-04-20 17:23:26 INFO  StatefulSetOperator:181 - Pod my-cluster-kafka-0 has been deleted
2018-04-20 17:23:26 INFO  StatefulSetOperator:202 - Kubernetes watcher has been closed!
2018-04-20 17:23:50 INFO  StatefulSetOperator:121 - Roll myproject/my-cluster-kafka: Rolling pod my-cluster-kafka-1
2018-04-20 17:23:50 INFO  StatefulSetOperator:186 - Ignored action ADDED on pod my-cluster-kafka-1 while waiting for Pod deletion
2018-04-20 17:23:50 INFO  StatefulSetOperator:186 - Ignored action MODIFIED on pod my-cluster-kafka-1 while waiting for Pod deletion
2018-04-20 17:23:55 INFO  StatefulSetOperator:186 - Ignored action MODIFIED on pod my-cluster-kafka-1 while waiting for Pod deletion
2018-04-20 17:24:02 INFO  StatefulSetOperator:186 - Ignored action MODIFIED on pod my-cluster-kafka-1 while waiting for Pod deletion
2018-04-20 17:24:02 INFO  StatefulSetOperator:181 - Pod my-cluster-kafka-1 has been deleted
2018-04-20 17:24:02 INFO  StatefulSetOperator:202 - Kubernetes watcher has been closed!
2018-04-20 17:24:29 INFO  StatefulSetOperator:121 - Roll myproject/my-cluster-kafka: Rolling pod my-cluster-kafka-2
2018-04-20 17:24:29 INFO  StatefulSetOperator:186 - Ignored action ADDED on pod my-cluster-kafka-2 while waiting for Pod deletion
2018-04-20 17:24:29 INFO  StatefulSetOperator:186 - Ignored action MODIFIED on pod my-cluster-kafka-2 while waiting for Pod deletion
2018-04-20 17:24:33 INFO  StatefulSetOperator:186 - Ignored action MODIFIED on pod my-cluster-kafka-2 while waiting for Pod deletion
2018-04-20 17:24:34 INFO  StatefulSetOperator:186 - Ignored action MODIFIED on pod my-cluster-kafka-2 while waiting for Pod deletion
2018-04-20 17:24:34 INFO  StatefulSetOperator:186 - Ignored action MODIFIED on pod my-cluster-kafka-2 while waiting for Pod deletion
2018-04-20 17:24:34 INFO  StatefulSetOperator:181 - Pod my-cluster-kafka-2 has been deleted
2018-04-20 17:24:34 INFO  StatefulSetOperator:202 - Kubernetes watcher has been closed!
```

to:

```
2018-04-20 17:46:48 INFO  StatefulSetOperator:89 - Starting rolling update of myproject/my-cluster-kafka
2018-04-20 17:46:48 INFO  StatefulSetOperator:122 - Rolling update of myproject/my-cluster-kafka: Rolling pod my-cluster-kafka-0
2018-04-20 17:47:12 INFO  StatefulSetOperator:122 - Rolling update of myproject/my-cluster-kafka: Rolling pod my-cluster-kafka-1
2018-04-20 17:47:50 INFO  StatefulSetOperator:122 - Rolling update of myproject/my-cluster-kafka: Rolling pod my-cluster-kafka-2
```

which should be easier to read and understand for users.

