### PR TITLE
Push docs to master on website only when building master

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -34,5 +34,7 @@ else
     export DOCKER_TAG=$TAG
     echo "Pushing to docker org $DOCKER_ORG"
     make docker_push
-    make docu_pushtowebsite
+    if [ "$BRANCH" = "master" ]; then
+        make docu_pushtowebsite
+    fi
 fi


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Only push the docs to master docs website URL when actually building master.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging

