### PR TITLE
Remove IRC notifications sicne we moved from IRC to Slack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,6 @@
 sudo: required
 language: java
 notifications:
-  irc:
-    on_success: never
-    template:
-    - "%{repository}#%{build_number} (%{branch} - %{commit} : %{author}): %{message}"
-    channels:
-    - chat.freenode.net#strimzi
-    use_notice: true
   slack:
     secure: c8TGIgFUIwQm/b4LKRjyqs+Lw4QCg2nd6lnwxjwsJKCJBUmJp5Pf+h8rznXJUglxytYWoLZQ7NFuFyt85L1RQQxK+rWeRn6mddEr5gR3vXJUvYycPAIWDGfVVkSsKdPVyxgbmlrSxbThB4lMHIeUUzE4ITTb9IyXxPcvTHSBPQVpED/MlJgYLucRKHpUbvNn8Bj+bKECDzbNoZTLc7gXDPIi3ejazLC2BYzxHfk52b7O18LhLMWVra8fccxlr1sBzprrzTKj10yDXrzuyv8YOcFTs/ru8wZyz+8hPk97KBk1wyEN7mFhFVPlTQP/cOMYUMM/iflWLV2iR0gmg7Y5LrBauR0CkLW30KOLR9p4B4Ygp5CuJPxrniYfKUXlB1KyUPLlDjMc8/CZ8Aunc4SniZqDg8Ow4vix/3PebGj+2rwjDL7KizMzxNSQa0ieMEUxgiWnPl5ZY8zXUkklHH+x7sB9aX3UpElnfREbq9d9w2Ak6EwvANTds4lPScieOY1gntvTCfcEethR3mMEY9vT4R9+ZXF54RKogbBFG89k+1J2Dv0rI8ZZTpwYIkNWHpxfIeKz4jekOm0lFJE/8/zWIgyZEZSqIi6GhfiFaEUzOKXG295VfDhE5KF+uzXVHeWPA8Hgy1aggCtXc/hBam3L8Ec2gaSEU547MNuLOMQkEhY=
 jdk:


### PR DESCRIPTION
### Type of change

- ~~Bugfix~~
- Enhancement / new feature
- ~~Refactoring~~

### Description

Since we are not using the IRC channel anymore and moved to Slack, I think we should remove the notifications. We should
* Be nice to the provides of free services such as Travis or Freenode ;-)
* Stop giving the channel signs of life :-o

WDYT?
