### PR TITLE
Using ConfigMap instead of config map consistently

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
@@ -119,7 +119,7 @@ public class ClusterOperator extends AbstractVerticle {
                         try {
                             type = labels.type();
                         } catch (IllegalArgumentException e) {
-                            log.warn("Unknown {} label {} received in Config Map {} in namespace {}",
+                            log.warn("Unknown {} label {} received in ConfigMap {} in namespace {}",
                                     Labels.STRIMZI_TYPE_LABEL,
                                     cm.getMetadata().getLabels().get(Labels.STRIMZI_TYPE_LABEL),
                                     cm.getMetadata().getName(), namespace);
@@ -128,7 +128,7 @@ public class ClusterOperator extends AbstractVerticle {
 
                         final AbstractAssemblyOperator cluster;
                         if (type == null) {
-                            log.warn("Missing label {} in Config Map {} in namespace {}", Labels.STRIMZI_TYPE_LABEL, cm.getMetadata().getName(), namespace);
+                            log.warn("Missing label {} in ConfigMap {} in namespace {}", Labels.STRIMZI_TYPE_LABEL, cm.getMetadata().getName(), namespace);
                             return;
                         } else {
                             switch (type) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/Utils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/Utils.java
@@ -13,7 +13,7 @@ import java.util.Map;
 public class Utils {
     public static int getInteger(Map<String, String> data, String key, int defaultValue) {
         try {
-            if (data.get(key) == null) { // value is not set in config map -> will be used default value
+            if (data.get(key) == null) { // value is not set in ConfigMap -> will be used default value
                 return defaultValue;
             }
             return Integer.parseInt(data.get(key));
@@ -27,7 +27,7 @@ public class Utils {
     }
 
     public static boolean getBoolean(Map<String, String> data, String key, boolean defaultValue) {
-        if (data.get(key) == null) { // value is not set in config map
+        if (data.get(key) == null) { // value is not set in ConfigMap
             return defaultValue;
         } // java parses "truue" as false. We need to be more strict
         if (data.get(key).equals("true")) {
@@ -41,7 +41,7 @@ public class Utils {
 
     public static Storage getStorage(Map<String, String> data, String key) {
         try {
-            if (data.get(key) == null) { // value is not set in config map
+            if (data.get(key) == null) { // value is not set in ConfigMap
                 return new Storage(Storage.StorageType.PERSISTENT_CLAIM);
             }
             return Storage.fromJson(new JsonObject(data.get(key)));
@@ -51,7 +51,7 @@ public class Utils {
     }
 
     public static String getNonEmptyString(Map<String, String> data, String key, String defaultValue) {
-        if (data.get(key) == null) { // value is not set in config map -> will be used default value
+        if (data.get(key) == null) { // value is not set in ConfigMap -> will be used default value
             return defaultValue;
         }
         if (data.get(key).length() == 0) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -47,7 +47,7 @@ public class ZookeeperCluster extends AbstractModel {
     private static final int DEFAULT_HEALTHCHECK_TIMEOUT = 5;
     private static final boolean DEFAULT_ZOOKEEPER_METRICS_ENABLED = false;
 
-    // Configuration keys (Config Map)
+    // Configuration keys (ConfigMap)
     public static final String KEY_IMAGE = "zookeeper-image";
     public static final String KEY_REPLICAS = "zookeeper-nodes";
     public static final String KEY_HEALTHCHECK_DELAY = "zookeeper-healthcheck-delay";

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/ResourceUtils.java
@@ -142,7 +142,7 @@ public class ResourceUtils {
     }
 
     /**
-     * Generate empty Kafka Connect S2I config map
+     * Generate empty Kafka Connect S2I ConfigMap
      */
     public static ConfigMap createEmptyKafkaConnectS2IClusterConfigMap(String clusterCmNamespace, String clusterCmName) {
         Map<String, String> cmData = new HashMap<>();
@@ -180,7 +180,7 @@ public class ResourceUtils {
     }
 
     /**
-     * Generate empty Kafka Connect config map
+     * Generate empty Kafka Connect ConfigMap
      */
     public static ConfigMap createEmptyKafkaConnectClusterConfigMap(String clusterCmNamespace, String clusterCmName) {
         Map<String, String> cmData = new HashMap<>();

--- a/common-test/src/main/java/io/strimzi/test/StrimziRunner.java
+++ b/common-test/src/main/java/io/strimzi/test/StrimziRunner.java
@@ -333,7 +333,7 @@ public class StrimziRunner extends BlockJUnit4ClassRunner {
                 JsonNode data = node.get("data");
                 ((ObjectNode) data).put("nodes", String.valueOf(cluster.nodes()));
                 ((ObjectNode) data).put("connect-config", cluster.connectConfig());
-                // updates values for config map
+                // updates values for ConfigMap
                 for (CmData cmData : cluster.config()) {
                     ((ObjectNode) data).put(cmData.key(), cmData.value());
                 }
@@ -373,7 +373,7 @@ public class StrimziRunner extends BlockJUnit4ClassRunner {
                 JsonNode data = node.get("data");
                 ((ObjectNode) data).put("kafka-nodes", String.valueOf(cluster.kafkaNodes()));
                 ((ObjectNode) data).put("zookeeper-nodes", String.valueOf(cluster.zkNodes()));
-                // updates values for config map
+                // updates values for ConfigMap
                 for (CmData cmData : cluster.config()) {
                     ((ObjectNode) data).put(cmData.key(), cmData.value());
                 }

--- a/common-test/src/main/java/io/strimzi/test/Topic.java
+++ b/common-test/src/main/java/io/strimzi/test/Topic.java
@@ -11,8 +11,8 @@ import java.lang.annotation.Target;
 
 /**
  * Annotation for test classes or methods run via {@code @RunWith(StrimziRunner.class)}
- * which causes that runner create kafka config map with Topic before,
- * and delete kafka config map with Topic after the tests.
+ * which causes that runner create kafka ConfigMap with Topic before,
+ * and delete kafka ConfigMap with Topic after the tests.
  */
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)

--- a/documentation/book/topic-operator.adoc
+++ b/documentation/book/topic-operator.adoc
@@ -11,15 +11,15 @@ corresponding Kafka topics.
 
 Specifically:
  
-* if a config map is created, the operator will create the topic it describes
-* if a config map is deleted, the operator will delete the topic it describes
-* if a config map is changed, the operator will update the topic it describes
+* if a ConfigMap is created, the operator will create the topic it describes
+* if a ConfigMap is deleted, the operator will delete the topic it describes
+* if a ConfigMap is changed, the operator will update the topic it describes
 
 And also, in the other direction:
 
-* if a topic is created, the operator will create a config map describing it
-* if a topic is deleted, the operator will create the config map describing it
-* if a topic is changed, the operator will update the config map describing it
+* if a topic is created, the operator will create a ConfigMap describing it
+* if a topic is deleted, the operator will create the ConfigMap describing it
+* if a topic is changed, the operator will update the ConfigMap describing it
 
 This is beneficial to a {ProductPlatformName} centric style of deploying
 applications, because it allows you to declare a ConfigMap as part of your
@@ -99,7 +99,7 @@ This example shows how to create a topic called "orders" with 10 partitions and 
 ifdef::Kubernetes[]
 ==== On {KubernetesName}
 
-1. The config map has to be prepared:
+1. The ConfigMap has to be prepared:
 +
 .Topic declaration ConfigMap
 [source,yaml]
@@ -155,7 +155,7 @@ endif::Kubernetes[]
 
 ==== On {OpenShiftName}
 
-1. The config map has to be prepared:
+1. The ConfigMap has to be prepared:
 +
 .Topic declaration ConfigMap
 [source,yaml]

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractClusterIT.java
@@ -117,7 +117,7 @@ public class AbstractClusterIT {
 
             String content = mapper.writeValueAsString(node);
             kubeClient.replaceContent(content);
-            LOGGER.info("Value in Config Map replaced");
+            LOGGER.info("Value in ConfigMap replaced");
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/systemtest/src/test/java/io/strimzi/systemtest/matchers/CmMatcher.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/matchers/CmMatcher.java
@@ -12,7 +12,7 @@ import java.io.IOException;
 
 /**
  * <p>A CmMatcher is custom matcher to check values for parameters
- * in the config map of tested cluster.</p>
+ * in the ConfigMap of tested cluster.</p>
  */
 public class CmMatcher extends BaseMatcher<String> {
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/matchers/Matchers.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/matchers/Matchers.java
@@ -18,8 +18,8 @@ public class Matchers {
     }
 
     /**
-     * Matcher to check value by key in config map
-     * @param key - key of config map
+     * Matcher to check value by key in ConfigMap
+     * @param key - key of ConfigMap
      * @param value - expected value for the key
      */
     public static Matcher<String> valueOfCmEquals(String key, String value) {

--- a/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
+++ b/topic-operator/src/test/java/io/strimzi/operator/topic/TopicOperatorTest.java
@@ -81,7 +81,7 @@ public class TopicOperatorTest {
         return result;
     }
 
-    /** Test what happens when a non-topic config map gets created in kubernetes */
+    /** Test what happens when a non-topic ConfigMap gets created in kubernetes */
     @Test
     public void testOnConfigMapAdded_ignorable(TestContext context) {
         ConfigMap cm = new ConfigMapBuilder().withNewMetadata().withName("non-topic").endMetadata().build();
@@ -96,7 +96,7 @@ public class TopicOperatorTest {
         });
     }
 
-    /** Test what happens when a non-topic config map gets created in kubernetes */
+    /** Test what happens when a non-topic ConfigMap gets created in kubernetes */
     @Test
     public void testOnConfigMapAdded_invalidCm(TestContext context) {
         Map<String, String> data = map(TopicSerialization.CM_KEY_REPLICAS, "1",
@@ -219,7 +219,7 @@ public class TopicOperatorTest {
     /**
      * 1. operator is notified that a topic is created
      * 2. operator successfully queries kafka to get topic metadata
-     * 3. operator successfully creates config map
+     * 3. operator successfully creates ConfigMap
      * 4. operator successfully creates in topic store
      */
     @Test
@@ -244,7 +244,7 @@ public class TopicOperatorTest {
      * 1. operator is notified that a topic is created
      * 2. operator initially failed querying kafka to get topic metadata
      * 3. operator is subsequently successful in querying kafka to get topic metadata
-     * 4. operator successfully creates config map
+     * 4. operator successfully creates ConfigMap
      * 5. operator successfully creates in topic store
      */
     @Test
@@ -348,7 +348,7 @@ public class TopicOperatorTest {
     }
 
     // TODO error getting full topic metadata, and then reconciliation
-    // TODO error creating config map (exists), and then reconciliation
+    // TODO error creating ConfigMap (exists), and then reconciliation
 
     /**
      * Test reconciliation when a configmap has been created while the operator wasn't running


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Trivial PR for using the ConfigMap term instead of "config map" consistently in the code (i.e. log, Javadoc) and documentation.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging

