### PR TITLE
Cc limits

### DIFF
--- a/common-test/src/main/java/io/strimzi/test/StrimziRunner.java
+++ b/common-test/src/main/java/io/strimzi/test/StrimziRunner.java
@@ -422,9 +422,9 @@ public class StrimziRunner extends BlockJUnit4ClassRunner {
                     JsonNodeFactory factory = new JsonNodeFactory(false);
                     ObjectNode resources = new ObjectNode(factory);
                     ObjectNode requests = new ObjectNode(factory);
-                    requests.put("cpu", "250m").put("memory", "128Mi");
+                    requests.put("cpu", "200m").put("memory", "128Mi");
                     ObjectNode limits = new ObjectNode(factory);
-                    limits.put("cpu", "250m").put("memory", "128Mi");
+                    limits.put("cpu", "1000m").put("memory", "128Mi");
                     resources.set("requests", requests);
                     resources.set("limits", limits);
                     containerNode.replace("resources", resources);

--- a/common-test/src/main/java/io/strimzi/test/StrimziRunner.java
+++ b/common-test/src/main/java/io/strimzi/test/StrimziRunner.java
@@ -422,9 +422,9 @@ public class StrimziRunner extends BlockJUnit4ClassRunner {
                     JsonNodeFactory factory = new JsonNodeFactory(false);
                     ObjectNode resources = new ObjectNode(factory);
                     ObjectNode requests = new ObjectNode(factory);
-                    requests.put("cpu", "200m").put("memory", "128Mi");
+                    requests.put("cpu", "250m").put("memory", "128Mi");
                     ObjectNode limits = new ObjectNode(factory);
-                    limits.put("cpu", "200m").put("memory", "128Mi");
+                    limits.put("cpu", "250m").put("memory", "128Mi");
                     resources.set("requests", requests);
                     resources.set("limits", limits);
                     containerNode.replace("resources", resources);

--- a/common-test/src/main/java/io/strimzi/test/StrimziRunner.java
+++ b/common-test/src/main/java/io/strimzi/test/StrimziRunner.java
@@ -419,6 +419,15 @@ public class StrimziRunner extends BlockJUnit4ClassRunner {
                     String dockerTag = System.getenv().getOrDefault("DOCKER_TAG", "latest");
                     ObjectNode containerNode = (ObjectNode) node.get("spec").get("template").get("spec").get("containers").get(0);
                     containerNode.put("imagePullPolicy", "Always");
+                    JsonNodeFactory factory = new JsonNodeFactory(false);
+                    ObjectNode resources = new ObjectNode(factory);
+                    ObjectNode requests = new ObjectNode(factory);
+                    requests.put("cpu", "200m").put("memory", "128Mi");
+                    ObjectNode limits = new ObjectNode(factory);
+                    limits.put("cpu", "200m").put("memory", "128Mi");
+                    resources.set("requests", requests);
+                    resources.set("limits", limits);
+                    containerNode.replace("resources", resources);
                     JsonNode ccImageNode = containerNode.get("image");
                     ((ObjectNode) containerNode).put("image", changeOrgAndTag(ccImageNode.asText(), dockerOrg, dockerTag));
                     for (JsonNode envVar : containerNode.get("env")) {

--- a/documentation/adoc/cluster-controller.adoc
+++ b/documentation/adoc/cluster-controller.adoc
@@ -376,6 +376,13 @@ Optional with no default.
 the cpu request for the container, corresponding directly to Kubernetes' {resources-link}[`spec.containers[\].resources.limits.cpu`] setting.
 Optional with no default.
 
+====== Minimum Resource Requirements
+
+Testing has shown that the cluster controller functions adequately with 128Mi of memory and 200m CPU when watching two clusters.
+It is therefore recommended to use these as a minimum when configuring resource requests and not to run it with lower limits than these.
+Configuring more generous limits is recommended, especially when it's controlling multiple clusters.
+
+
 [[jvm_json_config]]
 ===== JVM Options
 

--- a/documentation/adoc/topic-controller.adoc
+++ b/documentation/adoc/topic-controller.adoc
@@ -192,3 +192,16 @@ back-off. You might want to increase this value when topic creation could take m
 If the controller configuration needs to be changed the process must be killed and restarted.
 Since the controller is intended to execute within Kubernetes, this can be achieved
 by deleting the pod.
+
+
+=== Resource limits and requests
+
+The Topic Controller can run with resource limits:
+
+* When it is deployed by the Cluster Controller these can be specified in the `resources` key of the `topic-controller-config`.
+* When it is not deployed by the Cluster Controller these can be specified on the Deployment in the usual way.
+
+==== Minimum Resource Requirements
+
+Testing has shown that the topic controller functions adequately with 96Mi of memory and 100m CPU when watching two topics.
+It is therefore recommended to use these as a minimum when configuring resource requests and not to run it with lower limits than these. If the Kafka cluster has more than a handful of topics more generous requests and limits will be necessary.

--- a/examples/install/cluster-controller/04-deployment.yaml
+++ b/examples/install/cluster-controller/04-deployment.yaml
@@ -49,9 +49,9 @@ spec:
           resources:
             limits:
               memory: 128Mi
-              cpu: 200m
+              cpu: 250m
             requests:
               memory: 128Mi
-              cpu: 200m
+              cpu: 250m
   strategy:
     type: Recreate

--- a/examples/install/cluster-controller/04-deployment.yaml
+++ b/examples/install/cluster-controller/04-deployment.yaml
@@ -46,5 +46,12 @@ spec:
               port: 8080
             initialDelaySeconds: 10
             periodSeconds: 30
+          resources:
+            limits:
+              memory: 128Mi
+              cpu: 200m
+            requests:
+              memory: 128Mi
+              cpu: 200m
   strategy:
     type: Recreate

--- a/examples/install/cluster-controller/04-deployment.yaml
+++ b/examples/install/cluster-controller/04-deployment.yaml
@@ -49,9 +49,9 @@ spec:
           resources:
             limits:
               memory: 128Mi
-              cpu: 250m
+              cpu: 1000m
             requests:
               memory: 128Mi
-              cpu: 250m
+              cpu: 200m
   strategy:
     type: Recreate

--- a/examples/install/topic-controller/04-deployment.yaml
+++ b/examples/install/topic-controller/04-deployment.yaml
@@ -42,5 +42,12 @@ spec:
               port: 8080
             initialDelaySeconds: 10
             periodSeconds: 30
+          resources:
+            limits:
+              memory: 96Mi
+              cpu: 100m
+            requests:
+              memory: 96Mi
+              cpu: 100m
   strategy:
     type: Recreate


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Fixes #326 and #327 by adding resource limits and requests to the CC and TC YAML resources. The numbers used here were determined by experiment, in both cases two simultaneous reconciliations were observed with stable heap and CPU usage. When significantly lower numbers were use errors were observed.

### Checklist

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging

