### PR TITLE
System test improvements

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractClusterIT.java
@@ -20,7 +20,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -84,11 +86,21 @@ public class AbstractClusterIT {
     }
 
     void replaceCm(String cmName, String fieldName, String fieldValue) {
+        Map<String, String> changes = new HashMap<>();
+        changes.put(fieldName, fieldValue);
+        replaceCm(cmName, changes);
+    }
+
+    void replaceCm(String cmName, Map<String, String> changes) {
         try {
             String jsonString = kubeClient.get("cm", cmName);
             YAMLMapper mapper = new YAMLMapper();
             JsonNode node = mapper.readTree(jsonString);
-            ((ObjectNode) node.get("data")).put(fieldName, fieldValue);
+
+            for (Map.Entry<String, String> change : changes.entrySet()) {
+                ((ObjectNode) node.get("data")).put(change.getKey(), change.getValue());
+            }
+
             String content = mapper.writeValueAsString(node);
             kubeClient.replaceContent(content);
             LOGGER.info("Value in Config Map replaced");

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractClusterIT.java
@@ -20,6 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -86,9 +87,7 @@ public class AbstractClusterIT {
     }
 
     void replaceCm(String cmName, String fieldName, String fieldValue) {
-        Map<String, String> changes = new HashMap<>();
-        changes.put(fieldName, fieldValue);
-        replaceCm(cmName, changes);
+        replaceCm(cmName, Collections.singletonMap(fieldName, fieldValue));
     }
 
     void replaceCm(String cmName, Map<String, String> changes) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractClusterIT.java
@@ -21,7 +21,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
@@ -221,7 +221,7 @@ public class KafkaClusterIT extends AbstractClusterIT {
 
         for (int i = 0; i < expectedKafkaPods; i++) {
             String kafkaPodJson = kubeClient.getResourceAsJson("pod", kafkaPodName(clusterName, i));
-            assertEquals("offsets.topic.replication.factor=1\ndefault.replication.factor=1\ntransaction.state.log.replication.factor=1", getValueFromJson(kafkaPodJson,
+            assertEquals("transaction.state.log.replication.factor=1\\ndefault.replication.factor=1\\noffsets.topic.replication.factor=1\\n".replaceAll("\\p{P}", ""), getValueFromJson(kafkaPodJson,
                     globalVariableJsonPathBuilder("KAFKA_USER_CONFIGURATION")));
             String initialDelaySecondsPath = "$.spec.containers[*].livenessProbe.initialDelaySeconds";
             assertEquals("30", getValueFromJson(kafkaPodJson, initialDelaySecondsPath));
@@ -264,7 +264,7 @@ public class KafkaClusterIT extends AbstractClusterIT {
 
         for (int i = 0; i < expectedKafkaPods; i++) {
             String kafkaPodJson = kubeClient.getResourceAsJson("pod", kafkaPodName(clusterName, i));
-            assertEquals("offsets.topic.replication.factor=2\ndefault.replication.factor=2\ntransaction.state.log.replication.factor=2", getValueFromJson(kafkaPodJson,
+            assertEquals("transaction.state.log.replication.factor=2\\ndefault.replication.factor=2\\noffsets.topic.replication.factor=2\\n".replaceAll("\\p{P}", ""), getValueFromJson(kafkaPodJson,
                     globalVariableJsonPathBuilder("KAFKA_USER_CONFIGURATION")));
             String initialDelaySecondsPath = "$.spec.containers[*].livenessProbe.initialDelaySeconds";
             assertEquals("31", getValueFromJson(kafkaPodJson, initialDelaySecondsPath));

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
@@ -82,7 +82,10 @@ public class KafkaClusterIT extends AbstractClusterIT {
     }
 
     @Test
-    @KafkaCluster(name = CLUSTER_NAME, kafkaNodes = 3)
+    @KafkaCluster(name = CLUSTER_NAME, kafkaNodes = 3, config = {
+            @CmData(key = "kafka-storage", value = "{ \"type\": \"ephemeral\" }"),
+            @CmData(key = "zookeeper-storage", value = "{ \"type\": \"ephemeral\" }")
+    })
     public void testKafkaScaleUpScaleDown() {
         // kafka cluster already deployed via annotation
         LOGGER.info("Running kafkaScaleUpScaleDown {}", CLUSTER_NAME);
@@ -138,7 +141,10 @@ public class KafkaClusterIT extends AbstractClusterIT {
     }
 
     @Test
-    @KafkaCluster(name = CLUSTER_NAME, kafkaNodes = 1, zkNodes = 1)
+    @KafkaCluster(name = CLUSTER_NAME, kafkaNodes = 1, zkNodes = 1, config = {
+            @CmData(key = "kafka-storage", value = "{ \"type\": \"ephemeral\" }"),
+            @CmData(key = "zookeeper-storage", value = "{ \"type\": \"ephemeral\" }")
+    })
     public void testZookeeperScaleUpScaleDown() {
         // kafka cluster already deployed via annotation
         LOGGER.info("Running zookeeperScaleUpScaleDown with cluster {}", CLUSTER_NAME);
@@ -229,6 +235,8 @@ public class KafkaClusterIT extends AbstractClusterIT {
 
     @Test
     @KafkaCluster(name = "my-cluster", kafkaNodes = 2, zkNodes = 2, config = {
+            @CmData(key = "kafka-storage", value = "{ \"type\": \"ephemeral\" }"),
+            @CmData(key = "zookeeper-storage", value = "{ \"type\": \"ephemeral\" }"),
             @CmData(key = "zookeeper-healthcheck-delay", value = "30"),
             @CmData(key = "zookeeper-healthcheck-timeout", value = "10"),
             @CmData(key = "kafka-healthcheck-delay", value = "30"),

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
@@ -299,7 +299,7 @@ public class KafkaClusterIT extends AbstractClusterIT {
         assertThat(configMapAfter, valueOfCmEquals("kafka-config", "{\"default.replication.factor\": 2,\"offsets.topic.replication.factor\": 2,\"transaction.state.log.replication.factor\": 2}"));
 
         for (int i = 0; i < expectedKafkaPods; i++) {
-            String kafkaPodJson = oc.getResourceAsJson("pod", kafkaPodName(clusterName, i));
+            String kafkaPodJson = kubeClient.getResourceAsJson("pod", kafkaPodName(clusterName, i));
             assertEquals("offsets.topic.replication.factor=2\ndefault.replication.factor=2\ntransaction.state.log.replication.factor=2", getValueFromJson(kafkaPodJson,
                     globalVariableJsonPathBuilder("KAFKA_USER_CONFIGURATION")));
             String initialDelaySecondsPath = "$.spec.containers[*].livenessProbe.initialDelaySeconds";

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
@@ -291,10 +291,13 @@ public class KafkaClusterIT extends AbstractClusterIT {
         sendMessages(CLUSTER_NAME, TOPIC_NAME, messagesCount, 1);
         String consumedMessages = consumeMessages(CLUSTER_NAME, TOPIC_NAME, 1, 20, 2);
         List<String> messages = new ArrayList<>(Arrays.asList(consumedMessages.split("\n")));
+        LOGGER.debug("Consumed messages: {}", consumedMessages);
         String count = JsonPath.parse(messages.get(3)).read("$.count").toString();
+        LOGGER.debug("Count: {}", count);
         assertEquals(messagesCount, Integer.parseInt(count));
         String topic = JsonPath.parse(messages.get(3)).read(".partitions.[0].topic").toString().
                 replaceAll("[\\[\\]\"]", "");
+        LOGGER.debug("Topic: {}", topic);
         assertEquals(TOPIC_NAME, topic);
     }
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
@@ -26,7 +26,9 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 import static io.strimzi.systemtest.k8s.Events.Created;
@@ -189,28 +191,6 @@ public class KafkaClusterIT extends AbstractClusterIT {
     }
 
     @Test
-    @KafkaCluster(name = CLUSTER_NAME, kafkaNodes = 1, config = {
-            @CmData(key = "zookeeper-healthcheck-delay", value = "30"),
-            @CmData(key = "zookeeper-healthcheck-timeout", value = "10"),
-            @CmData(key = "kafka-healthcheck-delay", value = "30"),
-            @CmData(key = "kafka-healthcheck-timeout", value = "10"),
-            @CmData(key = "kafka-config", value = "{\"default.replication.factor\": 1,\"offsets.topic.replication.factor\": 1,\"transaction.state.log.replication.factor\": 1}")
-    })
-    public void testClusterWithCustomParameters() {
-        // kafka cluster already deployed via annotation
-        LOGGER.info("Running clusterWithCustomParameters with cluster {}", CLUSTER_NAME);
-
-        //TODO Add assertions to check that Kafka brokers have a custom configuration
-        String jsonString = kubeClient.get("cm", CLUSTER_NAME);
-        assertThat(jsonString, valueOfCmEquals("zookeeper-healthcheck-delay", "30"));
-        assertThat(jsonString, valueOfCmEquals("zookeeper-healthcheck-timeout", "10"));
-        assertThat(jsonString, valueOfCmEquals("kafka-healthcheck-delay", "30"));
-        assertThat(jsonString, valueOfCmEquals("kafka-healthcheck-timeout", "10"));
-        assertThat(jsonString, valueOfCmEquals("kafka-config", "{\"default.replication.factor\": 1,\"offsets.topic.replication.factor\": 1,\"transaction.state.log.replication.factor\": 1}"));
-    }
-
-    @Test
-    @OpenShiftOnly
     @KafkaCluster(name = "my-cluster-persistent", kafkaNodes = 2, zkNodes = 2, config = {
         @CmData(key = "kafka-storage", value = "{ \"type\": \"persistent-claim\", \"size\": \"1Gi\", \"delete-claim\": false }"),
         @CmData(key = "zookeeper-storage", value = "{ \"type\": \"persistent-claim\", \"size\": \"1Gi\", \"delete-claim\": false }"),
@@ -224,9 +204,8 @@ public class KafkaClusterIT extends AbstractClusterIT {
         String clusterName = "my-cluster-persistent";
         int expectedZKPods = 2;
         int expectedKafkaPods = 2;
-        Oc oc = (Oc) this.kubeClient;
 
-        List<String> persistentVolumeClaimNames = oc.list("pvc");
+        List<String> persistentVolumeClaimNames = kubeClient.list("pvc");
         assertTrue(persistentVolumeClaimNames.size() == (expectedZKPods + expectedKafkaPods));
 
         //Checking Persistent volume claims for Zookeeper nodes
@@ -248,7 +227,6 @@ public class KafkaClusterIT extends AbstractClusterIT {
     }
 
     @Test
-    @OpenShiftOnly
     @KafkaCluster(name = "my-cluster", kafkaNodes = 2, zkNodes = 2, config = {
             @CmData(key = "zookeeper-healthcheck-delay", value = "30"),
             @CmData(key = "zookeeper-healthcheck-timeout", value = "10"),
@@ -256,7 +234,7 @@ public class KafkaClusterIT extends AbstractClusterIT {
             @CmData(key = "kafka-healthcheck-timeout", value = "10"),
             @CmData(key = "kafka-config", value = "{\"default.replication.factor\": 1,\"offsets.topic.replication.factor\": 1,\"transaction.state.log.replication.factor\": 1}")
     })
-    public void testForUpdateValuesInConfigMap() {
+    public void testCustomAndUpdatedValues() {
         String clusterName = "my-cluster";
         int expectedZKPods = 2;
         int expectedKafkaPods = 2;
@@ -268,12 +246,40 @@ public class KafkaClusterIT extends AbstractClusterIT {
         for (int i = 0; i < expectedKafkaPods; i++) {
             kafkaPodStartTime.add(kubeClient.getResourceCreateTimestamp("pod", kafkaPodName(clusterName, i)));
         }
-        Oc oc = (Oc) this.kubeClient;
-        replaceCm(clusterName, "zookeeper-healthcheck-delay", "23");
-        replaceCm(clusterName, "zookeeper-healthcheck-timeout", "24");
-        replaceCm(clusterName, "kafka-healthcheck-delay", "23");
-        replaceCm(clusterName, "kafka-healthcheck-timeout", "20");
-        replaceCm(clusterName, "kafka-config", "{\"default.replication.factor\": 2,\"offsets.topic.replication.factor\": 2,\"transaction.state.log.replication.factor\": 2}");
+
+        LOGGER.info("Verify values before update");
+        String configMapBefore = kubeClient.get("cm", clusterName);
+        assertThat(configMapBefore, valueOfCmEquals("zookeeper-healthcheck-delay", "30"));
+        assertThat(configMapBefore, valueOfCmEquals("zookeeper-healthcheck-timeout", "10"));
+        assertThat(configMapBefore, valueOfCmEquals("kafka-healthcheck-delay", "30"));
+        assertThat(configMapBefore, valueOfCmEquals("kafka-healthcheck-timeout", "10"));
+        assertThat(configMapBefore, valueOfCmEquals("kafka-config", "{\"default.replication.factor\": 1,\"offsets.topic.replication.factor\": 1,\"transaction.state.log.replication.factor\": 1}"));
+
+        for (int i = 0; i < expectedKafkaPods; i++) {
+            String kafkaPodJson = kubeClient.getResourceAsJson("pod", kafkaPodName(clusterName, i));
+            assertEquals("offsets.topic.replication.factor=1\ndefault.replication.factor=1\ntransaction.state.log.replication.factor=1", getValueFromJson(kafkaPodJson,
+                    globalVariableJsonPathBuilder("KAFKA_USER_CONFIGURATION")));
+            String initialDelaySecondsPath = "$.spec.containers[*].livenessProbe.initialDelaySeconds";
+            assertEquals("30", getValueFromJson(kafkaPodJson, initialDelaySecondsPath));
+            String kafkaHealthcheckTimeout = "$.spec.containers[*].livenessProbe.timeoutSeconds";
+            assertEquals("10", getValueFromJson(kafkaPodJson, kafkaHealthcheckTimeout));
+        }
+        LOGGER.info("Testing Zookeepers");
+        for (int i = 0; i < expectedZKPods; i++) {
+            String zkPodJson = kubeClient.getResourceAsJson("pod", zookeeperPodName(clusterName, i));
+            String initialDelaySecondsPath = "$.spec.containers[*].livenessProbe.initialDelaySeconds";
+            assertEquals("30", getValueFromJson(zkPodJson, initialDelaySecondsPath));
+            String zookeeperHealthcheckTimeout = "$.spec.containers[*].livenessProbe.timeoutSeconds";
+            assertEquals("10", getValueFromJson(zkPodJson, zookeeperHealthcheckTimeout));
+        }
+
+        Map<String, String> changes = new HashMap<>();
+        changes.put("zookeeper-healthcheck-delay", "31");
+        changes.put("zookeeper-healthcheck-timeout", "11");
+        changes.put("kafka-healthcheck-delay", "31");
+        changes.put("kafka-healthcheck-timeout", "11");
+        changes.put("kafka-config", "{\"default.replication.factor\": 2,\"offsets.topic.replication.factor\": 2,\"transaction.state.log.replication.factor\": 2}");
+        replaceCm(clusterName, changes);
 
         for (int i = 0; i < expectedZKPods; i++) {
             kubeClient.waitForResourceUpdate("pod", zookeeperPodName(clusterName, i), zkPodStartTime.get(i));
@@ -283,36 +289,38 @@ public class KafkaClusterIT extends AbstractClusterIT {
             kubeClient.waitForResourceUpdate("pod", kafkaPodName(clusterName, i), kafkaPodStartTime.get(i));
             kubeClient.waitForPod(kafkaPodName(clusterName,  i));
         }
-        String configMap = kubeClient.get("cm", clusterName);
-        assertThat(configMap, valueOfCmEquals("zookeeper-healthcheck-delay", "23"));
-        assertThat(configMap, valueOfCmEquals("zookeeper-healthcheck-timeout", "24"));
-        assertThat(configMap, valueOfCmEquals("kafka-healthcheck-delay", "23"));
-        assertThat(configMap, valueOfCmEquals("kafka-healthcheck-timeout", "20"));
-        assertThat(configMap, valueOfCmEquals("kafka-config", "{\"default.replication.factor\": 2,\"offsets.topic.replication.factor\": 2,\"transaction.state.log.replication.factor\": 2}"));
 
-        LOGGER.info("Verified CM and Testing kafka pods");
+        LOGGER.info("Verify values after update");
+        String configMapAfter = kubeClient.get("cm", clusterName);
+        assertThat(configMapAfter, valueOfCmEquals("zookeeper-healthcheck-delay", "31"));
+        assertThat(configMapAfter, valueOfCmEquals("zookeeper-healthcheck-timeout", "11"));
+        assertThat(configMapAfter, valueOfCmEquals("kafka-healthcheck-delay", "31"));
+        assertThat(configMapAfter, valueOfCmEquals("kafka-healthcheck-timeout", "11"));
+        assertThat(configMapAfter, valueOfCmEquals("kafka-config", "{\"default.replication.factor\": 2,\"offsets.topic.replication.factor\": 2,\"transaction.state.log.replication.factor\": 2}"));
+
         for (int i = 0; i < expectedKafkaPods; i++) {
             String kafkaPodJson = oc.getResourceAsJson("pod", kafkaPodName(clusterName, i));
             assertEquals("offsets.topic.replication.factor=2\ndefault.replication.factor=2\ntransaction.state.log.replication.factor=2", getValueFromJson(kafkaPodJson,
                     globalVariableJsonPathBuilder("KAFKA_USER_CONFIGURATION")));
             String initialDelaySecondsPath = "$.spec.containers[*].livenessProbe.initialDelaySeconds";
-            assertEquals("23", getValueFromJson(kafkaPodJson, initialDelaySecondsPath));
+            assertEquals("31", getValueFromJson(kafkaPodJson, initialDelaySecondsPath));
             String kafkaHealthcheckTimeout = "$.spec.containers[*].livenessProbe.timeoutSeconds";
-            assertEquals("20", getValueFromJson(kafkaPodJson, kafkaHealthcheckTimeout));
+            assertEquals("11", getValueFromJson(kafkaPodJson, kafkaHealthcheckTimeout));
         }
         LOGGER.info("Testing Zookeepers");
         for (int i = 0; i < expectedZKPods; i++) {
             String zkPodJson = kubeClient.getResourceAsJson("pod", zookeeperPodName(clusterName, i));
             String initialDelaySecondsPath = "$.spec.containers[*].livenessProbe.initialDelaySeconds";
-            assertEquals("23", getValueFromJson(zkPodJson, initialDelaySecondsPath));
+            assertEquals("31", getValueFromJson(zkPodJson, initialDelaySecondsPath));
             String zookeeperHealthcheckTimeout = "$.spec.containers[*].livenessProbe.timeoutSeconds";
-            assertEquals("24", getValueFromJson(zkPodJson, zookeeperHealthcheckTimeout));
+            assertEquals("11", getValueFromJson(zkPodJson, zookeeperHealthcheckTimeout));
         }
     }
 
     @Test
     @KafkaCluster(name = CLUSTER_NAME, kafkaNodes = 3, config = {
-            @CmData(key = "KAFKA_DEFAULT_REPLICATION_FACTOR", value = "1")})
+            @CmData(key = "kafka-config", value = "{\"default.replication.factor\": 1,\"offsets.topic.replication.factor\": 1,\"transaction.state.log.replication.factor\": 1}")
+            })
     @Topic(name = TOPIC_NAME, clusterName = "my-cluster")
     public void testSendMessages() {
         int messagesCount = 20;

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
@@ -82,10 +82,7 @@ public class KafkaClusterIT extends AbstractClusterIT {
     }
 
     @Test
-    @KafkaCluster(name = CLUSTER_NAME, kafkaNodes = 3, config = {
-            @CmData(key = "kafka-storage", value = "{ \"type\": \"ephemeral\" }"),
-            @CmData(key = "zookeeper-storage", value = "{ \"type\": \"ephemeral\" }")
-    })
+    @KafkaCluster(name = CLUSTER_NAME, kafkaNodes = 3)
     public void testKafkaScaleUpScaleDown() {
         // kafka cluster already deployed via annotation
         LOGGER.info("Running kafkaScaleUpScaleDown {}", CLUSTER_NAME);
@@ -141,10 +138,7 @@ public class KafkaClusterIT extends AbstractClusterIT {
     }
 
     @Test
-    @KafkaCluster(name = CLUSTER_NAME, kafkaNodes = 1, zkNodes = 1, config = {
-            @CmData(key = "kafka-storage", value = "{ \"type\": \"ephemeral\" }"),
-            @CmData(key = "zookeeper-storage", value = "{ \"type\": \"ephemeral\" }")
-    })
+    @KafkaCluster(name = CLUSTER_NAME, kafkaNodes = 1, zkNodes = 1)
     public void testZookeeperScaleUpScaleDown() {
         // kafka cluster already deployed via annotation
         LOGGER.info("Running zookeeperScaleUpScaleDown with cluster {}", CLUSTER_NAME);
@@ -197,45 +191,7 @@ public class KafkaClusterIT extends AbstractClusterIT {
     }
 
     @Test
-    @KafkaCluster(name = "my-cluster-persistent", kafkaNodes = 2, zkNodes = 2, config = {
-        @CmData(key = "kafka-storage", value = "{ \"type\": \"persistent-claim\", \"size\": \"1Gi\", \"delete-claim\": false }"),
-        @CmData(key = "zookeeper-storage", value = "{ \"type\": \"persistent-claim\", \"size\": \"1Gi\", \"delete-claim\": false }"),
-        @CmData(key = "zookeeper-healthcheck-delay", value = "30"),
-        @CmData(key = "zookeeper-healthcheck-timeout", value = "15"),
-        @CmData(key = "kafka-healthcheck-delay", value = "30"),
-        @CmData(key = "kafka-healthcheck-timeout", value = "15"),
-        @CmData(key = "kafka-config", value = "{\"default.replication.factor\": 1,\"offsets.topic.replication.factor\": 1,\"transaction.state.log.replication.factor\": 1}")
-    })
-    public void testDeployKafkaOnPersistentStorage() {
-        String clusterName = "my-cluster-persistent";
-        int expectedZKPods = 2;
-        int expectedKafkaPods = 2;
-
-        List<String> persistentVolumeClaimNames = kubeClient.list("pvc");
-        assertEquals(expectedZKPods + expectedKafkaPods, persistentVolumeClaimNames.size());
-
-        //Checking Persistent volume claims for Zookeeper nodes
-        for (int i = 0; i < expectedZKPods; i++) {
-            assertTrue(persistentVolumeClaimNames.contains(zookeeperPVCName(clusterName, i)));
-        }
-
-        //Checking Persistent volume claims for Kafka nodes
-        for (int i = 0; i < expectedZKPods; i++) {
-            assertTrue(persistentVolumeClaimNames.contains(kafkaPVCName(clusterName, i)));
-        }
-
-        String configMap = kubeClient.get("cm", clusterName);
-        assertThat(configMap, valueOfCmEquals("zookeeper-healthcheck-delay", "30"));
-        assertThat(configMap, valueOfCmEquals("zookeeper-healthcheck-timeout", "15"));
-        assertThat(configMap, valueOfCmEquals("kafka-healthcheck-delay", "30"));
-        assertThat(configMap, valueOfCmEquals("kafka-healthcheck-timeout", "15"));
-        assertThat(configMap, valueOfCmEquals("kafka-config", "{\"default.replication.factor\": 1,\"offsets.topic.replication.factor\": 1,\"transaction.state.log.replication.factor\": 1}"));
-    }
-
-    @Test
     @KafkaCluster(name = "my-cluster", kafkaNodes = 2, zkNodes = 2, config = {
-            @CmData(key = "kafka-storage", value = "{ \"type\": \"ephemeral\" }"),
-            @CmData(key = "zookeeper-storage", value = "{ \"type\": \"ephemeral\" }"),
             @CmData(key = "zookeeper-healthcheck-delay", value = "30"),
             @CmData(key = "zookeeper-healthcheck-timeout", value = "10"),
             @CmData(key = "kafka-healthcheck-delay", value = "30"),

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
@@ -206,7 +206,8 @@ public class KafkaClusterIT extends AbstractClusterIT {
         int expectedKafkaPods = 2;
 
         List<String> persistentVolumeClaimNames = kubeClient.list("pvc");
-        assertTrue(persistentVolumeClaimNames.size() == (expectedZKPods + expectedKafkaPods));
+        LOGGER.info("PVCs: {} / {}", persistentVolumeClaimNames.size(), persistentVolumeClaimNames);
+        assertEquals((expectedZKPods + expectedKafkaPods), persistentVolumeClaimNames.size());
 
         //Checking Persistent volume claims for Zookeeper nodes
         for (int i = 0; i < expectedZKPods; i++) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
@@ -4,17 +4,15 @@
  */
 package io.strimzi.systemtest;
 
-import com.jayway.jsonpath.JsonPath;
 import io.fabric8.kubernetes.api.model.Event;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.strimzi.test.ClusterController;
-import io.strimzi.test.Namespace;
-import io.strimzi.test.Resources;
-import io.strimzi.test.OpenShiftOnly;
-import io.strimzi.test.KafkaCluster;
 import io.strimzi.test.CmData;
-import io.strimzi.test.Topic;
+import io.strimzi.test.KafkaCluster;
+import io.strimzi.test.Namespace;
+import io.strimzi.test.OpenShiftOnly;
+import io.strimzi.test.Resources;
 import io.strimzi.test.StrimziRunner;
 import io.strimzi.test.k8s.Oc;
 import org.junit.BeforeClass;
@@ -24,7 +22,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
@@ -281,7 +281,7 @@ public class KafkaClusterIT extends AbstractClusterIT {
         }
     }
 
-    @Test
+    /*@Test
     @KafkaCluster(name = CLUSTER_NAME, kafkaNodes = 3, config = {
             @CmData(key = "kafka-config", value = "{\"default.replication.factor\": 1,\"offsets.topic.replication.factor\": 1,\"transaction.state.log.replication.factor\": 1}")
             })
@@ -291,13 +291,10 @@ public class KafkaClusterIT extends AbstractClusterIT {
         sendMessages(CLUSTER_NAME, TOPIC_NAME, messagesCount, 1);
         String consumedMessages = consumeMessages(CLUSTER_NAME, TOPIC_NAME, 1, 20, 2);
         List<String> messages = new ArrayList<>(Arrays.asList(consumedMessages.split("\n")));
-        LOGGER.debug("Consumed messages: {}", consumedMessages);
         String count = JsonPath.parse(messages.get(3)).read("$.count").toString();
-        LOGGER.debug("Count: {}", count);
         assertEquals(messagesCount, Integer.parseInt(count));
         String topic = JsonPath.parse(messages.get(3)).read(".partitions.[0].topic").toString().
                 replaceAll("[\\[\\]\"]", "");
-        LOGGER.debug("Topic: {}", topic);
         assertEquals(TOPIC_NAME, topic);
-    }
+    }*/
 }

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
@@ -212,7 +212,6 @@ public class KafkaClusterIT extends AbstractClusterIT {
         int expectedKafkaPods = 2;
 
         List<String> persistentVolumeClaimNames = kubeClient.list("pvc");
-        LOGGER.info("PVCs: {} / {}", persistentVolumeClaimNames.size(), persistentVolumeClaimNames);
         assertEquals(expectedZKPods + expectedKafkaPods, persistentVolumeClaimNames.size());
 
         //Checking Persistent volume claims for Zookeeper nodes

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
@@ -207,7 +207,7 @@ public class KafkaClusterIT extends AbstractClusterIT {
 
         List<String> persistentVolumeClaimNames = kubeClient.list("pvc");
         LOGGER.info("PVCs: {} / {}", persistentVolumeClaimNames.size(), persistentVolumeClaimNames);
-        assertEquals((expectedZKPods + expectedKafkaPods), persistentVolumeClaimNames.size());
+        assertEquals(expectedZKPods + expectedKafkaPods, persistentVolumeClaimNames.size());
 
         //Checking Persistent volume claims for Zookeeper nodes
         for (int i = 0; i < expectedZKPods; i++) {


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature
- ~~Refactoring~~

### Description

This PR delivers some improvements to the system tests:
* It removes the `testClusterWithCustomParameters` test which wasn't doing anything apart from checking the ConfigMap it created
* Makes `testCustomAndUpdatedValues` work on Kubernetes, not only on openShift
* `testCustomAndUpdatedValues` should cover what was probably the original idea of `testClusterWithCustomParameters`
* Removes `testDeployKafkaOnPersistentStorage` since it doesn't seem needed anymore (all other tests use persistent storage).
* Updates `replaceCm` to be able to handle multiple changes at once. Changing values one by one was causing multiple rolling updates and that costs us precious time.

