### PR TITLE
ST: Fix for NoSuchElementException: No value present

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
@@ -337,7 +337,7 @@ public class KafkaClusterIT extends AbstractClusterIT {
         assertExpectedJavaOpts("jvm-resource-cluster-zookeeper-0",
                 "-Xmx600m", "-Xms300m");
 
-        String podName = client.pods().list().getItems().stream().filter(p -> p.getMetadata().getName().startsWith("jvm-resource-cluster-topic-operator-")).findFirst().get().getMetadata().getName();
+        String podName = client.pods().inNamespace(NAMESPACE).list().getItems().stream().filter(p -> p.getMetadata().getName().startsWith("jvm-resource-cluster-topic-operator-")).findFirst().get().getMetadata().getName();
 
         assertResources(NAMESPACE, podName,
                 "500M", "300m", "500M", "300m");


### PR DESCRIPTION
### Type of change
- Bugfix


### Description
Sometimes I can see `NoSuchElementException: No value present` for test `KafkaClusterIT.testJvmAndResources()`. The main reason for this failure is that we can't set `namespace` for `KubernetesClient` when we get pod name.

### Checklist
- [ ] Make sure all tests pass
