### PR TITLE
Fixed namespace where the watcher watches for topic ConfigMaps

### DIFF
--- a/topic-controller/src/main/java/io/strimzi/controller/topic/Session.java
+++ b/topic-controller/src/main/java/io/strimzi/controller/topic/Session.java
@@ -139,7 +139,7 @@ public class Session extends AbstractVerticle {
 
         Thread configMapThread = new Thread(() -> {
             LOGGER.debug("Watching configmaps matching {}", cmPredicate);
-            Session.this.topicCmWatch = kubeClient.configMaps().inNamespace(kubeClient.getNamespace()).watch(new ConfigMapWatcher(controller, cmPredicate));
+            Session.this.topicCmWatch = kubeClient.configMaps().inNamespace(namespace).watch(new ConfigMapWatcher(controller, cmPredicate));
             LOGGER.debug("Watching setup");
 
             // start the HTTP server for healthchecks


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The current watcher started by the TC always watches for topic configmaps in the namespace where the TC deployed which can be different from the `STRIMZI_NAMESPACE` env var. This PR fixes that, using the namespace provided by the `STRIMZI_NAMESPACE` env var.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging

