### PR TITLE
Remove images from examples

### DIFF
--- a/examples/configmaps/cluster-controller/kafka-connect.yaml
+++ b/examples/configmaps/cluster-controller/kafka-connect.yaml
@@ -7,7 +7,6 @@ metadata:
     strimzi.io/type: kafka-connect
 data:
   nodes: "1"
-  image: "strimzi/kafka-connect:latest"
   healthcheck-delay: "60"
   healthcheck-timeout: "5"
   KAFKA_CONNECT_BOOTSTRAP_SERVERS: "my-cluster-kafka:9092"

--- a/examples/configmaps/cluster-controller/kafka-ephemeral.yaml
+++ b/examples/configmaps/cluster-controller/kafka-ephemeral.yaml
@@ -7,11 +7,9 @@ metadata:
     strimzi.io/type: kafka
 data:
   kafka-nodes: "3"
-  kafka-image: "strimzi/kafka:latest"
   kafka-healthcheck-delay: "15"
   kafka-healthcheck-timeout: "5"
   zookeeper-nodes: "1"
-  zookeeper-image: "strimzi/zookeeper:latest"
   zookeeper-healthcheck-delay: "15"
   zookeeper-healthcheck-timeout: "5"
   kafka-config: |-

--- a/examples/configmaps/cluster-controller/kafka-persistent.yaml
+++ b/examples/configmaps/cluster-controller/kafka-persistent.yaml
@@ -7,11 +7,9 @@ metadata:
     strimzi.io/type: kafka
 data:
   kafka-nodes: "3"
-  kafka-image: "strimzi/kafka:latest"
   kafka-healthcheck-delay: "15"
   kafka-healthcheck-timeout: "5"
   zookeeper-nodes: "3"
-  zookeeper-image: "strimzi/zookeeper:latest"
   zookeeper-healthcheck-delay: "15"
   zookeeper-healthcheck-timeout: "5"
   kafka-config: |-

--- a/examples/templates/cluster-controller/connect-s2i-template.yaml
+++ b/examples/templates/cluster-controller/connect-s2i-template.yaml
@@ -62,18 +62,6 @@ parameters:
   displayName: Status replication factor
   name: KAFKA_CONNECT_STATUS_STORAGE_REPLICATION_FACTOR
   value: "3"
-- description: Image repository name of the S2I Docker image
-  displayName: S2I image repository
-  name: S2I_IMAGE_REPO_NAME
-  value: strimzi
-- description: Name of the S2I Docker image
-  displayName: S2I image name
-  name: S2I_IMAGE_NAME
-  value: kafka-connect-s2i
-- description: Tag of the S2I Docker image
-  displayName: S2I image tag
-  name: S2I_IMAGE_TAG
-  value: latest
 - description: Number of seconds after the container has started before healthcheck probes are initiated.
   displayName: Kafka Connect healthcheck initial delay
   name: HEALTHCHECK_DELAY
@@ -92,7 +80,6 @@ objects:
       strimzi.io/type: kafka-connect-s2i
   data:
     nodes: "${INSTANCES}"
-    image: "${S2I_IMAGE_REPO_NAME}/${S2I_IMAGE_NAME}:${S2I_IMAGE_TAG}"
     healthcheck-delay: "${HEALTHCHECK_DELAY}"
     healthcheck-timeout: "${HEALTHCHECK_TIMEOUT}"
     KAFKA_CONNECT_BOOTSTRAP_SERVERS: "${KAFKA_CONNECT_BOOTSTRAP_SERVERS}"

--- a/examples/templates/cluster-controller/connect-template.yaml
+++ b/examples/templates/cluster-controller/connect-template.yaml
@@ -61,18 +61,6 @@ parameters:
   displayName: Status replication factor
   name: KAFKA_CONNECT_STATUS_STORAGE_REPLICATION_FACTOR
   value: "3"
-- description: Image repository name
-  displayName: Repository Name
-  name: IMAGE_REPO_NAME
-  value: strimzi
-- description: Image name
-  displayName: Image Name
-  name: IMAGE_NAME
-  value: kafka-connect
-- description: Image tag
-  displayName: Image tag
-  name: IMAGE_TAG
-  value: latest
 - description: Number of seconds after the container has started before healthcheck probes are initiated.
   displayName: Kafka Connect healthcheck initial delay
   name: HEALTHCHECK_DELAY
@@ -91,7 +79,6 @@ objects:
       strimzi.io/type: kafka-connect
   data:
     nodes: "${INSTANCES}"
-    image: "${IMAGE_REPO_NAME}/${IMAGE_NAME}:${IMAGE_TAG}"
     healthcheck-delay: "${HEALTHCHECK_DELAY}"
     healthcheck-timeout: "${HEALTHCHECK_TIMEOUT}"
     KAFKA_CONNECT_BOOTSTRAP_SERVERS: "${KAFKA_CONNECT_BOOTSTRAP_SERVERS}"

--- a/examples/templates/cluster-controller/ephemeral-template.yaml
+++ b/examples/templates/cluster-controller/ephemeral-template.yaml
@@ -30,26 +30,6 @@ parameters:
   name: KAFKA_NODE_COUNT
   required: true
   value: "3"
-- description: Image repository name
-  displayName: Repository Name
-  name: IMAGE_REPO_NAME
-  value: strimzi
-- description: Kafka image name
-  displayName: Kafka image Name
-  name: KAFKA_IMAGE_NAME
-  value: kafka
-- description: Kafka image tag
-  displayName: Kafka image tag
-  name: KAFKA_IMAGE_TAG
-  value: latest
-- description: Zookeeper image name
-  displayName: Zookeeper image Name
-  name: ZOOKEEPER_IMAGE_NAME
-  value: zookeeper
-- description: Zookeeper image tag
-  displayName: Zookeeper image tag
-  name: ZOOKEEPER_IMAGE_TAG
-  value: latest
 - description: Number of seconds after the container has started before healthcheck probes are initiated.
   displayName: Zookeeper healthcheck initial delay
   name: ZOOKEEPER_HEALTHCHECK_DELAY
@@ -88,11 +68,9 @@ objects:
       strimzi.io/kind: cluster
   data:
     kafka-nodes: "${KAFKA_NODE_COUNT}"
-    kafka-image: "${IMAGE_REPO_NAME}/${KAFKA_IMAGE_NAME}:${KAFKA_IMAGE_TAG}"
     kafka-healthcheck-delay: "${KAFKA_HEALTHCHECK_DELAY}"
     kafka-healthcheck-timeout: "${KAFKA_HEALTHCHECK_TIMEOUT}"
     zookeeper-nodes: "${ZOOKEEPER_NODE_COUNT}"
-    zookeeper-image: "${IMAGE_REPO_NAME}/${ZOOKEEPER_IMAGE_NAME}:${ZOOKEEPER_IMAGE_TAG}"
     zookeeper-healthcheck-delay: "${ZOOKEEPER_HEALTHCHECK_DELAY}"
     zookeeper-healthcheck-timeout: "${ZOOKEEPER_HEALTHCHECK_TIMEOUT}"
     kafka-config: |-

--- a/examples/templates/cluster-controller/persistent-template.yaml
+++ b/examples/templates/cluster-controller/persistent-template.yaml
@@ -36,26 +36,6 @@ parameters:
   name: KAFKA_VOLUME_CAPACITY
   required: true
   value: 1Gi
-- description: Image repository name
-  displayName: Repository Name
-  name: IMAGE_REPO_NAME
-  value: strimzi
-- description: Kafka image name
-  displayName: Kafka image Name
-  name: KAFKA_IMAGE_NAME
-  value: kafka
-- description: Kafka image tag
-  displayName: Kafka image tag
-  name: KAFKA_IMAGE_TAG
-  value: latest
-- description: Zookeeper image name
-  displayName: Zookeeper image Name
-  name: ZOOKEEPER_IMAGE_NAME
-  value: zookeeper
-- description: Zookeeper image tag
-  displayName: Zookeeper image tag
-  name: ZOOKEEPER_IMAGE_TAG
-  value: latest
 - description: Number of seconds after the container has started before healthcheck probes are initiated.
   displayName: Zookeeper healthcheck initial delay
   name: ZOOKEEPER_HEALTHCHECK_DELAY
@@ -94,11 +74,9 @@ objects:
       strimzi.io/kind: cluster
   data:
     kafka-nodes: "${KAFKA_NODE_COUNT}"
-    kafka-image: "${IMAGE_REPO_NAME}/${KAFKA_IMAGE_NAME}:${KAFKA_IMAGE_TAG}"
     kafka-healthcheck-delay: "${KAFKA_HEALTHCHECK_DELAY}"
     kafka-healthcheck-timeout: "${KAFKA_HEALTHCHECK_TIMEOUT}"
     zookeeper-nodes: "${ZOOKEEPER_NODE_COUNT}"
-    zookeeper-image: "${IMAGE_REPO_NAME}/${ZOOKEEPER_IMAGE_NAME}:${ZOOKEEPER_IMAGE_TAG}"
     zookeeper-healthcheck-delay: "${ZOOKEEPER_HEALTHCHECK_DELAY}"
     zookeeper-healthcheck-timeout: "${ZOOKEEPER_HEALTHCHECK_TIMEOUT}"
     kafka-config: |-


### PR DESCRIPTION
### Type of change

- ~~Bugfix~~
- Enhancement / new feature
- ~~Refactoring~~

### Description

Currently, the Docker images can be configured in two ways:
* In the CC configuration
* In the Assembly config map

Our example right now contain both and that can cause confusion and problem. Among other things, the hardcoded images in example Config maps cause CI to crash with releases or when changing content of Docker images since the system tests do not modify them.

This PR proposes to remove the hardcoded images from the ConfigMaps and from the Templates. The option to use them will be still documented and available. Just not covered by the examples.

_Note: This also removes the parameters from the OpenShift templates. Since the templates are too stupid, we cannot have the field as optional._
