### PR TITLE
Use correct default image for S2I

### DIFF
--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/KafkaConnectS2ICluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/KafkaConnectS2ICluster.java
@@ -37,7 +37,7 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
 
     // Configuration defaults
     protected static final String DEFAULT_IMAGE =
-            System.getenv().getOrDefault("STRIMZI_DEFAULT_KAFKA_IMAGE", "strimzi/kafka-connect-s2i:latest");
+            System.getenv().getOrDefault("STRIMZI_DEFAULT_KAFKA_CONNECT_S2I_IMAGE", "strimzi/kafka-connect-s2i:latest");
 
     /**
      * Constructor


### PR DESCRIPTION
### Type of change

- Bugfix
- ~~Enhancement / new feature~~
- ~~Refactoring~~

### Description

There is a nasty bug since at least 0.3.0 - the default image for Kafka Connect S2I is using wrong environment variable and thus incorrect image.
