### PR TITLE
ST: Fix for consuming messages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
         <slf4j.version>1.7.22</slf4j.version>
         <junit.version>4.12</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
+        <valid4j.version>1.1</valid4j.version>
         <fasterxml.jackson.version>2.9.3</fasterxml.jackson.version>
         <fasterxml.jackson-annotations.version>2.9.0</fasterxml.jackson-annotations.version>
         <kafka.version>1.0.1</kafka.version>
@@ -169,6 +170,12 @@
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest-core</artifactId>
                 <version>${hamcrest.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.valid4j</groupId>
+                <artifactId>json-path-matchers</artifactId>
+                <version>${valid4j.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -20,6 +20,11 @@
             <artifactId>hamcrest-library</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.valid4j</groupId>
+            <artifactId>json-path-matchers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractClusterIT.java
@@ -179,6 +179,9 @@ public class AbstractClusterIT {
         LOGGER.info("Sending messages");
         String command = "sh bin/kafka-verifiable-producer.sh --broker-list " +
                 clusterName + "-kafka:9092 --topic " + topic + " --max-messages " + messagesCount + "";
+
+        LOGGER.info("Command for kafka-verifiable-producer.sh {}", command);
+
         kubeClient.exec(kafkaPodName(clusterName, kafkaPodID), "/bin/bash", "-c", command);
     }
 
@@ -188,8 +191,10 @@ public class AbstractClusterIT {
                 "bin/kafka-verifiable-consumer.sh --broker-list " + clusterName +
                         "-kafka:9092 --topic " + topic + " --group-id " + groupID + " & sleep "
                         + timeout + "; kill %1").out();
+        output = "[" + output.replaceAll("\n", ",") + "]";
+        LOGGER.info("Output for kafka-verifiable-consumer.sh {}", output);
+        return output;
 
-        return "[" + output.replaceAll("\n", ",") + "]";
     }
 
     protected void assertResources(String namespace, String podName, String memoryLimit, String cpuLimit, String memoryRequest, String cpuRequest) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractClusterIT.java
@@ -183,12 +183,13 @@ public class AbstractClusterIT {
     }
 
     public String consumeMessages(String clusterName, String topic, int groupID, int timeout, int kafkaPodID) {
-
         LOGGER.info("Consuming messages");
-        return kubeClient.exec(kafkaPodName(clusterName, kafkaPodID), "/bin/bash", "-c",
-                    "bin/kafka-verifiable-consumer.sh --broker-list " + clusterName +
-                            "-kafka:9092 --topic " + topic + " --group-id " + groupID + " & sleep "
-                            + timeout + "; kill %1").out();
+        String output = kubeClient.exec(kafkaPodName(clusterName, kafkaPodID), "/bin/bash", "-c",
+                "bin/kafka-verifiable-consumer.sh --broker-list " + clusterName +
+                        "-kafka:9092 --topic " + topic + " --group-id " + groupID + " & sleep "
+                        + timeout + "; kill %1").out();
+
+        return "[" + output.replaceAll("\n", ",") + "]";
     }
 
     protected void assertResources(String namespace, String podName, String memoryLimit, String cpuLimit, String memoryRequest, String cpuRequest) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.systemtest;
 
-import com.jayway.jsonpath.JsonPath;
 import io.fabric8.kubernetes.api.model.Event;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -25,7 +24,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
@@ -282,7 +282,7 @@ public class KafkaClusterIT extends AbstractClusterIT {
     }
 
     @Test
-    @JUnitGroup(name = "regression")
+    @JUnitGroup(name = "acceptance")
     @KafkaCluster(name = CLUSTER_NAME, kafkaNodes = 3, config = {
             @CmData(key = "kafka-config", value = "{\"default.replication.factor\": 1,\"offsets.topic.replication.factor\": 1,\"transaction.state.log.replication.factor\": 1}")
             })

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
@@ -284,7 +284,7 @@ public class KafkaClusterIT extends AbstractClusterIT {
     @Test
     @JUnitGroup(name = "acceptance")
     @KafkaCluster(name = CLUSTER_NAME, kafkaNodes = 3, config = {
-            @CmData(key = "kafka-config", value = "{\"default.replication.factor\": 1,\"offsets.topic.replication.factor\": 1,\"transaction.state.log.replication.factor\": 1}")
+            @CmData(key = "kafka-config", value = "{\"default.replication.factor\": 3,\"offsets.topic.replication.factor\": 3,\"transaction.state.log.replication.factor\": 3}")
             })
     @Topic(name = TOPIC_NAME, clusterName = "my-cluster")
     public void testSendMessages() {

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
@@ -282,7 +282,7 @@ public class KafkaClusterIT extends AbstractClusterIT {
     }
 
     @Test
-    @JUnitGroup(name = "acceptance")
+    @JUnitGroup(name = "regression")
     @KafkaCluster(name = CLUSTER_NAME, kafkaNodes = 3, config = {
             @CmData(key = "kafka-config", value = "{\"default.replication.factor\": 3,\"offsets.topic.replication.factor\": 3,\"transaction.state.log.replication.factor\": 3}")
             })


### PR DESCRIPTION
### Type of change
- Bugfix

### Description
1. Added json-path-matchers as a dependency for using JSON matchers instead of working with objects
2. Increased timeout for consuming messages. 20 seconds is not enough for consuming messages
3. Moved logic with parsing JSON to matchers (it will be helpful to have good assertion output in a case with failure)
4. Fixed JSON from kafka-verifiable-consumer.sh output

The previous state of the object:
`{...}
{...}`

after fix we have(Added brackets and commas):
`[{...},
{...}]`




### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation

