### PR TITLE
Enhanced configuration for Kafka Connect

### DIFF
--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/KafkaCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/KafkaCluster.java
@@ -157,7 +157,7 @@ public class KafkaCluster extends AbstractModel {
      */
     public static KafkaCluster fromAssembly(StatefulSet ss, String namespace, String cluster) {
 
-        KafkaCluster kafka =  new KafkaCluster(namespace, cluster, Labels.fromResource(ss));
+        KafkaCluster kafka = new KafkaCluster(namespace, cluster, Labels.fromResource(ss));
 
         kafka.setReplicas(ss.getSpec().getReplicas());
         Container container = ss.getSpec().getTemplate().getSpec().getContainers().get(0);
@@ -187,7 +187,10 @@ public class KafkaCluster extends AbstractModel {
             kafka.setStorage(storage);
         }
 
-        kafka.setConfiguration(new KafkaConfiguration(vars.getOrDefault(KEY_KAFKA_USER_CONFIGURATION, "")));
+        String kafkaConfiguration = containerEnvVars(container).get(KEY_KAFKA_USER_CONFIGURATION);
+        if (kafkaConfiguration != null) {
+            kafka.setConfiguration(new KafkaConfiguration(kafkaConfiguration));
+        }
 
         return kafka;
     }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/KafkaConnectCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/KafkaConnectCluster.java
@@ -45,7 +45,7 @@ public class KafkaConnectCluster extends AbstractModel {
     public static final String KEY_CONNECT_CONFIG = "connect-config";
 
     // Kafka Connect configuration keys (EnvVariables)
-    protected static final String KEY_KAFKA_CONNECT_USER_CONFIGURATION = "KAFKA_CONNECT_USER_CONFIGURATION";
+    protected static final String ENV_VAR_KAFKA_CONNECT_USER_CONFIGURATION = "KAFKA_CONNECT_USER_CONFIGURATION";
 
     public static String kafkaConnectClusterName(String cluster) {
         return cluster + KafkaConnectCluster.NAME_SUFFIX;
@@ -117,7 +117,7 @@ public class KafkaConnectCluster extends AbstractModel {
         kafkaConnect.setHealthCheckInitialDelay(container.getReadinessProbe().getInitialDelaySeconds());
         kafkaConnect.setHealthCheckTimeout(container.getReadinessProbe().getTimeoutSeconds());
 
-        String connectConfiguration = containerEnvVars(container).get(KEY_KAFKA_CONNECT_USER_CONFIGURATION);
+        String connectConfiguration = containerEnvVars(container).get(ENV_VAR_KAFKA_CONNECT_USER_CONFIGURATION);
         if (connectConfiguration != null) {
             kafkaConnect.setConfiguration(new KafkaConfiguration(connectConfiguration));
         }
@@ -156,7 +156,7 @@ public class KafkaConnectCluster extends AbstractModel {
         List<EnvVar> varList = new ArrayList<>();
 
         if (configuration != null) {
-            varList.add(buildEnvVar(KEY_KAFKA_CONNECT_USER_CONFIGURATION, configuration.getConfiguration()));
+            varList.add(buildEnvVar(ENV_VAR_KAFKA_CONNECT_USER_CONFIGURATION, configuration.getConfiguration()));
         }
 
         kafkaHeapOptions(varList, 1.0, 0L);

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/KafkaConnectCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/KafkaConnectCluster.java
@@ -119,7 +119,7 @@ public class KafkaConnectCluster extends AbstractModel {
 
         String connectConfiguration = containerEnvVars(container).get(ENV_VAR_KAFKA_CONNECT_USER_CONFIGURATION);
         if (connectConfiguration != null) {
-            kafkaConnect.setConfiguration(new KafkaConfiguration(connectConfiguration));
+            kafkaConnect.setConfiguration(new KafkaConnectConfiguration(connectConfiguration));
         }
 
         return kafkaConnect;

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/KafkaConnectCluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/KafkaConnectCluster.java
@@ -117,8 +117,10 @@ public class KafkaConnectCluster extends AbstractModel {
         kafkaConnect.setHealthCheckInitialDelay(container.getReadinessProbe().getInitialDelaySeconds());
         kafkaConnect.setHealthCheckTimeout(container.getReadinessProbe().getTimeoutSeconds());
 
-        Map<String, String> vars = containerEnvVars(container);
-        kafkaConnect.setConfiguration(new KafkaConfiguration(vars.getOrDefault(KEY_KAFKA_CONNECT_USER_CONFIGURATION, "")));
+        String connectConfiguration = containerEnvVars(container).get(KEY_KAFKA_CONNECT_USER_CONFIGURATION);
+        if (connectConfiguration != null) {
+            kafkaConnect.setConfiguration(new KafkaConfiguration(connectConfiguration));
+        }
 
         return kafkaConnect;
     }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/KafkaConnectConfiguration.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/KafkaConnectConfiguration.java
@@ -19,7 +19,6 @@ public class KafkaConnectConfiguration extends AbstractConfiguration {
 
     static {
         FORBIDDEN_OPTIONS = asList(
-                //"bootstrap.servers",
                 "ssl.",
                 "sasl.",
                 "security.",

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/KafkaConnectConfiguration.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/KafkaConnectConfiguration.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017-2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.strimzi.controller.cluster.model;
+
+import io.vertx.core.json.JsonObject;
+
+import java.util.List;
+
+import static java.util.Arrays.asList;
+
+/**
+ * Class for handling Kafka Connect configuration passed by the user
+ */
+public class KafkaConnectConfiguration extends AbstractConfiguration {
+    private static final List<String> FORBIDDEN_OPTIONS;
+
+    static {
+        FORBIDDEN_OPTIONS = asList(
+                //"bootstrap.servers",
+                "ssl.",
+                "sasl.",
+                "security.",
+                "listeners",
+                "plugin.path",
+                "rest.");
+    }
+
+    /**
+     * Constructor used to instantiate this class from String configuration. Should be used to create configuration
+     * from the Assembly.
+     *
+     * @param configuration Configuration in String format. Should contain zero or more lines with with key=value
+     *                      pairs.
+     */
+    public KafkaConnectConfiguration(String configuration) {
+        super(configuration, FORBIDDEN_OPTIONS);
+    }
+
+    /**
+     * Constructor used to instantiate this class from JsonObject. Should be used to create configuration from
+     * ConfigMap / CRD.
+     *
+     * @param jsonOptions     Json object with configuration options as key ad value pairs.
+     */
+    public KafkaConnectConfiguration(JsonObject jsonOptions) {
+        super(jsonOptions, FORBIDDEN_OPTIONS);
+    }
+}

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/KafkaConnectS2ICluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/KafkaConnectS2ICluster.java
@@ -96,7 +96,7 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
         kafkaConnect.setHealthCheckInitialDelay(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getReadinessProbe().getInitialDelaySeconds());
         kafkaConnect.setHealthCheckTimeout(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getReadinessProbe().getTimeoutSeconds());
 
-        String connectConfiguration = containerEnvVars(dep.getSpec().getTemplate().getSpec().getContainers().get(0)).get(KEY_KAFKA_CONNECT_USER_CONFIGURATION);
+        String connectConfiguration = containerEnvVars(dep.getSpec().getTemplate().getSpec().getContainers().get(0)).get(ENV_VAR_KAFKA_CONNECT_USER_CONFIGURATION);
         if (connectConfiguration != null) {
             kafkaConnect.setConfiguration(new KafkaConfiguration(connectConfiguration));
         }

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/KafkaConnectS2ICluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/KafkaConnectS2ICluster.java
@@ -24,6 +24,7 @@ import io.fabric8.openshift.api.model.ImageLookupPolicyBuilder;
 import io.fabric8.openshift.api.model.ImageStream;
 import io.fabric8.openshift.api.model.ImageStreamBuilder;
 import io.fabric8.openshift.api.model.TagReference;
+import io.vertx.core.json.JsonObject;
 
 import java.util.Collections;
 import java.util.Map;
@@ -67,15 +68,10 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
         kafkaConnect.setHealthCheckInitialDelay(Integer.parseInt(data.getOrDefault(KEY_HEALTHCHECK_DELAY, String.valueOf(DEFAULT_HEALTHCHECK_DELAY))));
         kafkaConnect.setHealthCheckTimeout(Integer.parseInt(data.getOrDefault(KEY_HEALTHCHECK_TIMEOUT, String.valueOf(DEFAULT_HEALTHCHECK_TIMEOUT))));
 
-        kafkaConnect.setBootstrapServers(data.getOrDefault(KEY_BOOTSTRAP_SERVERS, DEFAULT_BOOTSTRAP_SERVERS));
-        kafkaConnect.setGroupId(data.getOrDefault(KEY_GROUP_ID, DEFAULT_GROUP_ID));
-        kafkaConnect.setKeyConverter(data.getOrDefault(KEY_KEY_CONVERTER, DEFAULT_KEY_CONVERTER));
-        kafkaConnect.setKeyConverterSchemasEnable(Boolean.parseBoolean(data.getOrDefault(KEY_KEY_CONVERTER_SCHEMAS_EXAMPLE, String.valueOf(DEFAULT_KEY_CONVERTER_SCHEMAS_EXAMPLE))));
-        kafkaConnect.setValueConverter(data.getOrDefault(KEY_VALUE_CONVERTER, DEFAULT_VALUE_CONVERTER));
-        kafkaConnect.setValueConverterSchemasEnable(Boolean.parseBoolean(data.getOrDefault(KEY_VALUE_CONVERTER_SCHEMAS_EXAMPLE, String.valueOf(DEFAULT_VALUE_CONVERTER_SCHEMAS_EXAMPLE))));
-        kafkaConnect.setConfigStorageReplicationFactor(Integer.parseInt(data.getOrDefault(KEY_CONFIG_STORAGE_REPLICATION_FACTOR, String.valueOf(DEFAULT_CONFIG_STORAGE_REPLICATION_FACTOR))));
-        kafkaConnect.setOffsetStorageReplicationFactor(Integer.parseInt(data.getOrDefault(KEY_OFFSET_STORAGE_REPLICATION_FACTOR, String.valueOf(DEFAULT_OFFSET_STORAGE_REPLICATION_FACTOR))));
-        kafkaConnect.setStatusStorageReplicationFactor(Integer.parseInt(data.getOrDefault(KEY_STATUS_STORAGE_REPLICATION_FACTOR, String.valueOf(DEFAULT_STATUS_STORAGE_REPLICATION_FACTOR))));
+        String connectConfig = data.get(KEY_CONNECT_CONFIG);
+        if (connectConfig != null) {
+            kafkaConnect.setConfiguration(new KafkaConnectConfiguration(new JsonObject(connectConfig)));
+        }
 
         return kafkaConnect;
     }
@@ -101,16 +97,7 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
         kafkaConnect.setHealthCheckTimeout(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getReadinessProbe().getTimeoutSeconds());
 
         Map<String, String> vars = containerEnvVars(dep.getSpec().getTemplate().getSpec().getContainers().get(0));
-
-        kafkaConnect.setBootstrapServers(vars.getOrDefault(KEY_BOOTSTRAP_SERVERS, DEFAULT_BOOTSTRAP_SERVERS));
-        kafkaConnect.setGroupId(vars.getOrDefault(KEY_GROUP_ID, DEFAULT_GROUP_ID));
-        kafkaConnect.setKeyConverter(vars.getOrDefault(KEY_KEY_CONVERTER, DEFAULT_KEY_CONVERTER));
-        kafkaConnect.setKeyConverterSchemasEnable(Boolean.parseBoolean(vars.getOrDefault(KEY_KEY_CONVERTER_SCHEMAS_EXAMPLE, String.valueOf(DEFAULT_KEY_CONVERTER_SCHEMAS_EXAMPLE))));
-        kafkaConnect.setValueConverter(vars.getOrDefault(KEY_VALUE_CONVERTER, DEFAULT_VALUE_CONVERTER));
-        kafkaConnect.setValueConverterSchemasEnable(Boolean.parseBoolean(vars.getOrDefault(KEY_VALUE_CONVERTER_SCHEMAS_EXAMPLE, String.valueOf(DEFAULT_VALUE_CONVERTER_SCHEMAS_EXAMPLE))));
-        kafkaConnect.setConfigStorageReplicationFactor(Integer.parseInt(vars.getOrDefault(KEY_CONFIG_STORAGE_REPLICATION_FACTOR, String.valueOf(DEFAULT_CONFIG_STORAGE_REPLICATION_FACTOR))));
-        kafkaConnect.setOffsetStorageReplicationFactor(Integer.parseInt(vars.getOrDefault(KEY_OFFSET_STORAGE_REPLICATION_FACTOR, String.valueOf(DEFAULT_OFFSET_STORAGE_REPLICATION_FACTOR))));
-        kafkaConnect.setStatusStorageReplicationFactor(Integer.parseInt(vars.getOrDefault(KEY_STATUS_STORAGE_REPLICATION_FACTOR, String.valueOf(DEFAULT_STATUS_STORAGE_REPLICATION_FACTOR))));
+        kafkaConnect.setConfiguration(new KafkaConfiguration(vars.getOrDefault(KEY_KAFKA_CONNECT_USER_CONFIGURATION, "")));
 
         String sourceImage = sis.getSpec().getTags().get(0).getFrom().getName();
         kafkaConnect.setImage(sourceImage);

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/KafkaConnectS2ICluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/KafkaConnectS2ICluster.java
@@ -98,7 +98,7 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
 
         String connectConfiguration = containerEnvVars(dep.getSpec().getTemplate().getSpec().getContainers().get(0)).get(ENV_VAR_KAFKA_CONNECT_USER_CONFIGURATION);
         if (connectConfiguration != null) {
-            kafkaConnect.setConfiguration(new KafkaConfiguration(connectConfiguration));
+            kafkaConnect.setConfiguration(new KafkaConnectConfiguration(connectConfiguration));
         }
 
         String sourceImage = sis.getSpec().getTags().get(0).getFrom().getName();

--- a/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/KafkaConnectS2ICluster.java
+++ b/cluster-controller/src/main/java/io/strimzi/controller/cluster/model/KafkaConnectS2ICluster.java
@@ -96,8 +96,10 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
         kafkaConnect.setHealthCheckInitialDelay(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getReadinessProbe().getInitialDelaySeconds());
         kafkaConnect.setHealthCheckTimeout(dep.getSpec().getTemplate().getSpec().getContainers().get(0).getReadinessProbe().getTimeoutSeconds());
 
-        Map<String, String> vars = containerEnvVars(dep.getSpec().getTemplate().getSpec().getContainers().get(0));
-        kafkaConnect.setConfiguration(new KafkaConfiguration(vars.getOrDefault(KEY_KAFKA_CONNECT_USER_CONFIGURATION, "")));
+        String connectConfiguration = containerEnvVars(dep.getSpec().getTemplate().getSpec().getContainers().get(0)).get(KEY_KAFKA_CONNECT_USER_CONFIGURATION);
+        if (connectConfiguration != null) {
+            kafkaConnect.setConfiguration(new KafkaConfiguration(connectConfiguration));
+        }
 
         String sourceImage = sis.getSpec().getTags().get(0).getFrom().getName();
         kafkaConnect.setImage(sourceImage);

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/ResourceUtils.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/ResourceUtils.java
@@ -109,24 +109,13 @@ public class ResourceUtils {
      * Generate ConfigMap for Kafka Connect S2I cluster
      */
     public static ConfigMap createKafkaConnectS2IClusterConfigMap(String clusterCmNamespace, String clusterCmName, int replicas,
-                                                                  String image, int healthDelay, int healthTimeout, String bootstrapServers,
-                                                                  String groupID, int configReplicationFactor, int offsetReplicationFactor,
-                                                                  int statusReplicationFactor, String keyConverter, String valueConverter,
-                                                                  boolean keyConverterSchemas, boolean valuesConverterSchema) {
+                                                                  String image, int healthDelay, int healthTimeout, String connectConfig) {
         Map<String, String> cmData = new HashMap<>();
         cmData.put(KafkaConnectS2ICluster.KEY_IMAGE, image);
         cmData.put(KafkaConnectS2ICluster.KEY_REPLICAS, Integer.toString(replicas));
         cmData.put(KafkaConnectS2ICluster.KEY_HEALTHCHECK_DELAY, Integer.toString(healthDelay));
         cmData.put(KafkaConnectS2ICluster.KEY_HEALTHCHECK_TIMEOUT, Integer.toString(healthTimeout));
-        cmData.put(KafkaConnectS2ICluster.KEY_BOOTSTRAP_SERVERS, bootstrapServers);
-        cmData.put(KafkaConnectS2ICluster.KEY_GROUP_ID, groupID);
-        cmData.put(KafkaConnectS2ICluster.KEY_CONFIG_STORAGE_REPLICATION_FACTOR, Integer.toString(configReplicationFactor));
-        cmData.put(KafkaConnectS2ICluster.KEY_OFFSET_STORAGE_REPLICATION_FACTOR, Integer.toString(offsetReplicationFactor));
-        cmData.put(KafkaConnectS2ICluster.KEY_STATUS_STORAGE_REPLICATION_FACTOR, Integer.toString(statusReplicationFactor));
-        cmData.put(KafkaConnectS2ICluster.KEY_KEY_CONVERTER, keyConverter);
-        cmData.put(KafkaConnectS2ICluster.KEY_KEY_CONVERTER_SCHEMAS_EXAMPLE, Boolean.toString(keyConverterSchemas));
-        cmData.put(KafkaConnectS2ICluster.KEY_VALUE_CONVERTER, valueConverter);
-        cmData.put(KafkaConnectS2ICluster.KEY_VALUE_CONVERTER_SCHEMAS_EXAMPLE, Boolean.toString(valuesConverterSchema));
+        cmData.put(KafkaConnectS2ICluster.KEY_CONNECT_CONFIG, connectConfig);
 
         ConfigMap cm = createEmptyKafkaConnectS2IClusterConfigMap(clusterCmNamespace, clusterCmName);
         cm.setData(cmData);
@@ -156,24 +145,13 @@ public class ResourceUtils {
      * Generate ConfigMap for Kafka Connect cluster
      */
     public static ConfigMap createKafkaConnectClusterConfigMap(String clusterCmNamespace, String clusterCmName, int replicas,
-                                                                  String image, int healthDelay, int healthTimeout, String bootstrapServers,
-                                                                  String groupID, int configReplicationFactor, int offsetReplicationFactor,
-                                                                  int statusReplicationFactor, String keyConverter, String valueConverter,
-                                                                  boolean keyConverterSchemas, boolean valuesConverterSchema) {
+                                                                  String image, int healthDelay, int healthTimeout, String connectConfig) {
         Map<String, String> cmData = new HashMap<>();
         cmData.put(KafkaConnectCluster.KEY_IMAGE, image);
         cmData.put(KafkaConnectCluster.KEY_REPLICAS, Integer.toString(replicas));
         cmData.put(KafkaConnectCluster.KEY_HEALTHCHECK_DELAY, Integer.toString(healthDelay));
         cmData.put(KafkaConnectCluster.KEY_HEALTHCHECK_TIMEOUT, Integer.toString(healthTimeout));
-        cmData.put(KafkaConnectCluster.KEY_BOOTSTRAP_SERVERS, bootstrapServers);
-        cmData.put(KafkaConnectCluster.KEY_GROUP_ID, groupID);
-        cmData.put(KafkaConnectCluster.KEY_CONFIG_STORAGE_REPLICATION_FACTOR, Integer.toString(configReplicationFactor));
-        cmData.put(KafkaConnectCluster.KEY_OFFSET_STORAGE_REPLICATION_FACTOR, Integer.toString(offsetReplicationFactor));
-        cmData.put(KafkaConnectCluster.KEY_STATUS_STORAGE_REPLICATION_FACTOR, Integer.toString(statusReplicationFactor));
-        cmData.put(KafkaConnectCluster.KEY_KEY_CONVERTER, keyConverter);
-        cmData.put(KafkaConnectCluster.KEY_KEY_CONVERTER_SCHEMAS_EXAMPLE, Boolean.toString(keyConverterSchemas));
-        cmData.put(KafkaConnectCluster.KEY_VALUE_CONVERTER, valueConverter);
-        cmData.put(KafkaConnectCluster.KEY_VALUE_CONVERTER_SCHEMAS_EXAMPLE, Boolean.toString(valuesConverterSchema));
+        cmData.put(KafkaConnectCluster.KEY_CONNECT_CONFIG, connectConfig);
 
         ConfigMap cm = createEmptyKafkaConnectClusterConfigMap(clusterCmNamespace, clusterCmName);
         cm.setData(cmData);

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/model/KafkaConnectClusterTest.java
@@ -35,7 +35,7 @@ public class KafkaConnectClusterTest {
 
     protected List<EnvVar> getExpectedEnvVars() {
         List<EnvVar> expected = new ArrayList<EnvVar>();
-        expected.add(new EnvVarBuilder().withName(KafkaConnectCluster.KEY_KAFKA_CONNECT_USER_CONFIGURATION).withValue("foo=bar\n").build());
+        expected.add(new EnvVarBuilder().withName(KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_USER_CONFIGURATION).withValue("foo=bar\n").build());
         expected.add(new EnvVarBuilder().withName(AbstractModel.ENV_VAR_DYNAMIC_HEAP_FRACTION).withValue("1.0").build());
         return expected;
     }

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/model/KafkaConnectConfigurationTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/model/KafkaConnectConfigurationTest.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017-2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.strimzi.controller.cluster.model;
+
+import io.vertx.core.json.JsonObject;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class KafkaConnectConfigurationTest {
+    @Test
+    public void testWithHostPort() {
+        JsonObject configuration = new JsonObject().put("bootstrap.server", "my-server:9092");
+        String expectedConfiguration = "bootstrap.server=my-server\\:9092\n";
+
+        AbstractConfiguration config = new KafkaConfiguration(configuration);
+        assertEquals(expectedConfiguration, config.getConfiguration());
+    }
+}

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/model/KafkaConnectConfigurationTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/model/KafkaConnectConfigurationTest.java
@@ -9,7 +9,6 @@ import io.vertx.core.json.JsonObject;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class KafkaConnectConfigurationTest {
     @Test

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/model/KafkaConnectS2IClusterTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/model/KafkaConnectS2IClusterTest.java
@@ -39,7 +39,7 @@ public class KafkaConnectS2IClusterTest {
 
     protected List<EnvVar> getExpectedEnvVars() {
         List<EnvVar> expected = new ArrayList<EnvVar>();
-        expected.add(new EnvVarBuilder().withName(KafkaConnectCluster.KEY_KAFKA_CONNECT_USER_CONFIGURATION).withValue("foo=bar\n").build());
+        expected.add(new EnvVarBuilder().withName(KafkaConnectCluster.ENV_VAR_KAFKA_CONNECT_USER_CONFIGURATION).withValue("foo=bar\n").build());
         expected.add(new EnvVarBuilder().withName(AbstractModel.ENV_VAR_DYNAMIC_HEAP_FRACTION).withValue("1.0").build());
         return expected;
     }

--- a/cluster-controller/src/test/java/io/strimzi/controller/cluster/model/KafkaConnectS2IClusterTest.java
+++ b/cluster-controller/src/test/java/io/strimzi/controller/cluster/model/KafkaConnectS2IClusterTest.java
@@ -14,13 +14,15 @@ import io.fabric8.openshift.api.model.DeploymentConfig;
 import io.fabric8.openshift.api.model.ImageChangeTrigger;
 import io.fabric8.openshift.api.model.ImageStream;
 import io.strimzi.controller.cluster.ResourceUtils;
-import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.Test;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class KafkaConnectS2IClusterTest {
     private final String namespace = "test";
@@ -29,32 +31,15 @@ public class KafkaConnectS2IClusterTest {
     private final String image = "my-image:latest";
     private final int healthDelay = 100;
     private final int healthTimeout = 10;
-    private final String bootstrapServers = "my-cluster-kafka:9092";
-    private final String groupID = "my-cluster-group";
-    private final int configReplicationFactor = 1;
-    private final int offsetReplicationFactor = 1;
-    private final int statusReplicationFactor = 1;
-    private final String keyConverter = "org.apache.kafka.connect.json.AvroConverter";
-    private final String valueConverter = "org.apache.kafka.connect.json.AvroConverter";
-    private final boolean keyConverterSchemas = false;
-    private final boolean valuesConverterSchema = false;
+    private final String configurationJson = "{\"foo\":\"bar\"}";
 
     private final ConfigMap cm = ResourceUtils.createKafkaConnectS2IClusterConfigMap(namespace, cluster, replicas, image,
-            healthDelay, healthTimeout, bootstrapServers, groupID, configReplicationFactor, offsetReplicationFactor,
-            statusReplicationFactor, keyConverter, valueConverter, keyConverterSchemas, valuesConverterSchema);
+            healthDelay, healthTimeout, configurationJson);
     private final KafkaConnectS2ICluster kc = KafkaConnectS2ICluster.fromConfigMap(cm);
 
     protected List<EnvVar> getExpectedEnvVars() {
         List<EnvVar> expected = new ArrayList<EnvVar>();
-        expected.add(new EnvVarBuilder().withName(kc.KEY_BOOTSTRAP_SERVERS).withValue(bootstrapServers).build());
-        expected.add(new EnvVarBuilder().withName(kc.KEY_GROUP_ID).withValue(groupID).build());
-        expected.add(new EnvVarBuilder().withName(kc.KEY_KEY_CONVERTER).withValue(keyConverter).build());
-        expected.add(new EnvVarBuilder().withName(kc.KEY_KEY_CONVERTER_SCHEMAS_EXAMPLE).withValue(Boolean.toString(keyConverterSchemas)).build());
-        expected.add(new EnvVarBuilder().withName(kc.KEY_VALUE_CONVERTER).withValue(valueConverter).build());
-        expected.add(new EnvVarBuilder().withName(kc.KEY_VALUE_CONVERTER_SCHEMAS_EXAMPLE).withValue(Boolean.toString(valuesConverterSchema)).build());
-        expected.add(new EnvVarBuilder().withName(kc.KEY_CONFIG_STORAGE_REPLICATION_FACTOR).withValue(Integer.toString(configReplicationFactor)).build());
-        expected.add(new EnvVarBuilder().withName(kc.KEY_OFFSET_STORAGE_REPLICATION_FACTOR).withValue(Integer.toString(offsetReplicationFactor)).build());
-        expected.add(new EnvVarBuilder().withName(kc.KEY_STATUS_STORAGE_REPLICATION_FACTOR).withValue(Integer.toString(statusReplicationFactor)).build());
+        expected.add(new EnvVarBuilder().withName(KafkaConnectCluster.KEY_KAFKA_CONNECT_USER_CONFIGURATION).withValue("foo=bar\n").build());
         expected.add(new EnvVarBuilder().withName(AbstractModel.ENV_VAR_DYNAMIC_HEAP_FRACTION).withValue("1.0").build());
         return expected;
     }
@@ -68,15 +53,7 @@ public class KafkaConnectS2IClusterTest {
         assertEquals(KafkaConnectS2ICluster.DEFAULT_IMAGE, kc.sourceImageBaseName + ":" + kc.sourceImageTag);
         assertEquals(KafkaConnectS2ICluster.DEFAULT_HEALTHCHECK_DELAY, kc.healthCheckInitialDelay);
         assertEquals(KafkaConnectS2ICluster.DEFAULT_HEALTHCHECK_TIMEOUT, kc.healthCheckTimeout);
-        assertEquals(KafkaConnectS2ICluster.DEFAULT_BOOTSTRAP_SERVERS, kc.bootstrapServers);
-        assertEquals(KafkaConnectS2ICluster.DEFAULT_CONFIG_STORAGE_REPLICATION_FACTOR, kc.configStorageReplicationFactor);
-        assertEquals(KafkaConnectS2ICluster.DEFAULT_OFFSET_STORAGE_REPLICATION_FACTOR, kc.offsetStorageReplicationFactor);
-        assertEquals(KafkaConnectS2ICluster.DEFAULT_STATUS_STORAGE_REPLICATION_FACTOR, kc.statusStorageReplicationFactor);
-        assertEquals(KafkaConnectS2ICluster.DEFAULT_GROUP_ID, kc.groupId);
-        assertEquals(KafkaConnectS2ICluster.DEFAULT_KEY_CONVERTER, kc.keyConverter);
-        assertEquals(KafkaConnectS2ICluster.DEFAULT_KEY_CONVERTER_SCHEMAS_EXAMPLE, kc.keyConverterSchemasEnable);
-        assertEquals(KafkaConnectS2ICluster.DEFAULT_VALUE_CONVERTER, kc.valueConverter);
-        assertEquals(KafkaConnectS2ICluster.DEFAULT_VALUE_CONVERTER_SCHEMAS_EXAMPLE, kc.valueConverterSchemasEnable);
+        assertNull(kc.getConfiguration());
     }
 
     @Test
@@ -86,15 +63,7 @@ public class KafkaConnectS2IClusterTest {
         assertEquals(image, kc.sourceImageBaseName + ":" + kc.sourceImageTag);
         assertEquals(healthDelay, kc.healthCheckInitialDelay);
         assertEquals(healthTimeout, kc.healthCheckTimeout);
-        assertEquals(bootstrapServers, kc.bootstrapServers);
-        assertEquals(configReplicationFactor, kc.configStorageReplicationFactor);
-        assertEquals(offsetReplicationFactor, kc.offsetStorageReplicationFactor);
-        assertEquals(statusReplicationFactor, kc.statusStorageReplicationFactor);
-        assertEquals(groupID, kc.groupId);
-        assertEquals(keyConverter, kc.keyConverter);
-        assertEquals(keyConverterSchemas, kc.keyConverterSchemasEnable);
-        assertEquals(valueConverter, kc.valueConverter);
-        assertEquals(valuesConverterSchema, kc.valueConverterSchemasEnable);
+        assertEquals("foo=bar\n", kc.getConfiguration().getConfiguration());
     }
 
     @Test
@@ -106,15 +75,7 @@ public class KafkaConnectS2IClusterTest {
         assertEquals(image, newKc.sourceImageBaseName + ":" + newKc.sourceImageTag);
         assertEquals(healthDelay, newKc.healthCheckInitialDelay);
         assertEquals(healthTimeout, newKc.healthCheckTimeout);
-        assertEquals(bootstrapServers, newKc.bootstrapServers);
-        assertEquals(configReplicationFactor, newKc.configStorageReplicationFactor);
-        assertEquals(offsetReplicationFactor, newKc.offsetStorageReplicationFactor);
-        assertEquals(statusReplicationFactor, newKc.statusStorageReplicationFactor);
-        assertEquals(groupID, newKc.groupId);
-        assertEquals(keyConverter, newKc.keyConverter);
-        assertEquals(keyConverterSchemas, newKc.keyConverterSchemasEnable);
-        assertEquals(valueConverter, newKc.valueConverter);
-        assertEquals(valuesConverterSchema, newKc.valueConverterSchemasEnable);
+        assertEquals("foo=bar\n", kc.getConfiguration().getConfiguration());
     }
 
     @Test
@@ -127,15 +88,7 @@ public class KafkaConnectS2IClusterTest {
         assertEquals(KafkaConnectS2ICluster.DEFAULT_IMAGE, newKc.sourceImageBaseName + ":" + newKc.sourceImageTag);
         assertEquals(KafkaConnectS2ICluster.DEFAULT_HEALTHCHECK_DELAY, newKc.healthCheckInitialDelay);
         assertEquals(KafkaConnectS2ICluster.DEFAULT_HEALTHCHECK_TIMEOUT, newKc.healthCheckTimeout);
-        assertEquals(KafkaConnectS2ICluster.DEFAULT_BOOTSTRAP_SERVERS, newKc.bootstrapServers);
-        assertEquals(KafkaConnectS2ICluster.DEFAULT_CONFIG_STORAGE_REPLICATION_FACTOR, newKc.configStorageReplicationFactor);
-        assertEquals(KafkaConnectS2ICluster.DEFAULT_OFFSET_STORAGE_REPLICATION_FACTOR, newKc.offsetStorageReplicationFactor);
-        assertEquals(KafkaConnectS2ICluster.DEFAULT_STATUS_STORAGE_REPLICATION_FACTOR, newKc.statusStorageReplicationFactor);
-        assertEquals(KafkaConnectS2ICluster.DEFAULT_GROUP_ID, newKc.groupId);
-        assertEquals(KafkaConnectS2ICluster.DEFAULT_KEY_CONVERTER, newKc.keyConverter);
-        assertEquals(KafkaConnectS2ICluster.DEFAULT_KEY_CONVERTER_SCHEMAS_EXAMPLE, newKc.keyConverterSchemasEnable);
-        assertEquals(KafkaConnectS2ICluster.DEFAULT_VALUE_CONVERTER, newKc.valueConverter);
-        assertEquals(KafkaConnectS2ICluster.DEFAULT_VALUE_CONVERTER_SCHEMAS_EXAMPLE, newKc.valueConverterSchemasEnable);
+        assertNull(newKc.getConfiguration());
     }
 
     @Test

--- a/common-test/src/main/java/io/strimzi/test/ConnectCluster.java
+++ b/common-test/src/main/java/io/strimzi/test/ConnectCluster.java
@@ -20,7 +20,7 @@ import java.lang.annotation.Target;
 @Repeatable(ConnectCluster.Container.class)
 public @interface ConnectCluster {
     String name();
-    String bootstrapServers();
+    String connectConfig();
     int nodes() default 1;
     CmData[] config() default {};
 

--- a/common-test/src/main/java/io/strimzi/test/StrimziRunner.java
+++ b/common-test/src/main/java/io/strimzi/test/StrimziRunner.java
@@ -12,17 +12,6 @@ import io.strimzi.test.k8s.KubeClient;
 import io.strimzi.test.k8s.KubeClusterResource;
 import io.strimzi.test.k8s.Minishift;
 import io.strimzi.test.k8s.OpenShift;
-import org.junit.ClassRule;
-import org.junit.runner.notification.RunNotifier;
-import org.junit.runners.BlockJUnit4ClassRunner;
-import org.junit.runners.model.Annotatable;
-import org.junit.runners.model.FrameworkField;
-import org.junit.runners.model.FrameworkMethod;
-import org.junit.runners.model.InitializationError;
-import org.junit.runners.model.Statement;
-import org.junit.runners.model.TestClass;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -37,6 +26,18 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+
+import org.junit.ClassRule;
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.runners.model.Annotatable;
+import org.junit.runners.model.FrameworkField;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.InitializationError;
+import org.junit.runners.model.Statement;
+import org.junit.runners.model.TestClass;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static io.strimzi.test.TestUtils.indent;
 import static io.strimzi.test.k8s.BaseKubeClient.CM;
@@ -325,7 +326,7 @@ public class StrimziRunner extends BlockJUnit4ClassRunner {
                 ((ObjectNode) metadata).put("name", cluster.name());
                 JsonNode data = node.get("data");
                 ((ObjectNode) data).put("nodes", String.valueOf(cluster.nodes()));
-                ((ObjectNode) data).put("KAFKA_CONNECT_BOOTSTRAP_SERVERS", cluster.bootstrapServers());
+                ((ObjectNode) data).put("KAFKA_CONNECT_USER_CONFIGURATION", cluster.connectConfig());
                 // updates values for config map
                 for (CmData cmData : cluster.config()) {
                     ((ObjectNode) data).put(cmData.key(), cmData.value());

--- a/common-test/src/main/java/io/strimzi/test/StrimziRunner.java
+++ b/common-test/src/main/java/io/strimzi/test/StrimziRunner.java
@@ -329,9 +329,7 @@ public class StrimziRunner extends BlockJUnit4ClassRunner {
                 ((ObjectNode) data).put("connect-config", cluster.connectConfig());
                 // updates values for config map
                 for (CmData cmData : cluster.config()) {
-                    if (data.has(cmData.key())) {
-                        ((ObjectNode) data).put(cmData.key(), cmData.value());
-                    }
+                    ((ObjectNode) data).put(cmData.key(), cmData.value());
                 }
             });
             last = new Bracket(last) {

--- a/common-test/src/main/java/io/strimzi/test/StrimziRunner.java
+++ b/common-test/src/main/java/io/strimzi/test/StrimziRunner.java
@@ -326,10 +326,12 @@ public class StrimziRunner extends BlockJUnit4ClassRunner {
                 ((ObjectNode) metadata).put("name", cluster.name());
                 JsonNode data = node.get("data");
                 ((ObjectNode) data).put("nodes", String.valueOf(cluster.nodes()));
-                ((ObjectNode) data).put("KAFKA_CONNECT_USER_CONFIGURATION", cluster.connectConfig());
+                ((ObjectNode) data).put("connect-config", cluster.connectConfig());
                 // updates values for config map
                 for (CmData cmData : cluster.config()) {
-                    ((ObjectNode) data).put(cmData.key(), cmData.value());
+                    if (data.has(cmData.key())) {
+                        ((ObjectNode) data).put(cmData.key(), cmData.value());
+                    }
                 }
             });
             last = new Bracket(last) {

--- a/docker-images/kafka-connect/scripts/kafka_connect_config_generator.sh
+++ b/docker-images/kafka-connect/scripts/kafka_connect_config_generator.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 
-CONFIG_FILE=$1
-
 # Write the config file
-cat > ${CONFIG_FILE:-/tmp/strimzi-connect.properties} <<EOF
+cat <<EOF
 # REST Listeners
 rest.port=8083
 rest.advertised.host.name=$(hostname -I)

--- a/docker-images/kafka-connect/scripts/kafka_connect_config_generator.sh
+++ b/docker-images/kafka-connect/scripts/kafka_connect_config_generator.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+CONFIG_FILE=$1
+
+# Write the config file
+cat > ${CONFIG_FILE:-/tmp/strimzi-connect.properties} <<EOF
+# REST Listeners
+rest.port=8083
+rest.advertised.host.name=$(hostname -I)
+rest.advertised.port=8083
+# Plugins
+plugin.path=${KAFKA_CONNECT_PLUGIN_PATH}
+# User configuration
+${KAFKA_CONNECT_USER_CONFIGURATION}
+EOF

--- a/docker-images/kafka-connect/scripts/kafka_connect_run.sh
+++ b/docker-images/kafka-connect/scripts/kafka_connect_run.sh
@@ -4,11 +4,9 @@ if [ -z "$KAFKA_CONNECT_PLUGIN_PATH" ]; then
 export KAFKA_CONNECT_PLUGIN_PATH="${KAFKA_HOME}/plugins"
 fi
 
-# Generate the config file
-./kafka_connect_config_generator.sh /tmp/strimzi-connect.properties
-
-echo "Starting Kafka connect with configuration:"
-cat /tmp/strimzi-connect.properties
+# Generate and print the config file
+echo "Starting Kafka Connect with configuration:"
+./kafka_connect_config_generator.sh | tee /tmp/strimzi-connect.properties
 echo ""
 
 # Disable Kafka's GC logging (which logs to a file)...

--- a/docker-images/kafka-connect/scripts/kafka_connect_run.sh
+++ b/docker-images/kafka-connect/scripts/kafka_connect_run.sh
@@ -1,60 +1,11 @@
 #!/bin/bash
 
-if [ -z "$KAFKA_CONNECT_BOOTSTRAP_SERVERS" ]; then
-export KAFKA_CONNECT_BOOTSTRAP_SERVERS="kafka:9092"
-fi
-
-if [ -z "$KAFKA_CONNECT_GROUP_ID" ]; then
-export KAFKA_CONNECT_GROUP_ID="connect-cluster"
-fi
-
-if [ -z "$KAFKA_CONNECT_OFFSET_STORAGE_TOPIC" ]; then
-export KAFKA_CONNECT_OFFSET_STORAGE_TOPIC="${KAFKA_CONNECT_GROUP_ID}-offsets"
-fi
-
-if [ -z "$KAFKA_CONNECT_CONFIG_STORAGE_TOPIC" ]; then
-export KAFKA_CONNECT_CONFIG_STORAGE_TOPIC="${KAFKA_CONNECT_GROUP_ID}-configs"
-fi
-
-if [ -z "$KAFKA_CONNECT_STATUS_STORAGE_TOPIC" ]; then
-export KAFKA_CONNECT_STATUS_STORAGE_TOPIC="${KAFKA_CONNECT_GROUP_ID}-status"
-fi
-
-if [ -z "$KAFKA_CONNECT_KEY_CONVERTER" ]; then
-export KAFKA_CONNECT_KEY_CONVERTER="org.apache.kafka.connect.json.JsonConverter"
-fi
-
-if [ -z "$KAFKA_CONNECT_VALUE_CONVERTER" ]; then
-export KAFKA_CONNECT_VALUE_CONVERTER="org.apache.kafka.connect.json.JsonConverter"
-fi
-
 if [ -z "$KAFKA_CONNECT_PLUGIN_PATH" ]; then
 export KAFKA_CONNECT_PLUGIN_PATH="${KAFKA_HOME}/plugins"
 fi
 
-# Write the config file
-cat > /tmp/strimzi-connect.properties <<EOF
-rest.port=8083
-rest.advertised.host.name=$(hostname -I)
-rest.advertised.port=8083
-bootstrap.servers=${KAFKA_CONNECT_BOOTSTRAP_SERVERS}
-group.id=${KAFKA_CONNECT_GROUP_ID}
-offset.storage.topic=${KAFKA_CONNECT_OFFSET_STORAGE_TOPIC}
-config.storage.topic=${KAFKA_CONNECT_CONFIG_STORAGE_TOPIC}
-status.storage.topic=${KAFKA_CONNECT_STATUS_STORAGE_TOPIC}
-key.converter=${KAFKA_CONNECT_KEY_CONVERTER}
-value.converter=${KAFKA_CONNECT_VALUE_CONVERTER}
-key.converter.schemas.enable=${KAFKA_CONNECT_KEY_CONVERTER_SCHEMAS_ENABLE:-true}
-value.converter.schemas.enable=${KAFKA_CONNECT_VALUE_CONVERTER_SCHEMAS_ENABLE:-true}
-internal.key.converter=org.apache.kafka.connect.json.JsonConverter
-internal.value.converter=org.apache.kafka.connect.json.JsonConverter
-internal.key.converter.schemas.enable=${KAFKA_CONNECT_INTERNAL_KEY_CONVERTER_SCHEMAS_ENABLE:-false}
-internal.value.converter.schemas.enable=${KAFKA_CONNECT_INTERNAL_VALUE_CONVERTER_SCHEMAS_ENABLE:-false}
-plugin.path=${KAFKA_CONNECT_PLUGIN_PATH}
-config.storage.replication.factor=${KAFKA_CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR:-3}
-offset.storage.replication.factor=${KAFKA_CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR:-3}
-status.storage.replication.factor=${KAFKA_CONNECT_STATUS_STORAGE_REPLICATION_FACTOR:-3}
-EOF
+# Generate the config file
+./kafka_connect_config_generator.sh /tmp/strimzi-connect.properties
 
 echo "Starting Kafka connect with configuration:"
 cat /tmp/strimzi-connect.properties

--- a/docker-images/kafka/scripts/kafka_config_generator.sh
+++ b/docker-images/kafka/scripts/kafka_config_generator.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 
-CONFIG_FILE=$1
-
 # Write the config file
-cat > ${CONFIG_FILE:-/tmp/strimzi.properties} <<EOF
+cat <<EOF
 broker.id=${KAFKA_BROKER_ID}
 # Listeners
 listeners=CLIENT://0.0.0.0:9092,REPLICATION://0.0.0.0:9091

--- a/docker-images/kafka/scripts/kafka_run.sh
+++ b/docker-images/kafka/scripts/kafka_run.sh
@@ -35,11 +35,9 @@ fi
 # directory avoids trying to create it (and logging a permission denied error)
 export LOG_DIR="$KAFKA_HOME"
 
-# Generate the config file
-./kafka_config_generator.sh /tmp/strimzi.properties
-
+# Generate and print the config file
 echo "Starting Kafka with configuration:"
-cat /tmp/strimzi.properties
+./kafka_config_generator.sh | tee /tmp/strimzi.properties
 echo ""
 
 if [ -z "$KAFKA_HEAP_OPTS" -a -n "${DYNAMIC_HEAP_FRACTION}" ]; then

--- a/documentation/adoc/cluster-controller.adoc
+++ b/documentation/adoc/cluster-controller.adoc
@@ -484,47 +484,20 @@ More information about these configuration parameters in the related <<Topic Con
 In order to configure a Kafka Connect cluster deployment, it's possible to specify the following fields in the `data` section of 
 the related ConfigMap:
 
-* `nodes`: number of Kafka Connect worker nodes. Default is 1
-* `image`: the Docker image to use for the Kafka Connect workers.
+`nodes`:: Number of Kafka Connect worker nodes. Default is 1
+`image`:: The Docker image to use for the Kafka Connect workers.
 Default is determined by the value of the
 `<<STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE,STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE>>`
 environment variable of the Cluster Controller.
 If S2I is used (only on OpenShift), then it should be the related S2I image.
-* `healthcheck-delay`: the initial delay for the liveness and readiness probes for each Kafka Connect worker node. Default is 60
-* `healthcheck-timeout`: the timeout on the liveness and readiness probes for each Kafka Connect worker node. Default is 5
-* `resources`:
-a JSON string configuring the resource limits and requests for Kafka Connect containers.
+`healthcheck-delay`:: The initial delay for the liveness and readiness probes for each Kafka Connect worker node. Default is 60
+`healthcheck-timeout`:: The timeout on the liveness and readiness probes for each Kafka Connect worker node. Default is 5
+`resources`:: A JSON string configuring the resource limits and requests for Kafka Connect containers.
 The accepted JSON format is described in the <<resources_json_config>> section.
-* `jvmOptions`:
-a JSON string allowing the JVM running Kafka Connect to be configured.
+`jvmOptions`:: A JSON string allowing the JVM running Kafka Connect to be configured.
 The accepted JSON format is described in the <<jvm_json_config>> section.
-* `KAFKA_CONNECT_BOOTSTRAP_SERVERS`: a list of host/port pairs to use for establishing the initial connection to the Kafka cluster.
-It sets the `bootstrap.servers` property in the properties configuration file used by Kafka Connect worker nodes on startup.
-Default is `my-cluster-kafka:9092`
-* `KAFKA_CONNECT_GROUP_ID`: a unique string that identifies the Connect cluster group this worker belongs to.
-It sets the `group.id` property in the properties configuration file used by Kafka Connect worker nodes on startup.
-Default is `my-connect-cluster`
-* `KAFKA_CONNECT_KEY_CONVERTER`: converter class used to convert keys between Kafka Connect format and the serialized form 
-that is written to Kafka. It sets the `key.converter` property in the properties configuration file used by Kafka Connect 
-worker nodes on startup. Default is `org.apache.kafka.connect.json.JsonConverter`
-* `KAFKA_CONNECT_KEY_CONVERTER_SCHEMAS_ENABLE`: if Kafka Connect transformation on keys are with or without schemas.
-It sets the `key.converter.schemas.enable` property in the properties configuration file used by Kafka Connect worker nodes on startup.
-Default is true
-* `KAFKA_CONNECT_VALUE_CONVERTER`: converter class used to convert values between Kafka Connect format and the serialized form 
-that is written to Kafka. It sets the `value.converter` property in the properties configuration file used by Kafka Connect 
-worker nodes on startup. Default is `org.apache.kafka.connect.json.JsonConverter`
-* `KAFKA_CONNECT_VALUE_CONVERTER_SCHEMAS_ENABLE`: if Kafka Connect transformation on values are with or without schemas.
-It sets the `value.converter.schemas.enable` property in the properties configuration file used by Kafka Connect worker nodes on startup.
-Default is true
-* `KAFKA_CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR`: replication factor used when creating the configuration storage topic.
-It sets the `config.storage.replication.factor` property in the properties configuration file used by Kafka Connect worker nodes on startup.
-Default is 3
-* `KAFKA_CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR`: replication factor used when creating the offset storage topic.
-It sets the `offset.storage.replication.factor` property in the properties configuration file used by Kafka Connect worker nodes on startup.
-Default is 3
-* `KAFKA_CONNECT_STATUS_STORAGE_REPLICATION_FACTOR`: replication factor used when creating the status storage topic.
-It sets the `status.storage.replication.factor` property in the properties configuration file used by Kafka Connect worker nodes on startup.
-Default is 3
+`connect-config`:: A JSON string with Kafka Connect configuration. See section <<kafka_connect_configuration_json_config>>
+for more details.
 
 The following is an example of cluster configuration ConfigMap is the following.
 
@@ -543,21 +516,94 @@ data:
   image: "strimzi/kafka-connect:latest"
   healthcheck-delay: "60"
   healthcheck-timeout: "5"
-  KAFKA_CONNECT_BOOTSTRAP_SERVERS: "my-cluster-kafka:9092"
-  KAFKA_CONNECT_GROUP_ID: "my-connect-cluster"
-  KAFKA_CONNECT_KEY_CONVERTER: "org.apache.kafka.connect.json.JsonConverter"
-  KAFKA_CONNECT_KEY_CONVERTER_SCHEMAS_ENABLE: "true"
-  KAFKA_CONNECT_VALUE_CONVERTER: "org.apache.kafka.connect.json.JsonConverter"
-  KAFKA_CONNECT_VALUE_CONVERTER_SCHEMAS_ENABLE: "true"
-  KAFKA_CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR: "3"
-  KAFKA_CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR: "3"
-  KAFKA_CONNECT_STATUS_STORAGE_REPLICATION_FACTOR: "3"
+  connect-config: |-
+    {
+      "bootstrap.servers": "my-cluster-kafka:9092",
+      "group.id": "my-connect-cluster",
+      "offset.storage.topic": "my-connect-cluster-offsets",
+      "config.storage.topic": "my-connect-cluster-configs",
+      "status.storage.topic": "my-connect-cluster-status",
+      "key.converter": "org.apache.kafka.connect.json.JsonConverter",
+      "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+      "key.converter.schemas.enable": true,
+      "value.converter.schemas.enable": true,
+      "internal.key.converter": "org.apache.kafka.connect.json.JsonConverter",
+      "internal.value.converter": "org.apache.kafka.connect.json.JsonConverter",
+      "internal.key.converter.schemas.enable": false,
+      "internal.value.converter.schemas.enable": false,
+      "config.storage.replication.factor": 3,
+      "offset.storage.replication.factor": 3,
+      "status.storage.replication.factor": 3
+    }
 ----
 
 The resources created by the cluster controller into the Kubernetes/OpenShift cluster will be the following :
 
 * [connect-cluster-name]-connect Deployment which is in charge to create the Kafka Connect worker node pods
 * [connect-cluster-name]-connect Service which exposes the REST interface for managing the Kafka Connect cluster
+
+[[kafka_connect_configuration_json_config]]
+===== Kafka Connect configuration
+
+`connect-config` field allows detailed configuration of Apache Kafka Connect and Connect S2I. This field should contain
+a JSON object with Kafka Connect configuration options as keys. The values could be in one of the following types:
+
+* String
+* Integer
+* Long
+* Double
+* Float
+* Boolean
+
+The `connect-config` field supports all Kafka Connect configuration options with the exception of options related to:
+
+* Security (Encryption, Authentication and Authorization)
+* Listener / REST interface configuration
+* Plugin path configuration
+
+Specifically, all configuration options with keys starting with one of the following strings will be ignored:
+
+* `ssl.`
+* `sasl.`
+* `security.`
+* `listeners`
+* `plugin.path`
+* `rest.`
+
+All other options will be passed to Kafka Connect. List of all available options can be found on the
+http://kafka.apache.org/documentation/#connectconfigs[Kafka website]. An example of `connect-config` field is provided
+below.
+
+.Example Kafka Connect configuration
+[source,json]
+----
+{
+  "bootstrap.servers": "my-cluster-kafka:9092",
+  "group.id": "my-connect-cluster",
+  "offset.storage.topic": "my-connect-cluster-offsets",
+  "config.storage.topic": "my-connect-cluster-configs",
+  "status.storage.topic": "my-connect-cluster-status",
+  "key.converter": "org.apache.kafka.connect.json.JsonConverter",
+  "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+  "key.converter.schemas.enable": true,
+  "value.converter.schemas.enable": true,
+  "internal.key.converter": "org.apache.kafka.connect.json.JsonConverter",
+  "internal.value.converter": "org.apache.kafka.connect.json.JsonConverter",
+  "internal.key.converter.schemas.enable": false,
+  "internal.value.converter.schemas.enable": false,
+  "config.storage.replication.factor": 3,
+  "offset.storage.replication.factor": 3,
+  "status.storage.replication.factor": 3
+}
+----
+
+INFO:: The cluster controller doesn't validate the configuration provided by the user. When invalid configuration is provided, the
+Kafka Connect cluster might not start or might become unstable. In such cases, the configuration in the `connect-config` field
+should be fixed and the cluster controller will roll out the new configuration to all Kafka Connect instances.
+
+INFO:: Some configuration options are mandatory and in case they are not provided, Kafka Connect will not start. The cluster
+controller will not use any default values when the mandatory options are not specified - all mandatory configuration
+options have to be specified in the `connect-config` field.
 
 === Provisioning Role-Based Access Control (RBAC) for the controller
 

--- a/documentation/adoc/cluster-controller.adoc
+++ b/documentation/adoc/cluster-controller.adoc
@@ -184,14 +184,11 @@ a volume by the Kafka broker pods
 [[kafka_configuration_json_config]]
 ===== Kafka Configuration
 
-`kafka-config` field allows detailed configuration of Apache Kafka. This field should contain a JSON object with Kafka
-configuration options as keys. The values could be in one of the following types:
+The `kafka-config` field allows detailed configuration of Apache Kafka. This field should contain a JSON object with Kafka
+configuration options as keys. The values could be in one of the following JSON types:
 
 * String
-* Integer
-* Long
-* Double
-* Float
+* Number
 * Boolean
 
 The `kafka-config` field supports all Kafka configuration options with the exception of options related to:
@@ -223,8 +220,8 @@ Specifically, all configuration options with keys starting with one of the follo
 * `authorizer.`
 * `super.user`
 
-All other options will be passed to Kafka. List of all available options can be found on the
-http://kafka.apache.org/documentation/#brokerconfigs[Kafka website]. An example of `kafka-config` field is provided
+All other options will be passed to Kafka. A list of all the available options can be found on the
+http://kafka.apache.org/11/documentation.html#brokerconfigs[Kafka website]. An example `kafka-config` field is provided
 below.
 
 .Example Kafka configuration
@@ -249,7 +246,7 @@ below.
 }
 ----
 
-NOTE:: The cluster controller doesn't validate the configuration provided by the user. When invalid configuration is provided, the
+NOTE:: The cluster controller doesn't validate the provided configuration. When invalid configuration is provided, the
 Kafka cluster might not start or might become unstable. In such cases, the configuration in the `kafka-config` field
 should be fixed and the cluster controller will roll out the new configuration to all Kafka brokers.
 
@@ -545,14 +542,11 @@ The resources created by the cluster controller into the Kubernetes/OpenShift cl
 [[kafka_connect_configuration_json_config]]
 ===== Kafka Connect configuration
 
-`connect-config` field allows detailed configuration of Apache Kafka Connect and Connect S2I. This field should contain
-a JSON object with Kafka Connect configuration options as keys. The values could be in one of the following types:
+The `connect-config` field allows detailed configuration of Apache Kafka Connect and Connect S2I. This field should contain
+a JSON object with Kafka Connect configuration options as keys. The values could be in one of the following JSON types:
 
 * String
-* Integer
-* Long
-* Double
-* Float
+* Number
 * Boolean
 
 The `connect-config` field supports all Kafka Connect configuration options with the exception of options related to:
@@ -570,8 +564,8 @@ Specifically, all configuration options with keys starting with one of the follo
 * `plugin.path`
 * `rest.`
 
-All other options will be passed to Kafka Connect. List of all available options can be found on the
-http://kafka.apache.org/documentation/#connectconfigs[Kafka website]. An example of `connect-config` field is provided
+All other options will be passed to Kafka Connect. A list of all the available options can be found on the
+http://kafka.apache.org/11/documentation.html#connectconfigs[Kafka website]. An example `connect-config` field is provided
 below.
 
 .Example Kafka Connect configuration
@@ -597,7 +591,7 @@ below.
 }
 ----
 
-INFO:: The cluster controller doesn't validate the configuration provided by the user. When invalid configuration is provided, the
+INFO:: The cluster controller doesn't validate the provided configuration. When invalid configuration is provided, the
 Kafka Connect cluster might not start or might become unstable. In such cases, the configuration in the `connect-config` field
 should be fixed and the cluster controller will roll out the new configuration to all Kafka Connect instances.
 

--- a/examples/configmaps/cluster-controller/kafka-connect-s2i.yaml
+++ b/examples/configmaps/cluster-controller/kafka-connect-s2i.yaml
@@ -11,7 +11,7 @@ data:
   healthcheck-timeout: "5"
   connect-config: |-
     {
-      "bootstrap-servers": "my-cluster-kafka:9092",
+      "bootstrap.servers": "my-cluster-kafka:9092",
       "group.id": "my-connect-cluster",
       "offset.storage.topic": "my-connect-cluster-offsets",
       "config.storage.topic": "my-connect-cluster-configs",

--- a/examples/configmaps/cluster-controller/kafka-connect-s2i.yaml
+++ b/examples/configmaps/cluster-controller/kafka-connect-s2i.yaml
@@ -4,10 +4,10 @@ metadata:
   name: my-connect-cluster
   labels:
     strimzi.io/kind: cluster
-    strimzi.io/type: kafka-connect
+    strimzi.io/type: kafka-connect-s2i
 data:
   nodes: "1"
-  image: "strimzi/kafka-connect:latest"
+  image: "strimzi/kafka-connect-s2i:latest"
   healthcheck-delay: "60"
   healthcheck-timeout: "5"
   connect-config: |-

--- a/examples/configmaps/cluster-controller/kafka-connect-s2i.yaml
+++ b/examples/configmaps/cluster-controller/kafka-connect-s2i.yaml
@@ -7,7 +7,6 @@ metadata:
     strimzi.io/type: kafka-connect-s2i
 data:
   nodes: "1"
-  image: "strimzi/kafka-connect-s2i:latest"
   healthcheck-delay: "60"
   healthcheck-timeout: "5"
   connect-config: |-

--- a/examples/configmaps/cluster-controller/kafka-connect.yaml
+++ b/examples/configmaps/cluster-controller/kafka-connect.yaml
@@ -7,12 +7,11 @@ metadata:
     strimzi.io/type: kafka-connect
 data:
   nodes: "1"
-  image: "strimzi/kafka-connect:latest"
   healthcheck-delay: "60"
   healthcheck-timeout: "5"
   connect-config: |-
     {
-      "bootstrap-servers": "my-cluster-kafka:9092",
+      "bootstrap.servers": "my-cluster-kafka:9092",
       "group.id": "my-connect-cluster",
       "offset.storage.topic": "my-connect-cluster-offsets",
       "config.storage.topic": "my-connect-cluster-configs",

--- a/examples/configmaps/cluster-controller/kafka-ephemeral.yaml
+++ b/examples/configmaps/cluster-controller/kafka-ephemeral.yaml
@@ -7,9 +7,11 @@ metadata:
     strimzi.io/type: kafka
 data:
   kafka-nodes: "3"
+  kafka-image: "strimzi/kafka:latest"
   kafka-healthcheck-delay: "15"
   kafka-healthcheck-timeout: "5"
   zookeeper-nodes: "1"
+  zookeeper-image: "strimzi/zookeeper:latest"
   zookeeper-healthcheck-delay: "15"
   zookeeper-healthcheck-timeout: "5"
   kafka-config: |-

--- a/examples/configmaps/cluster-controller/kafka-ephemeral.yaml
+++ b/examples/configmaps/cluster-controller/kafka-ephemeral.yaml
@@ -7,11 +7,9 @@ metadata:
     strimzi.io/type: kafka
 data:
   kafka-nodes: "3"
-  kafka-image: "strimzi/kafka:latest"
   kafka-healthcheck-delay: "15"
   kafka-healthcheck-timeout: "5"
   zookeeper-nodes: "1"
-  zookeeper-image: "strimzi/zookeeper:latest"
   zookeeper-healthcheck-delay: "15"
   zookeeper-healthcheck-timeout: "5"
   kafka-config: |-

--- a/examples/configmaps/cluster-controller/kafka-persistent.yaml
+++ b/examples/configmaps/cluster-controller/kafka-persistent.yaml
@@ -7,11 +7,9 @@ metadata:
     strimzi.io/type: kafka
 data:
   kafka-nodes: "3"
-  kafka-image: "strimzi/kafka:latest"
   kafka-healthcheck-delay: "15"
   kafka-healthcheck-timeout: "5"
   zookeeper-nodes: "3"
-  zookeeper-image: "strimzi/zookeeper:latest"
   zookeeper-healthcheck-delay: "15"
   zookeeper-healthcheck-timeout: "5"
   kafka-config: |-

--- a/examples/configmaps/cluster-controller/kafka-persistent.yaml
+++ b/examples/configmaps/cluster-controller/kafka-persistent.yaml
@@ -7,9 +7,11 @@ metadata:
     strimzi.io/type: kafka
 data:
   kafka-nodes: "3"
+  kafka-image: "strimzi/kafka:latest"
   kafka-healthcheck-delay: "15"
   kafka-healthcheck-timeout: "5"
   zookeeper-nodes: "3"
+  zookeeper-image: "strimzi/zookeeper:latest"
   zookeeper-healthcheck-delay: "15"
   zookeeper-healthcheck-timeout: "5"
   kafka-config: |-

--- a/examples/templates/cluster-controller/connect-s2i-template.yaml
+++ b/examples/templates/cluster-controller/connect-s2i-template.yaml
@@ -95,12 +95,22 @@ objects:
     image: "${S2I_IMAGE_REPO_NAME}/${S2I_IMAGE_NAME}:${S2I_IMAGE_TAG}"
     healthcheck-delay: "${HEALTHCHECK_DELAY}"
     healthcheck-timeout: "${HEALTHCHECK_TIMEOUT}"
-    KAFKA_CONNECT_BOOTSTRAP_SERVERS: "${KAFKA_CONNECT_BOOTSTRAP_SERVERS}"
-    KAFKA_CONNECT_GROUP_ID: "${KAFKA_CONNECT_GROUP_ID}"
-    KAFKA_CONNECT_KEY_CONVERTER: "${KAFKA_CONNECT_KEY_CONVERTER}"
-    KAFKA_CONNECT_KEY_CONVERTER_SCHEMAS_ENABLE: "${KAFKA_CONNECT_KEY_CONVERTER_SCHEMAS_ENABLE}"
-    KAFKA_CONNECT_VALUE_CONVERTER: "${KAFKA_CONNECT_VALUE_CONVERTER}"
-    KAFKA_CONNECT_VALUE_CONVERTER_SCHEMAS_ENABLE: "${KAFKA_CONNECT_VALUE_CONVERTER_SCHEMAS_ENABLE}"
-    KAFKA_CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR: "${KAFKA_CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR}"
-    KAFKA_CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR: "${KAFKA_CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR}"
-    KAFKA_CONNECT_STATUS_STORAGE_REPLICATION_FACTOR: "${KAFKA_CONNECT_STATUS_STORAGE_REPLICATION_FACTOR}"
+    connect-config: |-
+      {
+        "bootstrap-servers": "${KAFKA_CONNECT_BOOTSTRAP_SERVERS}",
+        "group.id": "${KAFKA_CONNECT_GROUP_ID}",
+        "offset.storage.topic": "${KAFKA_CONNECT_GROUP_ID}-offsets",
+        "config.storage.topic": "${KAFKA_CONNECT_GROUP_ID}-configs",
+        "status.storage.topic": "${KAFKA_CONNECT_GROUP_ID}-status",
+        "key.converter": "${KAFKA_CONNECT_KEY_CONVERTER}",
+        "value.converter": "${KAFKA_CONNECT_VALUE_CONVERTER}",
+        "key.converter.schemas.enable": "${KAFKA_CONNECT_KEY_CONVERTER_SCHEMAS_ENABLE}",
+        "value.converter.schemas.enable": "${KAFKA_CONNECT_VALUE_CONVERTER_SCHEMAS_ENABLE}",
+        "internal.key.converter": "org.apache.kafka.connect.json.JsonConverter",
+        "internal.value.converter": "org.apache.kafka.connect.json.JsonConverter",
+        "internal.key.converter.schemas.enable": false,
+        "internal.value.converter.schemas.enable": false,
+        "config.storage.replication.factor": "${KAFKA_CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR}",
+        "offset.storage.replication.factor": "${KAFKA_CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR}",
+        "status.storage.replication.factor": "${KAFKA_CONNECT_STATUS_STORAGE_REPLICATION_FACTOR}"
+      }

--- a/examples/templates/cluster-controller/connect-s2i-template.yaml
+++ b/examples/templates/cluster-controller/connect-s2i-template.yaml
@@ -97,7 +97,7 @@ objects:
     healthcheck-timeout: "${HEALTHCHECK_TIMEOUT}"
     connect-config: |-
       {
-        "bootstrap-servers": "${KAFKA_CONNECT_BOOTSTRAP_SERVERS}",
+        "bootstrap.servers": "${KAFKA_CONNECT_BOOTSTRAP_SERVERS}",
         "group.id": "${KAFKA_CONNECT_GROUP_ID}",
         "offset.storage.topic": "${KAFKA_CONNECT_GROUP_ID}-offsets",
         "config.storage.topic": "${KAFKA_CONNECT_GROUP_ID}-configs",

--- a/examples/templates/cluster-controller/connect-template.yaml
+++ b/examples/templates/cluster-controller/connect-template.yaml
@@ -94,12 +94,22 @@ objects:
     image: "${IMAGE_REPO_NAME}/${IMAGE_NAME}:${IMAGE_TAG}"
     healthcheck-delay: "${HEALTHCHECK_DELAY}"
     healthcheck-timeout: "${HEALTHCHECK_TIMEOUT}"
-    KAFKA_CONNECT_BOOTSTRAP_SERVERS: "${KAFKA_CONNECT_BOOTSTRAP_SERVERS}"
-    KAFKA_CONNECT_GROUP_ID: "${KAFKA_CONNECT_GROUP_ID}"
-    KAFKA_CONNECT_KEY_CONVERTER: "${KAFKA_CONNECT_KEY_CONVERTER}"
-    KAFKA_CONNECT_KEY_CONVERTER_SCHEMAS_ENABLE: "${KAFKA_CONNECT_KEY_CONVERTER_SCHEMAS_ENABLE}"
-    KAFKA_CONNECT_VALUE_CONVERTER: "${KAFKA_CONNECT_VALUE_CONVERTER}"
-    KAFKA_CONNECT_VALUE_CONVERTER_SCHEMAS_ENABLE: "${KAFKA_CONNECT_VALUE_CONVERTER_SCHEMAS_ENABLE}"
-    KAFKA_CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR: "${KAFKA_CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR}"
-    KAFKA_CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR: "${KAFKA_CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR}"
-    KAFKA_CONNECT_STATUS_STORAGE_REPLICATION_FACTOR: "${KAFKA_CONNECT_STATUS_STORAGE_REPLICATION_FACTOR}"
+    connect-config: |-
+      {
+        "bootstrap-servers": "${KAFKA_CONNECT_BOOTSTRAP_SERVERS}",
+        "group.id": "${KAFKA_CONNECT_GROUP_ID}",
+        "offset.storage.topic": "${KAFKA_CONNECT_GROUP_ID}-offsets",
+        "config.storage.topic": "${KAFKA_CONNECT_GROUP_ID}-configs",
+        "status.storage.topic": "${KAFKA_CONNECT_GROUP_ID}-status",
+        "key.converter": "${KAFKA_CONNECT_KEY_CONVERTER}",
+        "value.converter": "${KAFKA_CONNECT_VALUE_CONVERTER}",
+        "key.converter.schemas.enable": "${KAFKA_CONNECT_KEY_CONVERTER_SCHEMAS_ENABLE}",
+        "value.converter.schemas.enable": "${KAFKA_CONNECT_VALUE_CONVERTER_SCHEMAS_ENABLE}",
+        "internal.key.converter": "org.apache.kafka.connect.json.JsonConverter",
+        "internal.value.converter": "org.apache.kafka.connect.json.JsonConverter",
+        "internal.key.converter.schemas.enable": false,
+        "internal.value.converter.schemas.enable": false,
+        "config.storage.replication.factor": "${KAFKA_CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR}",
+        "offset.storage.replication.factor": "${KAFKA_CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR}",
+        "status.storage.replication.factor": "${KAFKA_CONNECT_STATUS_STORAGE_REPLICATION_FACTOR}"
+      }

--- a/examples/templates/cluster-controller/connect-template.yaml
+++ b/examples/templates/cluster-controller/connect-template.yaml
@@ -96,7 +96,7 @@ objects:
     healthcheck-timeout: "${HEALTHCHECK_TIMEOUT}"
     connect-config: |-
       {
-        "bootstrap-servers": "${KAFKA_CONNECT_BOOTSTRAP_SERVERS}",
+        "bootstrap.servers": "${KAFKA_CONNECT_BOOTSTRAP_SERVERS}",
         "group.id": "${KAFKA_CONNECT_GROUP_ID}",
         "offset.storage.topic": "${KAFKA_CONNECT_GROUP_ID}-offsets",
         "config.storage.topic": "${KAFKA_CONNECT_GROUP_ID}-configs",

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractClusterIT.java
@@ -19,9 +19,6 @@ import io.strimzi.test.k8s.KubeClient;
 import io.strimzi.test.k8s.KubeClusterException;
 import io.strimzi.test.k8s.KubeClusterResource;
 import io.strimzi.test.k8s.ProcessResult;
-import org.junit.ClassRule;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -32,13 +29,17 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import org.junit.ClassRule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import static io.strimzi.test.TestUtils.indent;
 import static java.util.Arrays.asList;
+import static org.hamcrest.Matchers.isEmptyString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
 import static org.junit.Assert.assertThat;
-import static org.hamcrest.Matchers.isEmptyString;
+import static org.junit.Assert.fail;
 
 public class AbstractClusterIT {
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectClusterIT.java
@@ -33,7 +33,8 @@ public class ConnectClusterIT extends AbstractClusterIT {
 
     public static final String NAMESPACE = "connect-cluster-test";
     public static final String KAFKA_CLUSTER_NAME = "connect-tests";
-    public static final String CONNECT_CONFIG = "{\"bootstrap.servers\": \"" + KAFKA_CLUSTER_NAME + "-kafka:9092" + "\"}";
+    public static final String KAFKA_CONNECT_BOOTSTRAP_SERVERS = KAFKA_CLUSTER_NAME + "-kafka:9092";
+    public static final String CONNECT_CONFIG = "{\"bootstrap.servers\": \"" + KAFKA_CONNECT_BOOTSTRAP_SERVERS + "\"}";
 
     @Test
     @JUnitGroup(name = "regression")
@@ -43,7 +44,7 @@ public class ConnectClusterIT extends AbstractClusterIT {
         Oc oc = (Oc) this.kubeClient;
         String clusterName = "openshift-my-connect-cluster";
         oc.newApp("strimzi-connect", map("CLUSTER_NAME", clusterName,
-                "KEY_KAFKA_CONNECT_USER_CONFIGURATION", CONNECT_CONFIG));
+                "KAFKA_CONNECT_BOOTSTRAP_SERVERS", KAFKA_CONNECT_BOOTSTRAP_SERVERS));
         String deploymentName = clusterName + "-connect";
         oc.waitForDeployment(deploymentName);
         oc.deleteByName("cm", clusterName);
@@ -56,7 +57,7 @@ public class ConnectClusterIT extends AbstractClusterIT {
     public void testDeployUndeploy() {
         LOGGER.info("Looks like the connect cluster my-cluster deployed OK");
 
-        String podName = kubeClient.list("Pod").stream().filter(n -> n.startsWith("jvm-resource-connect-")).findFirst().get();
+        String podName = kubeClient.list("Pod").stream().filter(n -> n.startsWith("my-cluster-connect-")).findFirst().get();
         String kafkaPodJson = kubeClient.getResourceAsJson("pod", podName);
 
         assertEquals(("bootstrap.servers=" + KAFKA_CLUSTER_NAME + "-kafka:9092\\n").replaceAll("\\p{P}", ""), getValueFromJson(kafkaPodJson,


### PR DESCRIPTION
### Type of change

- ~~Bugfix~~
- Enhancement / new feature
- ~~Refactoring~~

### Description

This PR is part of #27. It delivers enhanced configuration possibilities for Apache Kafka Connect. Configuration for Kafka has been already delivered and configuration of Zookeeper will be delivered in separate PRs.

This PR adds new field `connect-config` to the Kafka cluster CM. This field should contain a JSON with configuration options. These options are passed to the Kafka Connect pods in environment variables. The generation of Kafka Connect configuration is handled by a separate script which is called within the same Docker image / pod. Separate script has been used in order to be able to easily move this to the init pod later once needed.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging

