### PR TITLE
Add section about Downloading Strimzi to the Getting started guide

### DIFF
--- a/documentation/book/getting-started.adoc
+++ b/documentation/book/getting-started.adoc
@@ -1,5 +1,12 @@
 == Getting started
 
+=== Downloading {ProductName}
+
+Strimzi releases are available for download from {ReleaseDownload}.
+The release artifacts contain documentation and example YAML files for deployment on {ProductPlatformName}.
+The example files are used through this documentation and can be used to install {ProductName}.
+The Docker images are available on {DockerRepository}.
+
 === Prerequisites
 
 An {ProductPlatformName} cluster is required to deploy {ProductLongName}. {ProductName} supports all kinds of clusters - from public and
@@ -16,7 +23,6 @@ endif::InstallationAppendix[]
 
 In order to execute the commands in this guide, your {ProductPlatformName} user needs to have the rights to create and
 manage RBAC resources (Roles and Role Bindings).
-
 
 === Cluster Operator
 

--- a/documentation/book/getting-started.adoc
+++ b/documentation/book/getting-started.adoc
@@ -4,7 +4,7 @@
 
 Strimzi releases are available for download from {ReleaseDownload}.
 The release artifacts contain documentation and example YAML files for deployment on {ProductPlatformName}.
-The example files are used through this documentation and can be used to install {ProductName}.
+The example files are used throughout this documentation and can be used to install {ProductName}.
 The Docker images are available on {DockerRepository}.
 
 === Prerequisites

--- a/documentation/common/attributes.adoc
+++ b/documentation/common/attributes.adoc
@@ -23,9 +23,12 @@
 :ProductPlatformName: {OpenShiftName} or {KubernetesName}
 :ProductPlatformLongName: {OpenShiftLongName} or {KubernetesLongName}
 
+// Source and download links
+:ReleaseDownload: https://github.com/strimzi/strimzi/releases[GitHub]
+
 // Docker image names
 :DockerTag: {ProductVersion}
-:DockerRepository: https://hub.docker.com[Docker Hub]
+:DockerRepository: https://hub.docker.com/u/strimzi[Docker Hub]
 :DockerZookeeper: strimzi/zookeeper:{DockerTag}
 :DockerKafka: strimzi/kafka:{DockerTag}
 :DockerKafkaConnect: strimzi/kafka-connect:{DockerTag}


### PR DESCRIPTION
### Type of change

- ~~Bugfix~~
- Enhancement / new feature
- ~~Refactoring~~

### Description

The documentation currently doesn't contain any details about where and how should Strimzi be downloaded. This PR adds a new section to the docu which describes where to download it. This should close #355 