### PR TITLE
Travis improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ services:
 #  apt:
 #    packages:
 #      - asciidoctor
+install: true
 before_install:
 - gem install asciidoctor
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,9 @@ before_script:
 - "./.travis/setup-kubernetes.sh"
 script:
 - "./.travis/build.sh"
+cache:
+  directories:
+  - $HOME/.m2
 env:
   global:
   - PULL_REQUEST=${TRAVIS_PULL_REQUEST}

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -15,7 +15,7 @@ all: docker_build docker_push
 
 docker_build:
 	# Build Docker image ...
-	docker build -t strimzi/$(PROJECT_NAME):latest $(DOCKERFILE_DIR)
+	docker build -q -t strimzi/$(PROJECT_NAME):latest $(DOCKERFILE_DIR)
 
 docker_tag:
 	# Tag the "latest" image we built with the given tag

--- a/Makefile.maven
+++ b/Makefile.maven
@@ -1,11 +1,12 @@
 # Makefile.maven contains the shared tasks for building Java applications. This file is
 # included into the Makefile files which contain some Java sources which should be build
 # (E.g. cluster-controller etc.).
-#
+
+MVN_ARGS        ?= -q
 
 java_build:
 	echo "Building JAR file ..."
-	mvn ${MVN_ARGS} verify
+	mvn $(MVN_ARGS) verify
 
 java_clean:
 	echo "Cleaning Maven build ..."

--- a/Makefile.maven
+++ b/Makefile.maven
@@ -2,11 +2,9 @@
 # included into the Makefile files which contain some Java sources which should be build
 # (E.g. cluster-controller etc.).
 
-MVN_ARGS        ?= -q
-
 java_build:
 	echo "Building JAR file ..."
-	mvn $(MVN_ARGS) verify
+	mvn -q $(MVN_ARGS) verify
 
 java_clean:
 	echo "Cleaning Maven build ..."

--- a/common-test/Makefile
+++ b/common-test/Makefile
@@ -8,6 +8,14 @@ clean: java_clean
 
 #include ../Makefile.docker
 
-include ../Makefile.maven
+java_build:
+	echo "Building JAR file ..."
+	mvn -DtrimStackTrace=false install
+
+java_clean:
+	echo "Cleaning Maven build ..."
+	mvn clean
+
+#include ../Makefile.maven
 
 .PHONY: build clean release

--- a/common-test/Makefile
+++ b/common-test/Makefile
@@ -8,14 +8,6 @@ clean: java_clean
 
 #include ../Makefile.docker
 
-java_build:
-	echo "Building JAR file ..."
-	mvn -DtrimStackTrace=false install
-
-java_clean:
-	echo "Cleaning Maven build ..."
-	mvn clean
-
-#include ../Makefile.maven
+include ../Makefile.maven
 
 .PHONY: build clean release

--- a/common-test/Makefile
+++ b/common-test/Makefile
@@ -10,7 +10,7 @@ clean: java_clean
 
 java_build:
 	echo "Building JAR file ..."
-	mvn -DtrimStackTrace=false install
+	mvn -q -DtrimStackTrace=false install
 
 java_clean:
 	echo "Cleaning Maven build ..."

--- a/systemtest/scripts/run_tests.sh
+++ b/systemtest/scripts/run_tests.sh
@@ -5,4 +5,4 @@ if [ -n "$TESTCASE" ]; then
     EXTRA_ARGS="-Dtest=$TESTCASE"
 fi
 
-mvn verify -pl systemtest -Djava.net.preferIPv4Stack=true -DtrimStackTrace=false $EXTRA_ARGS
+mvn -q verify -pl systemtest -Djava.net.preferIPv4Stack=true -DtrimStackTrace=false $EXTRA_ARGS

--- a/topic-controller/src/test/resources/log4j.properties
+++ b/topic-controller/src/test/resources/log4j.properties
@@ -3,5 +3,5 @@ log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
 
-log4j.logger.io.strimzi=DEBUG, stdout
+log4j.logger.io.strimzi=INFO, stdout
 log4j.additivity.io.strimzi=false


### PR DESCRIPTION
### Type of change

- CI improvement

### Description

* Make the output less noisy by telling `mvn` and `docker` to be quiet.
* Disable the default behaviour of the travis `install` phase. For [a java project](https://docs.travis-ci.com/user/languages/java/) this does, approximately, `mvn install`, which is pointless for us as the java artifacts get build in the `script` phase.
* Use the travis [cache](https://docs.travis-ci.com/user/caching/) for mvn dependencies.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging

