### PR TITLE
Adding comment on replica factor limits from Kafka

### DIFF
--- a/documentation/adoc/topic-operator.adoc
+++ b/documentation/adoc/topic-operator.adoc
@@ -90,7 +90,7 @@ The `data` of such ConfigMaps supports the following keys:
 
 * `name` The name of the topic. Optional; if this is absent the name of the ConfigMap itself is used.
 * `partitions` The number of partitions of the Kafka topic. This can be increased, but not decreased. Required. 
-* `replicas` The number of replicas of the Kafka topic. Required. _Note:_ This can not be larger than the number of your available brokers.
+* `replicas` The number of replicas of the Kafka topic. This cannot be larger than the number of nodes in the Kafka cluster. Required.
 * `config` A string in JSON format representing the https://kafka.apache.org/documentation/#topicconfigs[topic configuration]. Optional, defaulting to the empty set.
  
 

--- a/documentation/adoc/topic-operator.adoc
+++ b/documentation/adoc/topic-operator.adoc
@@ -90,7 +90,7 @@ The `data` of such ConfigMaps supports the following keys:
 
 * `name` The name of the topic. Optional; if this is absent the name of the ConfigMap itself is used.
 * `partitions` The number of partitions of the Kafka topic. This can be increased, but not decreased. Required. 
-* `replicas` The number of replicas of the Kafka topic. Required. 
+* `replicas` The number of replicas of the Kafka topic. Required. _Note:_ This can not be larger than the number of your available brokers.
 * `config` A string in JSON format representing the https://kafka.apache.org/documentation/#topicconfigs[topic configuration]. Optional, defaulting to the empty set.
  
 


### PR DESCRIPTION
### Type of change

Adding hint that the number of `replicas` can not be larger than the available brokers. Kafka does not allow this, and does not adjust it to the min. available nodes.

Feel free to ignore the PR, but might not hurt to mention this Kafka limit


### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [X] Update documentation

