### PR TITLE
Add supported versions of Kubernetes and OpenShift

### DIFF
--- a/documentation/book/getting-started.adoc
+++ b/documentation/book/getting-started.adoc
@@ -9,12 +9,10 @@ The Docker images are available on {DockerRepository}.
 
 === Prerequisites
 
-An {ProductPlatformName} cluster is required to deploy {ProductLongName}. {ProductName} supports all kinds of clusters - from public and
-private clouds down to local deployments intended for development purposes. This guide expects that an {ProductPlatformName}
-cluster is available and the
-ifdef::Kubernetes[`kubectl` or]
-`oc` command line tools are installed and configured to connect
-to the running cluster.
+{ProductLongName} runs on {ProductPlatformName} cluster.
+{ProductName} supports ifdef::Kubernetes[{KubernetesLongName} 1.9 and higher] or {OpenShiftLongName} 3.9 and higher.
+{ProductName} works on all kinds of clusters - from public and private clouds down to local deployments intended for development purposes.
+This guide expects that an {ProductPlatformName} cluster is available and the ifdef::Kubernetes[`kubectl` or] `oc` command line tools are installed and configured to connect to the running cluster.
 
 ifdef::InstallationAppendix[]
 When no existing {ProductPlatformName} cluster is available, `Minikube` or `Minishift` can be used to create a local

--- a/documentation/book/getting-started.adoc
+++ b/documentation/book/getting-started.adoc
@@ -10,7 +10,7 @@ The Docker images are available on {DockerRepository}.
 === Prerequisites
 
 {ProductLongName} runs on {ProductPlatformName}.
-{ProductName} supports ifdef::Kubernetes[{KubernetesLongName} {KubernetesVersion}] or {OpenShiftLongName} {OpenShiftVersion}.
+{ProductName} supports ifdef::Kubernetes[{KubernetesLongName} {KubernetesVersion} or] {OpenShiftLongName} {OpenShiftVersion}.
 {ProductName} works on all kinds of clusters - from public and private clouds down to local deployments intended for development.
 This guide expects that an {ProductPlatformName} cluster is available and the ifdef::Kubernetes[`kubectl` or] `oc` command line tools are installed and configured to connect to the running cluster.
 

--- a/documentation/book/getting-started.adoc
+++ b/documentation/book/getting-started.adoc
@@ -12,7 +12,7 @@ The Docker images are available on {DockerRepository}.
 {ProductLongName} runs on {ProductPlatformName}.
 {ProductName} supports ifdef::Kubernetes[{KubernetesLongName} {KubernetesVersion}] or {OpenShiftLongName} {OpenShiftVersion}.
 {ProductName} works on all kinds of clusters - from public and private clouds down to local deployments intended for development.
-This guide expects that an {ProductPlatformName} cluster is available and the ifdef::Kubernetes[`kubectl` or] `oc` command line tools are installed and configured to connect to the running cluster.
+This guide expects that a(n) {ProductPlatformName} cluster is available and the ifdef::Kubernetes[`kubectl` or] `oc` command line tools are installed and configured to connect to the running cluster.
 
 ifdef::InstallationAppendix[]
 When no existing {ProductPlatformName} cluster is available, `Minikube` or `Minishift` can be used to create a local

--- a/documentation/book/getting-started.adoc
+++ b/documentation/book/getting-started.adoc
@@ -12,7 +12,7 @@ The Docker images are available on {DockerRepository}.
 {ProductLongName} runs on {ProductPlatformName}.
 {ProductName} supports ifdef::Kubernetes[{KubernetesLongName} {KubernetesVersion}] or {OpenShiftLongName} {OpenShiftVersion}.
 {ProductName} works on all kinds of clusters - from public and private clouds down to local deployments intended for development.
-This guide expects that a(n) {ProductPlatformName} cluster is available and the ifdef::Kubernetes[`kubectl` or] `oc` command line tools are installed and configured to connect to the running cluster.
+This guide expects that an {ProductPlatformName} cluster is available and the ifdef::Kubernetes[`kubectl` or] `oc` command line tools are installed and configured to connect to the running cluster.
 
 ifdef::InstallationAppendix[]
 When no existing {ProductPlatformName} cluster is available, `Minikube` or `Minishift` can be used to create a local

--- a/documentation/book/getting-started.adoc
+++ b/documentation/book/getting-started.adoc
@@ -10,7 +10,7 @@ The Docker images are available on {DockerRepository}.
 === Prerequisites
 
 {ProductLongName} runs on {ProductPlatformName} cluster.
-{ProductName} supports ifdef::Kubernetes[{KubernetesLongName} 1.9 and higher] or {OpenShiftLongName} 3.9 and higher.
+{ProductName} supports ifdef::Kubernetes[{KubernetesLongName} {KubernetesVersion}] or {OpenShiftLongName} {OpenShiftVersion}.
 {ProductName} works on all kinds of clusters - from public and private clouds down to local deployments intended for development purposes.
 This guide expects that an {ProductPlatformName} cluster is available and the ifdef::Kubernetes[`kubectl` or] `oc` command line tools are installed and configured to connect to the running cluster.
 

--- a/documentation/book/getting-started.adoc
+++ b/documentation/book/getting-started.adoc
@@ -9,9 +9,9 @@ The Docker images are available on {DockerRepository}.
 
 === Prerequisites
 
-{ProductLongName} runs on {ProductPlatformName} cluster.
+{ProductLongName} runs on {ProductPlatformName}.
 {ProductName} supports ifdef::Kubernetes[{KubernetesLongName} {KubernetesVersion}] or {OpenShiftLongName} {OpenShiftVersion}.
-{ProductName} works on all kinds of clusters - from public and private clouds down to local deployments intended for development purposes.
+{ProductName} works on all kinds of clusters - from public and private clouds down to local deployments intended for development.
 This guide expects that an {ProductPlatformName} cluster is available and the ifdef::Kubernetes[`kubectl` or] `oc` command line tools are installed and configured to connect to the running cluster.
 
 ifdef::InstallationAppendix[]

--- a/documentation/common/attributes.adoc
+++ b/documentation/common/attributes.adoc
@@ -17,7 +17,7 @@
 :ProductName: Strimzi
 :ProductVersion: master
 :OpenShiftName: OpenShift
-:OpenShiftLongName: OpenShift
+:OpenShiftLongName: OpenShift Origin
 :KubernetesName: Kubernetes
 :KubernetesLongName: Kubernetes
 :ProductPlatformName: {OpenShiftName} or {KubernetesName}

--- a/documentation/common/attributes.adoc
+++ b/documentation/common/attributes.adoc
@@ -18,8 +18,10 @@
 :ProductVersion: master
 :OpenShiftName: OpenShift
 :OpenShiftLongName: OpenShift Origin
+:OpenShiftVersion: 3.9 and higher
 :KubernetesName: Kubernetes
 :KubernetesLongName: Kubernetes
+:KubernetesVersion: 1.9 and higher
 :ProductPlatformName: {OpenShiftName} or {KubernetesName}
 :ProductPlatformLongName: {OpenShiftLongName} or {KubernetesLongName}
 


### PR DESCRIPTION
### Type of change

- ~~Bugfix~~
- Enhancement / new feature
- ~~Refactoring~~

### Description

Currently, our docu is missing any information about supported versions of Kubernetes and OpenShift. That can lead to people trying it on too old and unsupported versions. This PR adds information about supported versions of Kubernetes and OpenShift.