### PR TITLE
Add missing strimzi.io/cluster label to TC examples in docu - Closes #407

### DIFF
--- a/documentation/adoc/getting-started.adoc
+++ b/documentation/adoc/getting-started.adoc
@@ -310,6 +310,6 @@ for "topic ConfigMaps" which are those with the following labels:
 strimzi.io/cluster: <cluster-name>
 strimzi.io/kind: topic
 
-When the Topic Controller is deployed manually the `strimzi.io/cluster` label is not necessary.
+NOTE: When the Topic Controller is deployed manually the `strimzi.io/cluster` label is not necessary.
 
 The topic ConfigMap contains the topic configuration in a specific format. The ConfigMap format is described in <<topic_config_map_details>>.

--- a/documentation/adoc/topic-controller.adoc
+++ b/documentation/adoc/topic-controller.adoc
@@ -109,11 +109,14 @@ metadata:
   name: orders
   labels:
     strimzi.io/kind: topic
+    strimzi.io/cluster: my-cluster
 data:
   name: orders
   partitions: "10"
   replicas: "2"
 ----
+
+NOTE: When the Topic Controller is deployed manually the `strimzi.io/cluster` label is not necessary.
 
 Because the `config` key is omitted from the `data` the topic's config will be empty, and thus default to the 
 Kafka broker default.
@@ -146,6 +149,7 @@ metadata:
   name: orders
   labels:
     strimzi.io/kind: topic
+    strimzi.io/cluster: my-cluster
 data:
   name: orders
   partitions: "10"


### PR DESCRIPTION
### Type of change

- Bugfix
- ~~Enhancement / new feature~~
- ~~Refactoring~~

### Description

I most TC examples the default expectation is that TC has been deployed from CC and such examples have the `strimzi.io/cluster` label. But the TC documentation had examples without this label. This PR adds the labels to all examples (with a note that such label might not be needed when deploying TC directly).
