### PR TITLE
Make it possible for Connect S2I deployments to use insecure Docker repositories

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
@@ -317,9 +317,7 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
     }
 
     /**
-     * Returns true if the source repo for the S2I image should be treated as insecure in source ImageStream
-     *
-     * @return
+     * @return true if the source repo for the S2I image should be treated as insecure in source ImageStream
      */
     public boolean isInsecureSourceRepository() {
         return insecureSourceRepository;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
@@ -75,7 +75,7 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
         kafkaConnect.setHealthCheckInitialDelay(Integer.parseInt(data.getOrDefault(KEY_HEALTHCHECK_DELAY, String.valueOf(DEFAULT_HEALTHCHECK_DELAY))));
         kafkaConnect.setHealthCheckTimeout(Integer.parseInt(data.getOrDefault(KEY_HEALTHCHECK_TIMEOUT, String.valueOf(DEFAULT_HEALTHCHECK_TIMEOUT))));
 
-        kafkaConnect.setInsecureSourceRepository(Boolean.parseBoolean((data.getOrDefault(KEY_INSECURE_SOURCE_REPO, "false"))));
+        kafkaConnect.setInsecureSourceRepository(Boolean.parseBoolean(data.getOrDefault(KEY_INSECURE_SOURCE_REPO, "false")));
 
         String connectConfig = data.get(KEY_CONNECT_CONFIG);
         if (connectConfig != null) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectS2ICluster.java
@@ -23,7 +23,10 @@ import io.fabric8.openshift.api.model.ImageChangeTrigger;
 import io.fabric8.openshift.api.model.ImageLookupPolicyBuilder;
 import io.fabric8.openshift.api.model.ImageStream;
 import io.fabric8.openshift.api.model.ImageStreamBuilder;
+import io.fabric8.openshift.api.model.TagImportPolicy;
+import io.fabric8.openshift.api.model.TagImportPolicyBuilder;
 import io.fabric8.openshift.api.model.TagReference;
+import io.fabric8.openshift.api.model.TagReferencePolicyBuilder;
 import io.vertx.core.json.JsonObject;
 
 import java.util.Collections;
@@ -35,10 +38,14 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
     protected String sourceImageBaseName = DEFAULT_IMAGE.substring(0, DEFAULT_IMAGE.lastIndexOf(":"));
     protected String sourceImageTag = DEFAULT_IMAGE.substring(DEFAULT_IMAGE.lastIndexOf(":") + 1);
     protected String tag = "latest";
+    protected boolean insecureSourceRepository = false;
 
     // Configuration defaults
     protected static final String DEFAULT_IMAGE =
             System.getenv().getOrDefault("STRIMZI_DEFAULT_KAFKA_CONNECT_S2I_IMAGE", "strimzi/kafka-connect-s2i:latest");
+
+    // Configuration keys (in ConfigMap)
+    public static final String KEY_INSECURE_SOURCE_REPO = "insecure-source-repo";
 
     /**
      * Constructor
@@ -67,6 +74,8 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
         kafkaConnect.setJvmOptions(JvmOptions.fromJson(data.get(KEY_JVM_OPTIONS)));
         kafkaConnect.setHealthCheckInitialDelay(Integer.parseInt(data.getOrDefault(KEY_HEALTHCHECK_DELAY, String.valueOf(DEFAULT_HEALTHCHECK_DELAY))));
         kafkaConnect.setHealthCheckTimeout(Integer.parseInt(data.getOrDefault(KEY_HEALTHCHECK_TIMEOUT, String.valueOf(DEFAULT_HEALTHCHECK_TIMEOUT))));
+
+        kafkaConnect.setInsecureSourceRepository(Boolean.parseBoolean((data.getOrDefault(KEY_INSECURE_SOURCE_REPO, "false"))));
 
         String connectConfig = data.get(KEY_CONNECT_CONFIG);
         if (connectConfig != null) {
@@ -103,6 +112,14 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
 
         String sourceImage = sis.getSpec().getTags().get(0).getFrom().getName();
         kafkaConnect.setImage(sourceImage);
+
+        TagImportPolicy policy = sis.getSpec().getTags().get(0).getImportPolicy();
+        if (policy != null) {
+            Boolean insecure = policy.getInsecure();
+            if (insecure != null) {
+                kafkaConnect.setInsecureSourceRepository(insecure);
+            }
+        }
 
         return kafkaConnect;
     }
@@ -183,6 +200,11 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
         TagReference sourceTag = new TagReference();
         sourceTag.setName(sourceImageTag);
         sourceTag.setFrom(image);
+
+        if (insecureSourceRepository)   {
+            sourceTag.setImportPolicy(new TagImportPolicyBuilder().withInsecure(true).build());
+            sourceTag.setReferencePolicy(new TagReferencePolicyBuilder().withType("Local").build());
+        }
 
         ImageStream imageStream = new ImageStreamBuilder()
                 .withNewMetadata()
@@ -292,5 +314,23 @@ public class KafkaConnectS2ICluster extends KafkaConnectCluster {
         this.sourceImageTag = image.substring(image.lastIndexOf(":") + 1);
         this.image = name + ":" + tag;
 
+    }
+
+    /**
+     * Returns true if the source repo for the S2I image should be treated as insecure in source ImageStream
+     *
+     * @return
+     */
+    public boolean isInsecureSourceRepository() {
+        return insecureSourceRepository;
+    }
+
+    /**
+     * Set whether the source repository for the S2I image should be treated as insecure
+     *
+     * @param insecureSourceRepository  Set to true for using insecure repository
+     */
+    public void setInsecureSourceRepository(boolean insecureSourceRepository) {
+        this.insecureSourceRepository = insecureSourceRepository;
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -109,13 +109,15 @@ public class ResourceUtils {
      * Generate ConfigMap for Kafka Connect S2I cluster
      */
     public static ConfigMap createKafkaConnectS2IClusterConfigMap(String clusterCmNamespace, String clusterCmName, int replicas,
-                                                                  String image, int healthDelay, int healthTimeout, String connectConfig) {
+                                                                  String image, int healthDelay, int healthTimeout, String connectConfig,
+                                                                  boolean insecureSourceRepo) {
         Map<String, String> cmData = new HashMap<>();
         cmData.put(KafkaConnectS2ICluster.KEY_IMAGE, image);
         cmData.put(KafkaConnectS2ICluster.KEY_REPLICAS, Integer.toString(replicas));
         cmData.put(KafkaConnectS2ICluster.KEY_HEALTHCHECK_DELAY, Integer.toString(healthDelay));
         cmData.put(KafkaConnectS2ICluster.KEY_HEALTHCHECK_TIMEOUT, Integer.toString(healthTimeout));
         cmData.put(KafkaConnectS2ICluster.KEY_CONNECT_CONFIG, connectConfig);
+        cmData.put(KafkaConnectS2ICluster.KEY_INSECURE_SOURCE_REPO, String.valueOf(insecureSourceRepo));
 
         ConfigMap cm = createEmptyKafkaConnectS2IClusterConfigMap(clusterCmNamespace, clusterCmName);
         cm.setData(cmData);


### PR DESCRIPTION
### Type of change

- ~~Bugfix~~
- Enhancement / new feature
- ~~Refactoring~~

### Description

This PR adds new option `insecure-source-repo` to Connect S2I config map. When set to `true`, it will configure the `ImportPolicy` and `ReferencePolicy` to make it possible to use the S2I image from insecure Docker repository.

_Note: There is currently no S2I documentation (this is covered by another issue). Therefore no documentation was updated with this PR.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [X] Write tests
- [X] Make sure all tests pass
- [ ] Update documentation
- [X] Check RBAC rights for Kubernetes / OpenShift roles
- [X] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [X] Reference relevant issue(s) and close them after merging

