### PR TITLE
Internal converters should have disabled schema

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectConfiguration.java
@@ -37,6 +37,8 @@ public class KafkaConnectConfiguration extends AbstractConfiguration {
         DEFAULTS.setProperty("value.converter", "org.apache.kafka.connect.json.JsonConverter");
         DEFAULTS.setProperty("internal.key.converter", "org.apache.kafka.connect.json.JsonConverter");
         DEFAULTS.setProperty("internal.value.converter", "org.apache.kafka.connect.json.JsonConverter");
+        DEFAULTS.setProperty("internal.key.converter.schemas.enable", "false");
+        DEFAULTS.setProperty("internal.value.converter.schemas.enable", "false");
     }
 
     /**

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -29,21 +29,25 @@ public class KafkaConnectClusterTest {
     private final String configurationJson = "{\"foo\":\"bar\"}";
     private final String expectedConfiguration = "group.id=connect-cluster\n" +
             "key.converter=org.apache.kafka.connect.json.JsonConverter\n" +
+            "internal.key.converter.schemas.enable=false\n" +
             "value.converter=org.apache.kafka.connect.json.JsonConverter\n" +
             "config.storage.topic=connect-cluster-configs\n" +
             "status.storage.topic=connect-cluster-status\n" +
             "offset.storage.topic=connect-cluster-offsets\n" +
             "foo=bar\n" +
             "internal.key.converter=org.apache.kafka.connect.json.JsonConverter\n" +
+            "internal.value.converter.schemas.enable=false\n" +
             "internal.value.converter=org.apache.kafka.connect.json.JsonConverter\n";
-    private final String defaultConfiguration = "internal.value.converter=org.apache.kafka.connect.json.JsonConverter\n" +
-            "offset.storage.topic=connect-cluster-offsets\n" +
-            "group.id=connect-cluster\n" +
-            "status.storage.topic=connect-cluster-status\n" +
-            "internal.key.converter=org.apache.kafka.connect.json.JsonConverter\n" +
-            "value.converter=org.apache.kafka.connect.json.JsonConverter\n" +
+    private final String defaultConfiguration = "group.id=connect-cluster\n" +
             "key.converter=org.apache.kafka.connect.json.JsonConverter\n" +
-            "config.storage.topic=connect-cluster-configs\n";
+            "internal.key.converter.schemas.enable=false\n" +
+            "value.converter=org.apache.kafka.connect.json.JsonConverter\n" +
+            "config.storage.topic=connect-cluster-configs\n" +
+            "status.storage.topic=connect-cluster-status\n" +
+            "offset.storage.topic=connect-cluster-offsets\n" +
+            "internal.key.converter=org.apache.kafka.connect.json.JsonConverter\n" +
+            "internal.value.converter.schemas.enable=false\n" +
+            "internal.value.converter=org.apache.kafka.connect.json.JsonConverter\n";
 
     private final ConfigMap cm = ResourceUtils.createKafkaConnectClusterConfigMap(namespace, cluster, replicas, image,
             healthDelay, healthTimeout, configurationJson);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectS2IClusterTest.java
@@ -36,21 +36,25 @@ public class KafkaConnectS2IClusterTest {
     private final String configurationJson = "{\"foo\":\"bar\"}";
     private final String expectedConfiguration = "group.id=connect-cluster\n" +
             "key.converter=org.apache.kafka.connect.json.JsonConverter\n" +
+            "internal.key.converter.schemas.enable=false\n" +
             "value.converter=org.apache.kafka.connect.json.JsonConverter\n" +
             "config.storage.topic=connect-cluster-configs\n" +
             "status.storage.topic=connect-cluster-status\n" +
             "offset.storage.topic=connect-cluster-offsets\n" +
             "foo=bar\n" +
             "internal.key.converter=org.apache.kafka.connect.json.JsonConverter\n" +
+            "internal.value.converter.schemas.enable=false\n" +
             "internal.value.converter=org.apache.kafka.connect.json.JsonConverter\n";
-    private final String defaultConfiguration = "internal.value.converter=org.apache.kafka.connect.json.JsonConverter\n" +
-            "offset.storage.topic=connect-cluster-offsets\n" +
-            "group.id=connect-cluster\n" +
-            "status.storage.topic=connect-cluster-status\n" +
-            "internal.key.converter=org.apache.kafka.connect.json.JsonConverter\n" +
-            "value.converter=org.apache.kafka.connect.json.JsonConverter\n" +
+    private final String defaultConfiguration = "group.id=connect-cluster\n" +
             "key.converter=org.apache.kafka.connect.json.JsonConverter\n" +
-            "config.storage.topic=connect-cluster-configs\n";
+            "internal.key.converter.schemas.enable=false\n" +
+            "value.converter=org.apache.kafka.connect.json.JsonConverter\n" +
+            "config.storage.topic=connect-cluster-configs\n" +
+            "status.storage.topic=connect-cluster-status\n" +
+            "offset.storage.topic=connect-cluster-offsets\n" +
+            "internal.key.converter=org.apache.kafka.connect.json.JsonConverter\n" +
+            "internal.value.converter.schemas.enable=false\n" +
+            "internal.value.converter=org.apache.kafka.connect.json.JsonConverter\n";
     private final boolean insecureSourceRepo = false;
 
     private final ConfigMap cm = ResourceUtils.createKafkaConnectS2IClusterConfigMap(namespace, cluster, replicas, image,

--- a/documentation/adoc/cluster-operator.adoc
+++ b/documentation/adoc/cluster-operator.adoc
@@ -651,6 +651,8 @@ Selected options have default values:
 * `value.converter` with default value `org.apache.kafka.connect.json.JsonConverter`
 * `internal.key.converter` with default value `org.apache.kafka.connect.json.JsonConverter`
 * `internal.value.converter` with default value `org.apache.kafka.connect.json.JsonConverter`
+* `internal.key.converter.schemas.enable` with default value `false`
+* `internal.value.converter.schemas.enable` with default value `false`
 
 These options will be automatically configured in case they are not present in the `connect-config` field.
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectClusterIT.java
@@ -56,12 +56,14 @@ public class ConnectClusterIT extends AbstractClusterIT {
 
     private static final String EXPECTED_CONFIG = "group.id=connect-cluster\\n" +
             "key.converter=org.apache.kafka.connect.json.JsonConverter\\n" +
+            "internal.key.converter.schemas.enable=false\\n" +
             "value.converter=org.apache.kafka.connect.json.JsonConverter\\n" +
             "bootstrap.servers=" + KAFKA_CONNECT_BOOTSTRAP_SERVERS_ESCAPED + "\\n" +
             "config.storage.topic=connect-cluster-configs\\n" +
             "status.storage.topic=connect-cluster-status\\n" +
             "offset.storage.topic=connect-cluster-offsets\\n" +
             "internal.key.converter=org.apache.kafka.connect.json.JsonConverter\\n" +
+            "internal.value.converter.schemas.enable=false\\n" +
             "internal.value.converter=org.apache.kafka.connect.json.JsonConverter\\n";
 
     @Test


### PR DESCRIPTION
### Type of change

- Bugfix
- ~~Enhancement / new feature~~
- ~~Refactoring~~

### Description

The change of Kafka Connect and Kafka Connect S2I configuration removed the default values for `internal.key.converter.schemas.enable` and `internal.value.converter.schemas.enable` options which should be set to `false` by default. This PR adds them to the list of default options.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Check RBAC rights for Kubernetes / OpenShift roles
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging

