### PR TITLE
invalid configmap should not print stack trace

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/ClusterOperator.java
@@ -156,7 +156,12 @@ public class ClusterOperator extends AbstractVerticle {
                                     if (result.succeeded()) {
                                         log.info("{}: assembly reconciled", reconciliation);
                                     } else {
-                                        log.error("{}: Failed to reconcile", reconciliation, result.cause());
+                                        Throwable cause = result.cause();
+                                        if (cause instanceof InvalidConfigMapException) {
+                                            log.warn("{}: Failed to reconcile {}", reconciliation, cause.getMessage());
+                                        } else {
+                                            log.warn("{}: Failed to reconcile {}", reconciliation, cause);
+                                        }
                                     }
                                 });
                                 break;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/Utils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/Utils.java
@@ -81,7 +81,7 @@ public final class Utils {
                 return "Unexpected character - " + token;
             }
             if (token.contains("Failed to decode: Unexpected end-of-input")) {
-                return "JSON braces";
+                return "JSON bracing";
             }
             token = token.replace("Failed to decode: Unrecognized token '", "");
             token = token.substring(0, token.indexOf("'"));
@@ -92,6 +92,8 @@ public final class Utils {
             int i;
             String blame = "";
             for (i = 0; i < entries.length; ++i) {
+                if (entries[i].length() < 1)
+                    continue;
                 if (entries[i].split(":")[1].equals(token)) {
                     blame = entries[i].split(":")[0];
                     break;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractAssemblyOperator.java
@@ -7,6 +7,7 @@ package io.strimzi.operator.cluster.operator.assembly;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.strimzi.operator.cluster.InvalidConfigMapException;
 import io.strimzi.operator.cluster.Reconciliation;
 import io.strimzi.operator.cluster.model.AssemblyType;
 import io.strimzi.operator.cluster.model.Labels;
@@ -123,7 +124,15 @@ public abstract class AbstractAssemblyOperator {
                         createOrUpdate(reconciliation, cm, createResult -> {
                             lock.release();
                             log.debug("{}: Lock {} released", reconciliation, lockName);
-                            handler.handle(createResult);
+                            if (createResult.failed()) {
+                                if (createResult.cause() instanceof InvalidConfigMapException) {
+                                    log.error(createResult.cause().getMessage());
+                                } else {
+                                    log.error(createResult.cause().toString());
+                                }
+                            } else {
+                                handler.handle(createResult);
+                            }
                         });
                     } else {
                         log.info("{}: assembly {} should be deleted", reconciliation, assemblyName);
@@ -186,7 +195,12 @@ public abstract class AbstractAssemblyOperator {
                 if (result.succeeded()) {
                     log.info("{}: Assembly reconciled", reconciliation);
                 } else {
-                    log.error("{}: Failed to reconcile", reconciliation, result.cause());
+                    Throwable cause = result.cause();
+                    if (cause instanceof InvalidConfigMapException) {
+                        log.warn("{}: Failed to reconcile {}", reconciliation, cause.getMessage());
+                    } else {
+                        log.warn("{}: Failed to reconcile {}", reconciliation, cause);
+                    }
                 }
                 latch.countDown();
             });

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -206,7 +206,7 @@ public class KafkaConnectClusterTest {
             KafkaCluster.fromConfigMap(cm);
             fail("Expected it to throw an exception");
         } catch (InvalidConfigMapException e) {
-            assertEquals("JSON braces", e.getKey());
+            assertEquals("JSON bracing", e.getKey());
         }
     }
 


### PR DESCRIPTION
### Type of change
- Enhancement / new feature

### Description
We do not need entire stack trace when InvalidConfigMapException is rised.

### Checklist
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging

