### PR TITLE
Make Zookeeeper user configurable

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -58,16 +58,13 @@ public class KafkaCluster extends AbstractModel {
     public static final String KEY_METRICS_CONFIG = "kafka-metrics-config";
     public static final String KEY_STORAGE = "kafka-storage";
     public static final String KEY_KAFKA_CONFIG = "kafka-config";
-
-    // Kafka configuration keys (EnvVariables)
-    public static final String KEY_KAFKA_ZOOKEEPER_CONNECT = "KAFKA_ZOOKEEPER_CONNECT";
-    private static final String KEY_KAFKA_METRICS_ENABLED = "KAFKA_METRICS_ENABLED";
     public static final String KEY_JVM_OPTIONS = "kafka-jvmOptions";
     public static final String KEY_RESOURCES = "kafka-resources";
 
-    // Kafka configuration keys
-    protected static final String KEY_KAFKA_USER_CONFIGURATION = "KAFKA_USER_CONFIGURATION";
-    public static final String KEY_KAFKA_HEAP_OPTS = "KAFKA_HEAP_OPTS";
+    // Kafka configuration keys (EnvVariables)
+    public static final String ENV_VAR_KAFKA_ZOOKEEPER_CONNECT = "KAFKA_ZOOKEEPER_CONNECT";
+    private static final String ENV_VAR_KAFKA_METRICS_ENABLED = "KAFKA_METRICS_ENABLED";
+    protected static final String ENV_VAR_KAFKA_USER_CONFIGURATION = "KAFKA_USER_CONFIGURATION";
 
     /**
      * Constructor
@@ -126,7 +123,7 @@ public class KafkaCluster extends AbstractModel {
         kafka.setHealthCheckInitialDelay(Integer.parseInt(data.getOrDefault(KEY_HEALTHCHECK_DELAY, String.valueOf(DEFAULT_HEALTHCHECK_DELAY))));
         kafka.setHealthCheckTimeout(Integer.parseInt(data.getOrDefault(KEY_HEALTHCHECK_TIMEOUT, String.valueOf(DEFAULT_HEALTHCHECK_TIMEOUT))));
 
-        kafka.setZookeeperConnect(data.getOrDefault(KEY_KAFKA_ZOOKEEPER_CONNECT, kafkaClusterCm.getMetadata().getName() + "-zookeeper:2181"));
+        kafka.setZookeeperConnect(data.getOrDefault(ENV_VAR_KAFKA_ZOOKEEPER_CONNECT, kafkaClusterCm.getMetadata().getName() + "-zookeeper:2181"));
 
         String metricsConfig = data.get(KEY_METRICS_CONFIG);
         kafka.setMetricsEnabled(metricsConfig != null);
@@ -141,6 +138,7 @@ public class KafkaCluster extends AbstractModel {
         if (kafkaConfig != null) {
             kafka.setConfiguration(new KafkaConfiguration(new JsonObject(kafkaConfig)));
         }
+
         kafka.setResources(Resources.fromJson(data.get(KEY_RESOURCES)));
         kafka.setJvmOptions(JvmOptions.fromJson(data.get(KEY_JVM_OPTIONS)));
 
@@ -167,9 +165,9 @@ public class KafkaCluster extends AbstractModel {
 
         Map<String, String> vars = containerEnvVars(container);
 
-        kafka.setZookeeperConnect(vars.getOrDefault(KEY_KAFKA_ZOOKEEPER_CONNECT, ss.getMetadata().getName() + "-zookeeper:2181"));
+        kafka.setZookeeperConnect(vars.getOrDefault(ENV_VAR_KAFKA_ZOOKEEPER_CONNECT, ss.getMetadata().getName() + "-zookeeper:2181"));
 
-        kafka.setMetricsEnabled(Boolean.parseBoolean(vars.getOrDefault(KEY_KAFKA_METRICS_ENABLED, String.valueOf(DEFAULT_KAFKA_METRICS_ENABLED))));
+        kafka.setMetricsEnabled(Boolean.parseBoolean(vars.getOrDefault(ENV_VAR_KAFKA_METRICS_ENABLED, String.valueOf(DEFAULT_KAFKA_METRICS_ENABLED))));
         if (kafka.isMetricsEnabled()) {
             kafka.setMetricsConfigName(metricConfigsName(cluster));
         }
@@ -187,7 +185,7 @@ public class KafkaCluster extends AbstractModel {
             kafka.setStorage(storage);
         }
 
-        String kafkaConfiguration = containerEnvVars(container).get(KEY_KAFKA_USER_CONFIGURATION);
+        String kafkaConfiguration = containerEnvVars(container).get(ENV_VAR_KAFKA_USER_CONFIGURATION);
         if (kafkaConfiguration != null) {
             kafka.setConfiguration(new KafkaConfiguration(kafkaConfiguration));
         }
@@ -299,12 +297,12 @@ public class KafkaCluster extends AbstractModel {
     @Override
     protected List<EnvVar> getEnvVars() {
         List<EnvVar> varList = new ArrayList<>();
-        varList.add(buildEnvVar(KEY_KAFKA_ZOOKEEPER_CONNECT, zookeeperConnect));
-        varList.add(buildEnvVar(KEY_KAFKA_METRICS_ENABLED, String.valueOf(isMetricsEnabled)));
+        varList.add(buildEnvVar(ENV_VAR_KAFKA_ZOOKEEPER_CONNECT, zookeeperConnect));
+        varList.add(buildEnvVar(ENV_VAR_KAFKA_METRICS_ENABLED, String.valueOf(isMetricsEnabled)));
         kafkaHeapOptions(varList, 0.5, 5L * 1024L * 1024L * 1024L);
 
         if (configuration != null) {
-            varList.add(buildEnvVar(KEY_KAFKA_USER_CONFIGURATION, configuration.getConfiguration()));
+            varList.add(buildEnvVar(ENV_VAR_KAFKA_USER_CONFIGURATION, configuration.getConfiguration()));
         }
 
         return varList;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -59,9 +59,9 @@ public class ZookeeperCluster extends AbstractModel {
     public static final String KEY_ZOOKEEPER_CONFIG = "zookeeper-config";
 
     // Zookeeper configuration keys (EnvVariables)
-    private static final String ENV_VAR_ZOOKEEPER_NODE_COUNT = "ZOOKEEPER_NODE_COUNT";
+    public static final String ENV_VAR_ZOOKEEPER_NODE_COUNT = "ZOOKEEPER_NODE_COUNT";
     public static final String ENV_VAR_ZOOKEEPER_METRICS_ENABLED = "ZOOKEEPER_METRICS_ENABLED";
-    protected static final String ENV_VAR_ZOOKEEPER_CONFIGURATION = "ZOOKEEPER_CONFIGURATION";
+    public static final String ENV_VAR_ZOOKEEPER_CONFIGURATION = "ZOOKEEPER_CONFIGURATION";
 
     public static String zookeeperClusterName(String cluster) {
         return cluster + ZookeeperCluster.NAME_SUFFIX;
@@ -73,6 +73,10 @@ public class ZookeeperCluster extends AbstractModel {
 
     public static String zookeeperHeadlessName(String cluster) {
         return cluster + ZookeeperCluster.HEADLESS_NAME_SUFFIX;
+    }
+
+    public static String zookeeperPodName(String cluster, int pod) {
+        return zookeeperClusterName(cluster) + "-" + pod;
     }
 
     public static String getPersistentVolumeClaimName(String clusterName, int podId) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperConfiguration.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017-2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.strimzi.operator.cluster.model;
+
+import java.util.List;
+
+import io.vertx.core.json.JsonObject;
+
+import static java.util.Arrays.asList;
+
+/**
+ * Class for handling Kafka configuration passed by the user
+ */
+public class ZookeeperConfiguration extends AbstractConfiguration {
+    private static final List<String> FORBIDDEN_OPTIONS;
+
+    static {
+        FORBIDDEN_OPTIONS = asList(
+                "server.",
+                "dataDir",
+                "dataLogDir",
+                "clientPort",
+                "authProvider",
+                "quorum.auth",
+                "requireClientAuthScheme");
+    }
+
+    /**
+     * Constructor used to instantiate this class from String configuration. Should be used to create configuration
+     * from the Assembly.
+     *
+     * @param configuration Configuration in String format. Should contain zero or more lines with with key=value
+     *                      pairs.
+     */
+    public ZookeeperConfiguration(String configuration) {
+        super(configuration, FORBIDDEN_OPTIONS);
+    }
+
+    /**
+     * Constructor used to instantiate this class from JsonObject. Should be used to create configuration from
+     * ConfigMap / CRD.
+     *
+     * @param jsonOptions     Json object with configuration options as key ad value pairs.
+     */
+    public ZookeeperConfiguration(JsonObject jsonOptions) {
+        super(jsonOptions, FORBIDDEN_OPTIONS);
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperConfiguration.java
@@ -12,7 +12,7 @@ import io.vertx.core.json.JsonObject;
 import static java.util.Arrays.asList;
 
 /**
- * Class for handling Kafka configuration passed by the user
+ * Class for handling Zookeeper configuration passed by the user
  */
 public class ZookeeperConfiguration extends AbstractConfiguration {
     private static final List<String> FORBIDDEN_OPTIONS;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -55,28 +55,37 @@ public class ResourceUtils {
                                                         String image, int healthDelay, int healthTimeout,
                                                         String metricsCmJson) {
         return createKafkaClusterConfigMap(clusterCmNamespace, clusterCmName, replicas, image, healthDelay,
-                healthTimeout, metricsCmJson, "",
+                healthTimeout, metricsCmJson, "{}", "{}",
                 "{\"type\": \"ephemeral\"}", null);
     }
     public static ConfigMap createKafkaClusterConfigMap(String clusterCmNamespace, String clusterCmName, int replicas,
                                                         String image, int healthDelay, int healthTimeout,
                                                         String metricsCmJson, String kafkaConfigurationJson) {
         return createKafkaClusterConfigMap(clusterCmNamespace, clusterCmName, replicas, image, healthDelay,
-                healthTimeout, metricsCmJson, kafkaConfigurationJson,
+                healthTimeout, metricsCmJson, kafkaConfigurationJson, "{}",
                 "{\"type\": \"ephemeral\"}", null);
     }
     public static ConfigMap createKafkaClusterConfigMap(String clusterCmNamespace, String clusterCmName, int replicas,
                                                         String image, int healthDelay, int healthTimeout,
                                                         String metricsCmJson, String kafkaConfigurationJson,
-                                                        String storage) {
+                                                        String zooConfigurationJson) {
         return createKafkaClusterConfigMap(clusterCmNamespace, clusterCmName, replicas, image, healthDelay,
-                healthTimeout, metricsCmJson, kafkaConfigurationJson,
+                healthTimeout, metricsCmJson, kafkaConfigurationJson, zooConfigurationJson,
+                "{\"type\": \"ephemeral\"}", null);
+    }
+    public static ConfigMap createKafkaClusterConfigMap(String clusterCmNamespace, String clusterCmName, int replicas,
+                                                        String image, int healthDelay, int healthTimeout,
+                                                        String metricsCmJson, String kafkaConfigurationJson,
+                                                        String zooConfigurationJson, String storage) {
+        return createKafkaClusterConfigMap(clusterCmNamespace, clusterCmName, replicas, image, healthDelay,
+                healthTimeout, metricsCmJson, kafkaConfigurationJson, zooConfigurationJson,
                 storage, null);
     }
 
     public static ConfigMap createKafkaClusterConfigMap(String clusterCmNamespace, String clusterCmName, int replicas,
                                                         String image, int healthDelay, int healthTimeout, String metricsCmJson,
-                                                        String kafkaConfigurationJson, String storage, String topicOperator) {
+                                                        String kafkaConfigurationJson, String zooConfigurationJson,
+                                                        String storage, String topicOperator) {
         Map<String, String> cmData = new HashMap<>();
         cmData.put(KafkaCluster.KEY_REPLICAS, Integer.toString(replicas));
         cmData.put(KafkaCluster.KEY_IMAGE, image);
@@ -89,6 +98,7 @@ public class ResourceUtils {
         cmData.put(ZookeeperCluster.KEY_IMAGE, image + "-zk");
         cmData.put(ZookeeperCluster.KEY_HEALTHCHECK_DELAY, Integer.toString(healthDelay));
         cmData.put(ZookeeperCluster.KEY_HEALTHCHECK_TIMEOUT, Integer.toString(healthTimeout));
+        cmData.put(ZookeeperCluster.KEY_ZOOKEEPER_CONFIG, zooConfigurationJson);
         cmData.put(ZookeeperCluster.KEY_STORAGE, storage);
         cmData.put(ZookeeperCluster.KEY_METRICS_CONFIG, metricsCmJson);
         if (topicOperator != null) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -132,7 +132,7 @@ public class KafkaClusterTest {
     public void testPvcNames() {
 
         for (int i = 0; i < replicas; i++) {
-            assertEquals(kc.VOLUME_NAME + "-" + KafkaCluster.kafkaClusterName(cluster) + "-" + i, kc.getPersistentVolumeClaimName(i));
+            assertEquals(kc.VOLUME_NAME + "-" + KafkaCluster.kafkaPodName(cluster, i), kc.getPersistentVolumeClaimName(i));
         }
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/TopicOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/TopicOperatorTest.java
@@ -26,7 +26,8 @@ public class TopicOperatorTest {
     private final int healthDelay = 120;
     private final int healthTimeout = 30;
     private final String metricsCmJson = "{\"animal\":\"wombat\"}";
-    private final String kafkaJson = "{\"foo\":\"bar\"}";
+    private final String kafkaConfigJson = "{\"foo\":\"bar\"}";
+    private final String zooConfigJson = "{\"foo\":\"bar\"}";
     private final String storageJson = "{\"type\": \"ephemeral\"}";
 
     private final String tcWatchedNamespace = "my-topic-namespace";
@@ -43,7 +44,7 @@ public class TopicOperatorTest {
             "\"topicMetadataMaxAttempts\":" + tcTopicMetadataMaxAttempts +
             " }";
 
-    private final ConfigMap cm = ResourceUtils.createKafkaClusterConfigMap(namespace, cluster, replicas, image, healthDelay, healthTimeout, metricsCmJson, kafkaJson, storageJson, topicOperatorJson);
+    private final ConfigMap cm = ResourceUtils.createKafkaClusterConfigMap(namespace, cluster, replicas, image, healthDelay, healthTimeout, metricsCmJson, kafkaConfigJson, zooConfigJson, storageJson, topicOperatorJson);
     private final TopicOperator tc = TopicOperator.fromConfigMap(cm);
 
     private List<EnvVar> getExpectedEnvVars() {
@@ -71,7 +72,7 @@ public class TopicOperatorTest {
     @Test
     public void testFromConfigMapDefaultConfig() {
 
-        ConfigMap cm = ResourceUtils.createKafkaClusterConfigMap(namespace, cluster, replicas, image, healthDelay, healthTimeout, metricsCmJson, kafkaJson, storageJson, "{ }");
+        ConfigMap cm = ResourceUtils.createKafkaClusterConfigMap(namespace, cluster, replicas, image, healthDelay, healthTimeout, metricsCmJson, kafkaConfigJson, zooConfigJson, storageJson, "{ }");
         TopicOperator tc = TopicOperator.fromConfigMap(cm);
 
         assertEquals(TopicOperator.DEFAULT_IMAGE, tc.getImage());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -126,7 +126,7 @@ public class ZookeeperClusterTest {
     public void testPodNames() {
 
         for (int i = 0; i < replicas; i++) {
-            assertEquals(ZookeeperCluster.zookeeperClusterName(cluster) + "-" + i, zc.getPodName(i));
+            assertEquals(ZookeeperCluster.zookeeperPodName(cluster, i), zc.getPodName(i));
         }
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ZookeeperClusterTest.java
@@ -4,16 +4,17 @@
  */
 package io.strimzi.operator.cluster.model;
 
+import io.strimzi.operator.cluster.ResourceUtils;
+
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.extensions.StatefulSet;
-import io.strimzi.operator.cluster.ResourceUtils;
 import org.junit.Test;
 
 import static io.strimzi.operator.cluster.ResourceUtils.labels;
 import static org.junit.Assert.assertEquals;
 
-public class KafkaClusterTest {
+public class ZookeeperClusterTest {
 
     private final String namespace = "test";
     private final String cluster = "foo";
@@ -22,13 +23,14 @@ public class KafkaClusterTest {
     private final int healthDelay = 120;
     private final int healthTimeout = 30;
     private final String metricsCmJson = "{\"animal\":\"wombat\"}";
-    private final String configurationJson = "{\"foo\":\"bar\"}";
-    private final ConfigMap cm = ResourceUtils.createKafkaClusterConfigMap(namespace, cluster, replicas, image, healthDelay, healthTimeout, metricsCmJson, configurationJson);
-    private final KafkaCluster kc = KafkaCluster.fromConfigMap(cm);
+    private final String configurationJson = "{}";
+    private final String zooConfigurationJson = "{\"foo\":\"bar\"}";
+    private final ConfigMap cm = ResourceUtils.createKafkaClusterConfigMap(namespace, cluster, replicas, image, healthDelay, healthTimeout, metricsCmJson, configurationJson, zooConfigurationJson);
+    private final ZookeeperCluster zc = ZookeeperCluster.fromConfigMap(cm);
 
     @Test
     public void testMetricsConfigMap() {
-        ConfigMap metricsCm = kc.generateMetricsConfigMap();
+        ConfigMap metricsCm = zc.generateMetricsConfigMap();
         checkMetricsConfigMap(metricsCm);
     }
 
@@ -38,7 +40,7 @@ public class KafkaClusterTest {
 
     @Test
     public void testGenerateService() {
-        Service headful = kc.generateService();
+        Service headful = zc.generateService();
         checkService(headful);
     }
 
@@ -47,75 +49,75 @@ public class KafkaClusterTest {
         assertEquals(ResourceUtils.labels(Labels.STRIMZI_CLUSTER_LABEL, cluster,
                 Labels.STRIMZI_TYPE_LABEL, "kafka",
                 "my-user-label", "cromulent",
-                Labels.STRIMZI_NAME_LABEL, KafkaCluster.kafkaClusterName(cluster)), headful.getSpec().getSelector());
-        assertEquals(2, headful.getSpec().getPorts().size());
-        assertEquals(KafkaCluster.CLIENT_PORT_NAME, headful.getSpec().getPorts().get(0).getName());
-        assertEquals(new Integer(KafkaCluster.CLIENT_PORT), headful.getSpec().getPorts().get(0).getPort());
-        assertEquals(KafkaCluster.REPLICATION_PORT_NAME, headful.getSpec().getPorts().get(1).getName());
-        assertEquals(new Integer(KafkaCluster.REPLICATION_PORT), headful.getSpec().getPorts().get(1).getPort());
+                Labels.STRIMZI_NAME_LABEL, ZookeeperCluster.zookeeperClusterName(cluster)), headful.getSpec().getSelector());
+        assertEquals(1, headful.getSpec().getPorts().size());
+        assertEquals(ZookeeperCluster.CLIENT_PORT_NAME, headful.getSpec().getPorts().get(0).getName());
+        assertEquals(new Integer(ZookeeperCluster.CLIENT_PORT), headful.getSpec().getPorts().get(0).getPort());
         assertEquals("TCP", headful.getSpec().getPorts().get(0).getProtocol());
     }
 
     @Test
     public void testGenerateHeadlessService() {
-        Service headless = kc.generateHeadlessService();
+        Service headless = zc.generateHeadlessService();
         checkHeadlessService(headless);
     }
 
     private void checkHeadlessService(Service headless) {
-        assertEquals(KafkaCluster.headlessName(cluster), headless.getMetadata().getName());
+        assertEquals(ZookeeperCluster.zookeeperHeadlessName(cluster), headless.getMetadata().getName());
         assertEquals("ClusterIP", headless.getSpec().getType());
         assertEquals("None", headless.getSpec().getClusterIP());
         assertEquals(labels(Labels.STRIMZI_CLUSTER_LABEL, cluster,
                 Labels.STRIMZI_TYPE_LABEL, "kafka",
                 "my-user-label", "cromulent",
-                Labels.STRIMZI_NAME_LABEL, KafkaCluster.kafkaClusterName(cluster)), headless.getSpec().getSelector());
-        assertEquals(2, headless.getSpec().getPorts().size());
-        assertEquals(KafkaCluster.CLIENT_PORT_NAME, headless.getSpec().getPorts().get(0).getName());
-        assertEquals(new Integer(KafkaCluster.CLIENT_PORT), headless.getSpec().getPorts().get(0).getPort());
-        assertEquals(KafkaCluster.REPLICATION_PORT_NAME, headless.getSpec().getPorts().get(1).getName());
-        assertEquals(new Integer(KafkaCluster.REPLICATION_PORT), headless.getSpec().getPorts().get(1).getPort());
+                Labels.STRIMZI_NAME_LABEL, ZookeeperCluster.zookeeperClusterName(cluster)), headless.getSpec().getSelector());
+        assertEquals(3, headless.getSpec().getPorts().size());
+        assertEquals(ZookeeperCluster.CLIENT_PORT_NAME, headless.getSpec().getPorts().get(0).getName());
+        assertEquals(new Integer(ZookeeperCluster.CLIENT_PORT), headless.getSpec().getPorts().get(0).getPort());
+        assertEquals(ZookeeperCluster.CLUSTERING_PORT_NAME, headless.getSpec().getPorts().get(1).getName());
+        assertEquals(new Integer(ZookeeperCluster.CLUSTERING_PORT), headless.getSpec().getPorts().get(1).getPort());
+        assertEquals(ZookeeperCluster.LEADER_ELECTION_PORT_NAME, headless.getSpec().getPorts().get(2).getName());
+        assertEquals(new Integer(ZookeeperCluster.LEADER_ELECTION_PORT), headless.getSpec().getPorts().get(2).getPort());
         assertEquals("TCP", headless.getSpec().getPorts().get(0).getProtocol());
     }
 
     @Test
     public void testGenerateStatefulSet() {
         // We expect a single statefulSet ...
-        StatefulSet ss = kc.generateStatefulSet(true);
+        StatefulSet ss = zc.generateStatefulSet(true);
         checkStatefulSet(ss);
     }
 
     private void checkStatefulSet(StatefulSet ss) {
-        assertEquals(KafkaCluster.kafkaClusterName(cluster), ss.getMetadata().getName());
+        assertEquals(ZookeeperCluster.zookeeperClusterName(cluster), ss.getMetadata().getName());
         // ... in the same namespace ...
         assertEquals(namespace, ss.getMetadata().getNamespace());
         // ... with these labels
         assertEquals(labels("strimzi.io/cluster", cluster,
                 "strimzi.io/type", "kafka",
                 "my-user-label", "cromulent",
-                "strimzi.io/name", KafkaCluster.kafkaClusterName(cluster)),
+                "strimzi.io/name", ZookeeperCluster.zookeeperClusterName(cluster)),
                 ss.getMetadata().getLabels());
 
         assertEquals(new Integer(replicas), ss.getSpec().getReplicas());
-        assertEquals(image, ss.getSpec().getTemplate().getSpec().getContainers().get(0).getImage());
+        assertEquals(image + "-zk", ss.getSpec().getTemplate().getSpec().getContainers().get(0).getImage());
         assertEquals(new Integer(healthTimeout), ss.getSpec().getTemplate().getSpec().getContainers().get(0).getLivenessProbe().getTimeoutSeconds());
         assertEquals(new Integer(healthDelay), ss.getSpec().getTemplate().getSpec().getContainers().get(0).getLivenessProbe().getInitialDelaySeconds());
         assertEquals(new Integer(healthTimeout), ss.getSpec().getTemplate().getSpec().getContainers().get(0).getReadinessProbe().getTimeoutSeconds());
         assertEquals(new Integer(healthDelay), ss.getSpec().getTemplate().getSpec().getContainers().get(0).getReadinessProbe().getInitialDelaySeconds());
-        assertEquals("foo=bar\n", AbstractModel.containerEnvVars(ss.getSpec().getTemplate().getSpec().getContainers().get(0)).get(KafkaCluster.ENV_VAR_KAFKA_USER_CONFIGURATION));
+        assertEquals("foo=bar\n", AbstractModel.containerEnvVars(ss.getSpec().getTemplate().getSpec().getContainers().get(0)).get(ZookeeperCluster.ENV_VAR_ZOOKEEPER_CONFIGURATION));
     }
 
     /**
-     * Check that a KafkaCluster from a statefulset matches the one from a ConfigMap
+     * Check that a ZookeeperCluster from a statefulset matches the one from a ConfigMap
      */
     @Test
     public void testClusterFromStatefulSet() {
-        StatefulSet ss = kc.generateStatefulSet(true);
-        KafkaCluster kc2 = KafkaCluster.fromAssembly(ss, namespace, cluster);
+        StatefulSet ss = zc.generateStatefulSet(true);
+        ZookeeperCluster zc2 = ZookeeperCluster.fromAssembly(ss, namespace, cluster);
         // Don't check the metrics CM, since this isn't restored from the StatefulSet
-        checkService(kc2.generateService());
-        checkHeadlessService(kc2.generateHeadlessService());
-        checkStatefulSet(kc2.generateStatefulSet(true));
+        checkService(zc2.generateService());
+        checkHeadlessService(zc2.generateHeadlessService());
+        checkStatefulSet(zc2.generateStatefulSet(true));
     }
 
     // TODO test volume claim templates
@@ -124,7 +126,7 @@ public class KafkaClusterTest {
     public void testPodNames() {
 
         for (int i = 0; i < replicas; i++) {
-            assertEquals(KafkaCluster.kafkaClusterName(cluster) + "-" + i, kc.getPodName(i));
+            assertEquals(ZookeeperCluster.zookeeperClusterName(cluster) + "-" + i, zc.getPodName(i));
         }
     }
 
@@ -132,7 +134,7 @@ public class KafkaClusterTest {
     public void testPvcNames() {
 
         for (int i = 0; i < replicas; i++) {
-            assertEquals(kc.VOLUME_NAME + "-" + KafkaCluster.kafkaClusterName(cluster) + "-" + i, kc.getPersistentVolumeClaimName(i));
+            assertEquals(zc.VOLUME_NAME + "-" + ZookeeperCluster.zookeeperClusterName(cluster) + "-" + i, zc.getPersistentVolumeClaimName(i));
         }
     }
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -71,6 +71,7 @@ public class KafkaAssemblyOperatorTest {
     private final boolean openShift;
     private final boolean metrics;
     private final String kafkaConfig;
+    private final String zooConfig;
     private final String storage;
     private final String tcConfig;
     private final boolean deleteClaim;
@@ -79,13 +80,15 @@ public class KafkaAssemblyOperatorTest {
         private final boolean openShift;
         private final boolean metrics;
         private final String kafkaConfig;
+        private final String zooConfig;
         private final String storage;
         private final String tcConfig;
 
-        public Params(boolean openShift, boolean metrics, String kafkaConfig, String storage, String tcConfig) {
+        public Params(boolean openShift, boolean metrics, String kafkaConfig, String zooConfig, String storage, String tcConfig) {
             this.openShift = openShift;
             this.metrics = metrics;
             this.kafkaConfig = kafkaConfig;
+            this.zooConfig = zooConfig;
             this.storage = storage;
             this.tcConfig = tcConfig;
         }
@@ -94,6 +97,7 @@ public class KafkaAssemblyOperatorTest {
             return "openShift=" + openShift +
                     ",metrics=" + metrics +
                     ",kafkaConfig=" + kafkaConfig +
+                    ",zooConfig=" + zooConfig +
                     ",storage=" + storage +
                     ",tcConfig=" + tcConfig;
         }
@@ -118,6 +122,11 @@ public class KafkaAssemblyOperatorTest {
             "{ }",
             "{\"foo\": \"bar\"}"
         };
+        String[] zooConfigs = {
+            null,
+            "{ }",
+            "{\"foo\": \"bar\"}"
+        };
         String[] tcConfigs = {
             null,
             "{ }",
@@ -128,9 +137,11 @@ public class KafkaAssemblyOperatorTest {
         for (boolean shift: shiftiness) {
             for (boolean metric: metrics) {
                 for (String kafkaConfig: kafkaConfigs) {
-                    for (String storage : storageConfigs) {
-                        for (String tcConfig : tcConfigs) {
-                            result.add(new Params(shift, metric, kafkaConfig, storage, tcConfig));
+                    for (String zooConfig: zooConfigs) {
+                        for (String storage : storageConfigs) {
+                            for (String tcConfig : tcConfigs) {
+                                result.add(new Params(shift, metric, kafkaConfig, zooConfig, storage, tcConfig));
+                            }
                         }
                     }
                 }
@@ -143,6 +154,7 @@ public class KafkaAssemblyOperatorTest {
         this.openShift = params.openShift;
         this.metrics = params.metrics;
         this.kafkaConfig = params.kafkaConfig;
+        this.zooConfig = params.zooConfig;
         this.storage = params.storage;
         this.tcConfig = params.tcConfig;
         this.deleteClaim = Storage.fromJson(new JsonObject(params.storage)).isDeleteClaim();
@@ -383,7 +395,7 @@ public class KafkaAssemblyOperatorTest {
         int healthDelay = 120;
         int healthTimeout = 30;
         String metricsCmJson = metrics ? METRICS_CONFIG : null;
-        return ResourceUtils.createKafkaClusterConfigMap(clusterCmNamespace, clusterCmName, replicas, image, healthDelay, healthTimeout, metricsCmJson, kafkaConfig, storage, tcConfig);
+        return ResourceUtils.createKafkaClusterConfigMap(clusterCmNamespace, clusterCmName, replicas, image, healthDelay, healthTimeout, metricsCmJson, kafkaConfig, zooConfig, storage, tcConfig);
     }
 
     private static <T> Set<T> set(T... elements) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaSetOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/KafkaSetOperatorTest.java
@@ -16,7 +16,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static io.strimzi.operator.cluster.model.AbstractModel.containerEnvVars;
-import static io.strimzi.operator.cluster.model.KafkaCluster.KEY_KAFKA_ZOOKEEPER_CONNECT;
+import static io.strimzi.operator.cluster.model.KafkaCluster.ENV_VAR_KAFKA_ZOOKEEPER_CONNECT;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -93,7 +93,7 @@ public class KafkaSetOperatorTest {
 
     @Test
     public void testNeedsRollingUpdateEnvZkConnect() {
-        String envVar = KEY_KAFKA_ZOOKEEPER_CONNECT;
+        String envVar = ENV_VAR_KAFKA_ZOOKEEPER_CONNECT;
         a.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv().add(new EnvVar(envVar,
                 containerEnvVars(a.getSpec().getTemplate().getSpec().getContainers().get(0)).get(envVar) + "-foo", null));
         assertTrue(KafkaSetOperator.needsRollingUpdate(diff()));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZookeeperSetOperatiorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/ZookeeperSetOperatiorTest.java
@@ -16,7 +16,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static io.strimzi.operator.cluster.model.AbstractModel.containerEnvVars;
-import static io.strimzi.operator.cluster.model.ZookeeperCluster.KEY_ZOOKEEPER_METRICS_ENABLED;
+import static io.strimzi.operator.cluster.model.ZookeeperCluster.ENV_VAR_ZOOKEEPER_METRICS_ENABLED;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -89,7 +89,7 @@ public class ZookeeperSetOperatiorTest {
 
     @Test
     public void testNeedsRollingUpdateEnvZkMetricsEnabled() {
-        String envVar = KEY_ZOOKEEPER_METRICS_ENABLED;
+        String envVar = ENV_VAR_ZOOKEEPER_METRICS_ENABLED;
         a.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv().add(new EnvVar(envVar,
                 containerEnvVars(a.getSpec().getTemplate().getSpec().getContainers().get(0)).get(envVar) + "-foo", null));
         assertTrue(ZookeeperSetOperator.needsRollingUpdate(diff()));

--- a/docker-images/zookeeper/scripts/zookeeper_config_generator.sh
+++ b/docker-images/zookeeper/scripts/zookeeper_config_generator.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Write the config file
+cat <<EOF
+# the directory where the snapshot is stored.
+dataDir=${ZOOKEEPER_DATA_DIR}
+clientPort=2181
+
+# User configuration
+${ZOOKEEPER_CONFIGURATION}
+# Zookeeper nodes configuration
+EOF
+
+NODE=1
+while [ $NODE -le $ZOOKEEPER_NODE_COUNT ]; do
+    echo "server.${NODE}=${BASE_HOSTNAME}-$((NODE-1)).${BASE_FQDN}:2888:3888"
+    let NODE=NODE+1
+done

--- a/docker-images/zookeeper/scripts/zookeeper_run.sh
+++ b/docker-images/zookeeper/scripts/zookeeper_run.sh
@@ -24,33 +24,9 @@ mkdir -p $ZOOKEEPER_DATA_DIR
 # Create myid file
 echo $ZOOKEEPER_ID > $ZOOKEEPER_DATA_DIR/myid
 
-# Write the config file
-cat > /tmp/zookeeper.properties <<EOF
-timeTick=2000
-initLimit=5
-syncLimit=2
-
-# the directory where the snapshot is stored.
-dataDir=${ZOOKEEPER_DATA_DIR}
-clientPort=2181
-quorumListenOnAllIPs=true
-maxClientCnxns=0
-
-# Snapshot autopurging
-autopurge.snapRetainCount=3
-autopurge.purgeInterval=1
-
-# Ensemble configuration
-EOF
-
-NODE=1
-while [ $NODE -le $ZOOKEEPER_NODE_COUNT ]; do
-    echo "server.${NODE}=${BASE_HOSTNAME}-$((NODE-1)).${BASE_FQDN}:2888:3888" >> /tmp/zookeeper.properties
-    let NODE=NODE+1
-done
-
+# Generate and print the config file
 echo "Starting Zookeeper with configuration:"
-cat /tmp/zookeeper.properties
+./zookeeper_config_generator.sh | tee /tmp/zookeeper.properties
 echo ""
 
 if [ -z "$ZOOKEEPER_LOG_LEVEL" ]; then

--- a/documentation/adoc/cluster-operator.adoc
+++ b/documentation/adoc/cluster-operator.adoc
@@ -88,6 +88,7 @@ Default is determined by the value of the
 environment variable of the Cluster Operator.
 * `zookeeper-healthcheck-delay`: the initial delay for the liveness and readiness probes for each Zookeeper node. Default is 15
 * `zookeeper-healthcheck-timeout`: the timeout on the liveness and readiness probes for each Zookeeper node. Default is 5
+* `zookeeper-config`: a JSON string with Zookeeper configuration. See section <<zookeeper_configuration_json_config>> for more details.
 * `zookeeper-storage`: a JSON string representing the storage configuration for the Zookeeper nodes. See section
 <<storage_configuration_json_config>> for more details.
 * `zookeeper-metrics-config`: a JSON string representing the JMX exporter configuration for exposing metrics from Zookeeper nodes.
@@ -118,10 +119,6 @@ data:
   kafka-image: "strimzi/kafka:latest"
   kafka-healthcheck-delay: "15"
   kafka-healthcheck-timeout: "5"
-  zookeeper-nodes: "1"
-  zookeeper-image: "strimzi/zookeeper:latest"
-  zookeeper-healthcheck-delay: "15"
-  zookeeper-healthcheck-timeout: "5"
   kafka-config: |-
     {
       "num.partitions": 1,
@@ -142,8 +139,6 @@ data:
     }
   kafka-storage: |-
     { "type": "ephemeral" }
-  zookeeper-storage: |-
-    { "type": "ephemeral" }
   kafka-metrics-config: |-
     {
       "lowercaseOutputName": true,
@@ -162,6 +157,22 @@ data:
           }
       ]
     }
+  zookeeper-nodes: "1"
+  zookeeper-image: "strimzi/zookeeper:latest"
+  zookeeper-healthcheck-delay: "15"
+  zookeeper-healthcheck-timeout: "5"
+  zookeeper-config: |-
+    {
+      "timeTick": 2000,
+      "initLimit": 5,
+      "syncLimit": 2,
+      "quorumListenOnAllIPs": true,
+      "maxClientCnxns": 0,
+      "autopurge.snapRetainCount": 3,
+      "autopurge.purgeInterval": 1
+    }
+  zookeeper-storage: |-
+    { "type": "ephemeral" }
   zookeeper-metrics-config: |-
     {
       "lowercaseOutputName": true
@@ -249,6 +260,55 @@ below.
 NOTE:: The cluster operator doesn't validate the provided configuration. When invalid configuration is provided, the
 Kafka cluster might not start or might become unstable. In such cases, the configuration in the `kafka-config` field
 should be fixed and the cluster operator will roll out the new configuration to all Kafka brokers.
+
+[[zookeeper_configuration_json_config]]
+===== Zookeeper Configuration
+
+The `zookeeper-config` field allows detailed configuration of Apache Zookeeepr. This field should contain a JSON object
+with Zookeeper configuration options as keys. The values could be in one of the following JSON types:
+
+* String
+* Number
+* Boolean
+
+The `zookeeper-config` field supports all Zookeeper configuration options with the exception of options related to:
+
+* Security (Encryption, Authentication and Authorization)
+* Listener configuration
+* Configuration of data directories
+* Zookeeper cluster composition
+
+Specifically, all configuration options with keys starting with one of the following strings will be ignored:
+
+* `server.`
+* `dataDir`
+* `dataLogDir`
+* `clientPort`
+* `authProvider`
+* `quorum.auth`
+* `requireClientAuthScheme`
+
+All other options will be passed to Zookeeper. A list of all the available options can be found on the
+http://zookeeper.apache.org/doc/r3.4.12/zookeeperAdmin.html[Zookeeper website]. An example `zookeeper-config` field is provided
+below.
+
+.Example Zookeeper configuration
+[source,json]
+----
+{
+  "timeTick": 2000,
+  "initLimit": 5,
+  "syncLimit": 2,
+  "quorumListenOnAllIPs": true,
+  "maxClientCnxns": 0,
+  "autopurge.snapRetainCount": 3,
+  "autopurge.purgeInterval": 1
+}
+----
+
+NOTE:: The cluster operator doesn't validate the provided configuration. When invalid configuration is provided, the
+Zookeeper cluster might not start or might become unstable. In such cases, the configuration in the `zookeeper-config` field
+should be fixed and the cluster operator will roll out the new configuration to all Zookeeper nodes.
 
 [[storage_configuration_json_config]]
 ===== Storage

--- a/examples/configmaps/cluster-operator/kafka-ephemeral.yaml
+++ b/examples/configmaps/cluster-operator/kafka-ephemeral.yaml
@@ -9,9 +9,6 @@ data:
   kafka-nodes: "3"
   kafka-healthcheck-delay: "15"
   kafka-healthcheck-timeout: "5"
-  zookeeper-nodes: "1"
-  zookeeper-healthcheck-delay: "15"
-  zookeeper-healthcheck-timeout: "5"
   kafka-config: |-
     {
       "num.partitions": 1,
@@ -32,8 +29,6 @@ data:
     }
   kafka-storage: |-
     { "type": "ephemeral" }
-  zookeeper-storage: |-
-    { "type": "ephemeral" }
   kafka-metrics-config: |-
     {
       "lowercaseOutputName": true,
@@ -52,6 +47,21 @@ data:
           }
       ]
     }
+  zookeeper-nodes: "1"
+  zookeeper-healthcheck-delay: "15"
+  zookeeper-healthcheck-timeout: "5"
+  zookeeper-config: |-
+    {
+      "timeTick": 2000,
+      "initLimit": 5,
+      "syncLimit": 2,
+      "quorumListenOnAllIPs": true,
+      "maxClientCnxns": 0,
+      "autopurge.snapRetainCount": 3,
+      "autopurge.purgeInterval": 1
+    }
+  zookeeper-storage: |-
+    { "type": "ephemeral" }
   zookeeper-metrics-config: |-
     {
       "lowercaseOutputName": true

--- a/examples/configmaps/cluster-operator/kafka-persistent.yaml
+++ b/examples/configmaps/cluster-operator/kafka-persistent.yaml
@@ -9,9 +9,6 @@ data:
   kafka-nodes: "3"
   kafka-healthcheck-delay: "15"
   kafka-healthcheck-timeout: "5"
-  zookeeper-nodes: "3"
-  zookeeper-healthcheck-delay: "15"
-  zookeeper-healthcheck-timeout: "5"
   kafka-config: |-
     {
       "num.partitions": 1,
@@ -32,8 +29,6 @@ data:
     }
   kafka-storage: |-
     { "type": "persistent-claim", "size": "1Gi", "delete-claim": false }
-  zookeeper-storage: |-
-    { "type": "persistent-claim", "size": "1Gi", "delete-claim": false }
   kafka-metrics-config: |-
     {
       "lowercaseOutputName": true,
@@ -52,6 +47,21 @@ data:
           }
       ]
     }
+  zookeeper-nodes: "3"
+  zookeeper-healthcheck-delay: "15"
+  zookeeper-healthcheck-timeout: "5"
+  zookeeper-config: |-
+    {
+      "timeTick": 2000,
+      "initLimit": 5,
+      "syncLimit": 2,
+      "quorumListenOnAllIPs": true,
+      "maxClientCnxns": 0,
+      "autopurge.snapRetainCount": 3,
+      "autopurge.purgeInterval": 1
+    }
+  zookeeper-storage: |-
+    { "type": "persistent-claim", "size": "1Gi", "delete-claim": false }
   zookeeper-metrics-config: |-
     {
       "lowercaseOutputName": true

--- a/examples/templates/cluster-operator/ephemeral-template.yaml
+++ b/examples/templates/cluster-operator/ephemeral-template.yaml
@@ -70,9 +70,6 @@ objects:
     kafka-nodes: "${KAFKA_NODE_COUNT}"
     kafka-healthcheck-delay: "${KAFKA_HEALTHCHECK_DELAY}"
     kafka-healthcheck-timeout: "${KAFKA_HEALTHCHECK_TIMEOUT}"
-    zookeeper-nodes: "${ZOOKEEPER_NODE_COUNT}"
-    zookeeper-healthcheck-delay: "${ZOOKEEPER_HEALTHCHECK_DELAY}"
-    zookeeper-healthcheck-timeout: "${ZOOKEEPER_HEALTHCHECK_TIMEOUT}"
     kafka-config: |-
       {
         "num.partitions": 1,
@@ -93,8 +90,6 @@ objects:
       }
     kafka-storage: |-
       { "type": "ephemeral" }
-    zookeeper-storage: |-
-      { "type": "ephemeral" }
     kafka-metrics-config: |-
       {
         "lowercaseOutputName": true,
@@ -113,6 +108,21 @@ objects:
             }
         ]
       }
+    zookeeper-nodes: "${ZOOKEEPER_NODE_COUNT}"
+    zookeeper-healthcheck-delay: "${ZOOKEEPER_HEALTHCHECK_DELAY}"
+    zookeeper-healthcheck-timeout: "${ZOOKEEPER_HEALTHCHECK_TIMEOUT}"
+    zookeeper-config: |-
+      {
+        "timeTick": 2000,
+        "initLimit": 5,
+        "syncLimit": 2,
+        "quorumListenOnAllIPs": true,
+        "maxClientCnxns": 0,
+        "autopurge.snapRetainCount": 3,
+        "autopurge.purgeInterval": 1
+      }
+    zookeeper-storage: |-
+      { "type": "ephemeral" }
     zookeeper-metrics-config: |-
       {
         "lowercaseOutputName": true

--- a/examples/templates/cluster-operator/persistent-template.yaml
+++ b/examples/templates/cluster-operator/persistent-template.yaml
@@ -76,9 +76,6 @@ objects:
     kafka-nodes: "${KAFKA_NODE_COUNT}"
     kafka-healthcheck-delay: "${KAFKA_HEALTHCHECK_DELAY}"
     kafka-healthcheck-timeout: "${KAFKA_HEALTHCHECK_TIMEOUT}"
-    zookeeper-nodes: "${ZOOKEEPER_NODE_COUNT}"
-    zookeeper-healthcheck-delay: "${ZOOKEEPER_HEALTHCHECK_DELAY}"
-    zookeeper-healthcheck-timeout: "${ZOOKEEPER_HEALTHCHECK_TIMEOUT}"
     kafka-config: |-
       {
         "num.partitions": 1,
@@ -99,8 +96,6 @@ objects:
       }
     kafka-storage: |-
       { "type": "persistent-claim", "size": "${KAFKA_VOLUME_CAPACITY}", "delete-claim": false }
-    zookeeper-storage: |-
-      { "type": "persistent-claim", "size": "${ZOOKEEPER_VOLUME_CAPACITY}", "delete-claim": false }
     kafka-metrics-config: |-
       {
         "lowercaseOutputName": true,
@@ -119,6 +114,21 @@ objects:
             }
         ]
       }
+    zookeeper-nodes: "${ZOOKEEPER_NODE_COUNT}"
+    zookeeper-healthcheck-delay: "${ZOOKEEPER_HEALTHCHECK_DELAY}"
+    zookeeper-healthcheck-timeout: "${ZOOKEEPER_HEALTHCHECK_TIMEOUT}"
+    zookeeper-config: |-
+      {
+        "timeTick": 2000,
+        "initLimit": 5,
+        "syncLimit": 2,
+        "quorumListenOnAllIPs": true,
+        "maxClientCnxns": 0,
+        "autopurge.snapRetainCount": 3,
+        "autopurge.purgeInterval": 1
+      }
+    zookeeper-storage: |-
+      { "type": "persistent-claim", "size": "${ZOOKEEPER_VOLUME_CAPACITY}", "delete-claim": false }
     zookeeper-metrics-config: |-
       {
         "lowercaseOutputName": true

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
@@ -203,7 +203,8 @@ public class KafkaClusterIT extends AbstractClusterIT {
             @CmData(key = "zookeeper-healthcheck-timeout", value = "10"),
             @CmData(key = "kafka-healthcheck-delay", value = "30"),
             @CmData(key = "kafka-healthcheck-timeout", value = "10"),
-            @CmData(key = "kafka-config", value = "{\"default.replication.factor\": 1,\"offsets.topic.replication.factor\": 1,\"transaction.state.log.replication.factor\": 1}")
+            @CmData(key = "kafka-config", value = "{\"default.replication.factor\": 1,\"offsets.topic.replication.factor\": 1,\"transaction.state.log.replication.factor\": 1}"),
+            @CmData(key = "zookeeper-config", value = "{\"timeTick\": 2000, \"initLimit\": 5, \"syncLimit\": 2}")
     })
     public void testCustomAndUpdatedValues() {
         String clusterName = "my-cluster";
@@ -225,6 +226,7 @@ public class KafkaClusterIT extends AbstractClusterIT {
         assertThat(configMapBefore, valueOfCmEquals("kafka-healthcheck-delay", "30"));
         assertThat(configMapBefore, valueOfCmEquals("kafka-healthcheck-timeout", "10"));
         assertThat(configMapBefore, valueOfCmEquals("kafka-config", "{\"default.replication.factor\": 1,\"offsets.topic.replication.factor\": 1,\"transaction.state.log.replication.factor\": 1}"));
+        assertThat(configMapBefore, valueOfCmEquals("zookeeper-config", "{\"timeTick\": 2000, \"initLimit\": 5, \"syncLimit\": 2}"));
 
         for (int i = 0; i < expectedKafkaPods; i++) {
             String kafkaPodJson = kubeClient.getResourceAsJson("pod", kafkaPodName(clusterName, i));
@@ -238,6 +240,8 @@ public class KafkaClusterIT extends AbstractClusterIT {
         LOGGER.info("Testing Zookeepers");
         for (int i = 0; i < expectedZKPods; i++) {
             String zkPodJson = kubeClient.getResourceAsJson("pod", zookeeperPodName(clusterName, i));
+            assertEquals("timeTick=2000\\nsyncLimit=2\\ninitLimit=5\\n".replaceAll("\\p{P}", ""), getValueFromJson(zkPodJson,
+                    globalVariableJsonPathBuilder("ZOOKEEPER_CONFIGURATION")));
             String initialDelaySecondsPath = "$.spec.containers[*].livenessProbe.initialDelaySeconds";
             assertEquals("30", getValueFromJson(zkPodJson, initialDelaySecondsPath));
             String zookeeperHealthcheckTimeout = "$.spec.containers[*].livenessProbe.timeoutSeconds";
@@ -250,6 +254,7 @@ public class KafkaClusterIT extends AbstractClusterIT {
         changes.put("kafka-healthcheck-delay", "31");
         changes.put("kafka-healthcheck-timeout", "11");
         changes.put("kafka-config", "{\"default.replication.factor\": 2,\"offsets.topic.replication.factor\": 2,\"transaction.state.log.replication.factor\": 2}");
+        changes.put("zookeeper-config", "{\"timeTick\": 2100, \"initLimit\": 6, \"syncLimit\": 3}");
         replaceCm(clusterName, changes);
 
         for (int i = 0; i < expectedZKPods; i++) {
@@ -268,6 +273,7 @@ public class KafkaClusterIT extends AbstractClusterIT {
         assertThat(configMapAfter, valueOfCmEquals("kafka-healthcheck-delay", "31"));
         assertThat(configMapAfter, valueOfCmEquals("kafka-healthcheck-timeout", "11"));
         assertThat(configMapAfter, valueOfCmEquals("kafka-config", "{\"default.replication.factor\": 2,\"offsets.topic.replication.factor\": 2,\"transaction.state.log.replication.factor\": 2}"));
+        assertThat(configMapAfter, valueOfCmEquals("zookeeper-config", "{\"timeTick\": 2100, \"initLimit\": 6, \"syncLimit\": 3}"));
 
         for (int i = 0; i < expectedKafkaPods; i++) {
             String kafkaPodJson = kubeClient.getResourceAsJson("pod", kafkaPodName(clusterName, i));
@@ -281,6 +287,8 @@ public class KafkaClusterIT extends AbstractClusterIT {
         LOGGER.info("Testing Zookeepers");
         for (int i = 0; i < expectedZKPods; i++) {
             String zkPodJson = kubeClient.getResourceAsJson("pod", zookeeperPodName(clusterName, i));
+            assertEquals("timeTick=2100\\nsyncLimit=3\\ninitLimit=6\\n".replaceAll("\\p{P}", ""), getValueFromJson(zkPodJson,
+                    globalVariableJsonPathBuilder("ZOOKEEPER_CONFIGURATION")));
             String initialDelaySecondsPath = "$.spec.containers[*].livenessProbe.initialDelaySeconds";
             assertEquals("31", getValueFromJson(zkPodJson, initialDelaySecondsPath));
             String zookeeperHealthcheckTimeout = "$.spec.containers[*].livenessProbe.timeoutSeconds";


### PR DESCRIPTION
### Type of change

- ~~Bugfix~~
- Enhancement / new feature
- ~~Refactoring~~

### Description

This PR is part of #27. It delivers enhanced configuration possibilities for Apache Zookeeper.

This PR adds new field `zookeeepr-config` to the Kafka cluster CM. This field should contain a JSON with configuration options. These options are passed to the Zookeeeper pods in environment variables. The generation of Zookeeper configuration is handled by a separate script which is called within the same Docker image / pod. Separate script has been used in order to be able to easily move this to the init pod later once needed.

A separate PR should deliver default values for the configuration so that we can remove the values form the ConfigMaps / templates.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging

