### PR TITLE
Increase memory request and limit for CO

### DIFF
--- a/documentation/adoc/cluster-operator.adoc
+++ b/documentation/adoc/cluster-operator.adoc
@@ -433,7 +433,7 @@ Optional with no default.
 
 ====== Minimum Resource Requirements
 
-Testing has shown that the cluster operator functions adequately with 128Mi of memory and 200m CPU when watching two clusters.
+Testing has shown that the cluster operator functions adequately with 256Mi of memory and 200m CPU when watching two clusters.
 It is therefore recommended to use these as a minimum when configuring resource requests and not to run it with lower limits than these.
 Configuring more generous limits is recommended, especially when it's controlling multiple clusters.
 

--- a/examples/install/cluster-operator/04-deployment.yaml
+++ b/examples/install/cluster-operator/04-deployment.yaml
@@ -48,10 +48,10 @@ spec:
             periodSeconds: 30
           resources:
             limits:
-              memory: 128Mi
+              memory: 256Mi
               cpu: 1000m
             requests:
-              memory: 128Mi
+              memory: 256Mi
               cpu: 200m
   strategy:
     type: Recreate


### PR DESCRIPTION
### Type of change

- ~~Bugfix~~
- Enhancement / new feature
- ~~Refactoring~~

### Description

My testing in OpenShift Online showed that the Cluster Controller is not 100% stable with `128Mi` of memory and is being restarted with different OOM errors. Increasing memory to `256Mi` solves this. Since we want to leave a _good first impression_, this PR increases the memory used by CO by default to `256Mi`.