### PR TITLE
Add documentation for Kafka Connect S2I - Closes #225

### DIFF
--- a/documentation/book/cluster-operator.adoc
+++ b/documentation/book/cluster-operator.adoc
@@ -574,7 +574,7 @@ The accepted JSON format is described in the <<resources_json_config>> section.
 `jvmOptions`:: A JSON string allowing the JVM running Kafka Connect to be configured.
 The accepted JSON format is described in the <<jvm_json_config>> section.
 
-The following is an example of cluster configuration ConfigMap.
+The following is an example of a Kafka Connect configuration ConfigMap.
 
 .Example Kafka Connect cluster ConfigMap
 [source,yaml,options="nowrap",subs="attributes"]
@@ -711,7 +711,7 @@ Compared to the regular deployment, the Cluster Operator will create the followi
 
 The Kafka Connect S2I deployment supports the same options as the regular Kafka Connect deployment.
 A list of supported options can be found in the <<kafka_connect_config_map_details>> section.
-The `image` option specifies the Docker image which will be used as the _source image_ - the base image for the newly build Docker image.
+The `image` option specifies the Docker image which will be used as the _source image_ - the base image for the newly built Docker image.
 The default value of the `image` option is determined by the value of the `<<STRIMZI_DEFAULT_KAFKA_CONNECT_S2I_IMAGE,STRIMZI_DEFAULT_KAFKA_CONNECT_S2I_IMAGE>>` environment variable of the Cluster Operator.
 All other options have the same meaning as for the regular deployment.
 

--- a/documentation/book/cluster-operator.adoc
+++ b/documentation/book/cluster-operator.adoc
@@ -675,7 +675,7 @@ should be fixed and the Cluster Operator will roll out the new configuration to 
 
 ===== Kafka Connect S2I deployment
 
-When using {ProductName} together with an {OpenShiftName} cluster, Kafka Connect can be deployed with support for https://docs.openshift.org/3.9/dev_guide/builds/index.html[{OpenShiftName} Builds] and https://docs.openshift.org/3.9/creating_images/s2i.html#creating-images-s2i[Source-to-Image (S2I)].
+When using {ProductName} together with an {OpenShiftName} cluster, a user can deploy Kafka Connect with support for https://docs.openshift.org/3.9/dev_guide/builds/index.html[{OpenShiftName} Builds] and https://docs.openshift.org/3.9/creating_images/s2i.html#creating-images-s2i[Source-to-Image (S2I)].
 To activate the S2I deployment, the `strimzi.io/type` label in the ConfigMap should be set to `kafka-connect-s2i`.
 The following is a full example of a ConfigMap for a Kafka Connect S2I cluster.
 

--- a/documentation/book/cluster-operator.adoc
+++ b/documentation/book/cluster-operator.adoc
@@ -574,7 +574,7 @@ The accepted JSON format is described in the <<resources_json_config>> section.
 `jvmOptions`:: A JSON string allowing the JVM running Kafka Connect to be configured.
 The accepted JSON format is described in the <<jvm_json_config>> section.
 
-The following is an example of cluster configuration ConfigMap is the following.
+The following is an example of cluster configuration ConfigMap.
 
 .Example Kafka Connect cluster ConfigMap
 [source,yaml,options="nowrap",subs="attributes"]
@@ -672,6 +672,117 @@ These options will be automatically configured in case they are not present in t
 INFO:: The Cluster Operator doesn't validate the provided configuration. When invalid configuration is provided, the
 Kafka Connect cluster might not start or might become unstable. In such cases, the configuration in the `connect-config` field
 should be fixed and the Cluster Operator will roll out the new configuration to all Kafka Connect instances.
+
+===== Kafka Connect S2I deployment
+
+When using {ProductName} together with an {OpenShiftName} cluster, Kafka Connect can be deployed with support for https://docs.openshift.org/3.9/dev_guide/builds/index.html[{OpenShiftName} Builds] and https://docs.openshift.org/3.9/creating_images/s2i.html#creating-images-s2i[Source-to-Image (S2I)].
+To activate the S2I deployment, the `strimzi.io/type` label in the ConfigMap should be set to `kafka-connect-s2i`.
+The following is a full example of a ConfigMap for a Kafka Connect S2I cluster.
+
+.Example Kafka Connect S2I cluster ConfigMap
+[source,yaml,options="nowrap",subs="attributes"]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-connect-cluster
+  labels:
+    strimzi.io/kind: cluster
+    strimzi.io/type: kafka-connect-s2i
+data:
+  nodes: "1"
+  image: "{DockerKafkaConnectS2I}"
+  healthcheck-delay: "60"
+  healthcheck-timeout: "5"
+  connect-config: |-
+    {
+      "bootstrap.servers": "my-cluster-kafka:9092"
+    }
+----
+
+The S2I deployment is very similar to the regular Kafka Connect deployment.
+Compared to regular deployment, it will create additional resources.
+The resources created by the Cluster Operator for the S2I deployment will be the following:
+
+* [connect-cluster-name]-connect DeploymentConfig which is in charge to create the Kafka Connect worker node pods
+* [connect-cluster-name]-connect Service which exposes the REST interface for managing the Kafka Connect cluster
+* [connect-cluster-name]-connect BuildConfig which is responsible for building the new Kafka Connect Docker images
+* [connect-cluster-name]-connect-source ImageStream which is used as base image for the newly build Docker images
+* [connect-cluster-name]-connect ImageStream where the newly build Docker images will be pushed
+
+The Kafka Connect S2I deployment supports the same options as the regular Kafka Connect deployment.
+List of supported options can be found in the <<kafka_connect_config_map_details>> section.
+The `image` option specifies the Docker image which will be used as the _source image_ - the base image for the newly build Docker image.
+The default value of the `image` option is determined by the value of the `<<STRIMZI_DEFAULT_KAFKA_CONNECT_S2I_IMAGE,STRIMZI_DEFAULT_KAFKA_CONNECT_S2I_IMAGE>>` environment variable of the Cluster Operator.
+All other options have the same meaning as for the regular deployment.
+
+Once the Kafka Connect S2I cluster is deployed, new plugins can be added by starting a new {OpenShiftName} build.
+New build can be started using the `oc` command line tool.
+Before starting the build, a directory with all KafkaConnect plugins which should be added has the be created.
+The plugins and all their dependencies can be in a single directory or can be split into multiple subdirectories.
+For example:
+
+[source,shell]
+----
+$ tree ./s2i-plugins/
+./s2i-plugins/
+├── debezium-connector-mysql
+│   ├── CHANGELOG.md
+│   ├── CONTRIBUTE.md
+│   ├── COPYRIGHT.txt
+│   ├── debezium-connector-mysql-0.7.1.jar
+│   ├── debezium-core-0.7.1.jar
+│   ├── LICENSE.txt
+│   ├── mysql-binlog-connector-java-0.13.0.jar
+│   ├── mysql-connector-java-5.1.40.jar
+│   ├── README.md
+│   └── wkb-1.0.2.jar
+└── debezium-connector-postgres
+    ├── CHANGELOG.md
+    ├── CONTRIBUTE.md
+    ├── COPYRIGHT.txt
+    ├── debezium-connector-postgres-0.7.1.jar
+    ├── debezium-core-0.7.1.jar
+    ├── LICENSE.txt
+    ├── postgresql-42.0.0.jar
+    ├── protobuf-java-2.6.1.jar
+    └── README.md
+----
+
+New build can be started using the following command:
+
+[source,shell]
+oc start-build my-connect-cluster-connect --from-dir ./s2i-plugins/
+
+This command will upload the whole directory into the {OpenShiftName} cluster and start a new build.
+The build will take the base Docker image from the source ImageStream (named _[connect-cluster-name]-connect-source_) and add the directory and all files it contains into this image and push the resulting image into the target ImageStream (named _[connect-cluster-name]-connect_).
+When the new image is pushed to the target ImageStream, a rolling update of the Kafka Connect S2I deployment will be started and will roll out the new version of the image with the added plugins.
+By default, the `oc start-build` command will trigger the build and complete.
+The progress of the build can be observed in the {OpenShiftName} console.
+Alternatively, the option `--follow` can be used to follow the build from the command line:
+
+[source,shell]
+----
+oc start-build my-connect-cluster-connect --from-dir ./s2i-plugins/ --follow
+Uploading directory "s2i-plugins" as binary input for the build ...
+build "my-connect-cluster-connect-3" started
+Receiving source from STDIN as archive ...
+Assembling plugins into custom plugin directory /tmp/kafka-plugins
+Moving plugins to /tmp/kafka-plugins
+
+Pushing image 172.30.1.1:5000/myproject/my-connect-cluster-connect:latest ...
+Pushed 6/10 layers, 60% complete
+Pushed 7/10 layers, 70% complete
+Pushed 8/10 layers, 80% complete
+Pushed 9/10 layers, 90% complete
+Pushed 10/10 layers, 100% complete
+Push successful
+----
+
+NOTE: The S2I build will always add the additional Kafka Connect plugins to the original source image.
+They will not be added to the Docker image from previous build.
+To add multiple plugins to the deployment, they all have to be added within the same build.
+
 
 === Provisioning Role-Based Access Control (RBAC) for the operator
 
@@ -784,7 +895,7 @@ no image is specified as the `image` in the
 The image name to use as a default when deploying Kafka Connect S2I, if
 no image is specified as the `image` in the cluster ConfigMap.
 
-[[STRIMZI_DEFAULT_TOPIC_operator_IMAGE]] `STRIMZI_DEFAULT_TOPIC_operator_IMAGE`:: Optional, default `strimzi/topic-operator:latest`.
+[[STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE]] `STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE`:: Optional, default `strimzi/topic-operator:latest`.
 The image name to use as a default when deploying the topic operator, if
 no image is specified as the `image` in the <<topic_operator_json_config,topic operator config>>
 of the Kafka cluster ConfigMap.

--- a/documentation/book/cluster-operator.adoc
+++ b/documentation/book/cluster-operator.adoc
@@ -716,8 +716,7 @@ The default value of the `image` option is determined by the value of the `<<STR
 All other options have the same meaning as for the regular deployment.
 
 Once the Kafka Connect S2I cluster is deployed, new plugins can be added by starting a new {OpenShiftName} build.
-The new build can be started using the `oc` command line tool.
-Before starting the build, a directory with all the KafkaConnect plugins which should be added has the be created.
+Before starting the build, a directory with all the KafkaConnect plugins which should be added has to be created.
 The plugins and all their dependencies can be in a single directory or can be split into multiple subdirectories.
 For example:
 

--- a/documentation/book/cluster-operator.adoc
+++ b/documentation/book/cluster-operator.adoc
@@ -701,24 +701,23 @@ data:
 ----
 
 The S2I deployment is very similar to the regular Kafka Connect deployment.
-Compared to regular deployment, it will create additional resources.
-The resources created by the Cluster Operator for the S2I deployment will be the following:
+Compared to the regular deployment, the Cluster Operator will create the following additional resources:
 
-* [connect-cluster-name]-connect DeploymentConfig which is in charge to create the Kafka Connect worker node pods
-* [connect-cluster-name]-connect Service which exposes the REST interface for managing the Kafka Connect cluster
+* [connect-cluster-name]-connect-source ImageStream which is used as the base image for the newly-built Docker images
 * [connect-cluster-name]-connect BuildConfig which is responsible for building the new Kafka Connect Docker images
-* [connect-cluster-name]-connect-source ImageStream which is used as base image for the newly build Docker images
-* [connect-cluster-name]-connect ImageStream where the newly build Docker images will be pushed
+* [connect-cluster-name]-connect ImageStream where the newly built Docker images will be pushed
+* [connect-cluster-name]-connect DeploymentConfig which is in charge of creating the Kafka Connect worker node pods
+* [connect-cluster-name]-connect Service which exposes the REST interface for managing the Kafka Connect cluster
 
 The Kafka Connect S2I deployment supports the same options as the regular Kafka Connect deployment.
-List of supported options can be found in the <<kafka_connect_config_map_details>> section.
+A list of supported options can be found in the <<kafka_connect_config_map_details>> section.
 The `image` option specifies the Docker image which will be used as the _source image_ - the base image for the newly build Docker image.
 The default value of the `image` option is determined by the value of the `<<STRIMZI_DEFAULT_KAFKA_CONNECT_S2I_IMAGE,STRIMZI_DEFAULT_KAFKA_CONNECT_S2I_IMAGE>>` environment variable of the Cluster Operator.
 All other options have the same meaning as for the regular deployment.
 
 Once the Kafka Connect S2I cluster is deployed, new plugins can be added by starting a new {OpenShiftName} build.
-New build can be started using the `oc` command line tool.
-Before starting the build, a directory with all KafkaConnect plugins which should be added has the be created.
+The new build can be started using the `oc` command line tool.
+Before starting the build, a directory with all the KafkaConnect plugins which should be added has the be created.
 The plugins and all their dependencies can be in a single directory or can be split into multiple subdirectories.
 For example:
 
@@ -749,13 +748,13 @@ $ tree ./s2i-plugins/
     └── README.md
 ----
 
-New build can be started using the following command:
+A new build can be started using the following command:
 
 [source,shell]
 oc start-build my-connect-cluster-connect --from-dir ./s2i-plugins/
 
 This command will upload the whole directory into the {OpenShiftName} cluster and start a new build.
-The build will take the base Docker image from the source ImageStream (named _[connect-cluster-name]-connect-source_) and add the directory and all files it contains into this image and push the resulting image into the target ImageStream (named _[connect-cluster-name]-connect_).
+The build will take the base Docker image from the source ImageStream (named _[connect-cluster-name]-connect-source_) and add the directory and all the files it contains into this image and push the resulting image into the target ImageStream (named _[connect-cluster-name]-connect_).
 When the new image is pushed to the target ImageStream, a rolling update of the Kafka Connect S2I deployment will be started and will roll out the new version of the image with the added plugins.
 By default, the `oc start-build` command will trigger the build and complete.
 The progress of the build can be observed in the {OpenShiftName} console.
@@ -780,7 +779,7 @@ Push successful
 ----
 
 NOTE: The S2I build will always add the additional Kafka Connect plugins to the original source image.
-They will not be added to the Docker image from previous build.
+They will not be added to the Docker image from a previous build.
 To add multiple plugins to the deployment, they all have to be added within the same build.
 
 

--- a/documentation/book/getting-started.adoc
+++ b/documentation/book/getting-started.adoc
@@ -203,7 +203,7 @@ ifdef::Kubernetes[  - On {KubernetesName}, the Kafka Connect ConfigMap has to be
 ===== Using {OpenShiftName} Build and S2I image
 
 {OpenShiftName} supports https://docs.openshift.org/3.9/dev_guide/builds/index.html[Builds] which can be used together with
-https://docs.openshift.org/3.9/creating_images/s2i.html#creating-images-s2i[Source-to-Image (S2I)] framework to create
+the https://docs.openshift.org/3.9/creating_images/s2i.html#creating-images-s2i[Source-to-Image (S2I)] framework to create
 new Docker images. {OpenShiftName} Build takes a builder image with S2I support together with source code and/or binaries
 provided by the user and uses them to build a new Docker image. The newly created Docker Image will be stored in
 {OpenShiftName}'s local Docker repository and can then be used in deployments. {ProductName} provides a Kafka Connect builder

--- a/documentation/book/getting-started.adoc
+++ b/documentation/book/getting-started.adoc
@@ -202,8 +202,8 @@ ifdef::Kubernetes[  - On {KubernetesName}, the Kafka Connect ConfigMap has to be
 
 ===== Using {OpenShiftName} Build and S2I image
 
-{OpenShiftName} supports https://docs.openshift.org/3.6/dev_guide/builds/index.html[Builds] which can be used together with
-https://docs.openshift.org/3.6/creating_images/s2i.html#creating-images-s2i[Source-to-Image (S2I)] framework to create
+{OpenShiftName} supports https://docs.openshift.org/3.9/dev_guide/builds/index.html[Builds] which can be used together with
+https://docs.openshift.org/3.9/creating_images/s2i.html#creating-images-s2i[Source-to-Image (S2I)] framework to create
 new Docker images. {OpenShiftName} Build takes a builder image with S2I support together with source code and/or binaries
 provided by the user and uses them to build a new Docker image. The newly created Docker Image will be stored in
 {OpenShiftName}'s local Docker repository and can then be used in deployments. {ProductName} provides a Kafka Connect builder


### PR DESCRIPTION
### Type of change

- ~~Bugfix~~
- Enhancement / new feature
- ~~Refactoring~~

### Description

This PR adds Kafka Connect S2I documentation and should fix #225. The two other changes are just some very minor typos I noticed while doing these changes.

Point for consideration: It is added as a subsection of the Kafka Connect section. WDYT, is that ok? Or do you think it would be better to have it at the same level as Kafka and Kafka Connect sections?

_As always, feel free to commit any grammar fixes directly to the branch._