### PR TITLE
StatefulSetOperatorTests should not be ignored

### DIFF
--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/AbstractResourceOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/AbstractResourceOperatorTest.java
@@ -72,6 +72,11 @@ public abstract class AbstractResourceOperatorTest<C extends KubernetesClient, T
     /** Create the subclass of ResourceOperation to be tested */
     protected abstract AbstractResourceOperator<C, T, L, D, R> createResourceOperations(Vertx vertx, C mockClient);
 
+    /** Create the subclass of ResourceOperation to be tested with mocked readiness checks*/
+    protected AbstractResourceOperator<C, T, L, D, R> createResourceOperationsWithMockedReadiness(Vertx vertx, C mockClient)    {
+        return createResourceOperations(vertx, mockClient);
+    }
+
     @Test
     public void createWhenExistsIsAPatch(TestContext context) {
         createWhenExistsIsAPatch(context, true);
@@ -152,7 +157,7 @@ public abstract class AbstractResourceOperatorTest<C extends KubernetesClient, T
         C mockClient = mock(clientType());
         mocker(mockClient, mockCms);
 
-        AbstractResourceOperator<C, T, L, D, R> op = createResourceOperations(vertx, mockClient);
+        AbstractResourceOperator<C, T, L, D, R> op = createResourceOperationsWithMockedReadiness(vertx, mockClient);
 
         Async async = context.async();
         op.createOrUpdate(resource).setHandler(ar -> {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperatorTest.java
@@ -15,7 +15,6 @@ import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.ext.unit.TestContext;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.mockito.Mockito.mock;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/resource/StatefulSetOperatorTest.java
@@ -21,7 +21,6 @@ import org.junit.Test;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@Ignore
 public class StatefulSetOperatorTest
         extends ScalableResourceOperatorTest<KubernetesClient, StatefulSet, StatefulSetList,
                         DoneableStatefulSet, RollableScalableResource<StatefulSet, DoneableStatefulSet>> {
@@ -45,6 +44,10 @@ public class StatefulSetOperatorTest
                 .endMetadata()
                 .withNewSpec()
                     .withReplicas(3)
+                    .withNewTemplate()
+                        .withNewMetadata()
+                        .endMetadata()
+                    .endTemplate()
                 .endSpec()
                 .build();
     }
@@ -58,6 +61,16 @@ public class StatefulSetOperatorTest
 
     @Override
     protected StatefulSetOperator createResourceOperations(Vertx vertx, KubernetesClient mockClient) {
+        return new StatefulSetOperator(vertx, mockClient, 60_000L) {
+            @Override
+            protected boolean shouldIncrementGeneration(StatefulSet current, StatefulSet desired) {
+                return true;
+            }
+        };
+    }
+
+    @Override
+    protected StatefulSetOperator createResourceOperationsWithMockedReadiness(Vertx vertx, KubernetesClient mockClient) {
         return new StatefulSetOperator(vertx, mockClient, 60_000L) {
             @Override
             public Future<Void> readiness(String namespace, String name, long pollIntervalMs, long timeoutMs) {


### PR DESCRIPTION
### Type of change

- Bugfix
- ~~Enhancement / new feature~~
- ~~Refactoring~~

### Description

For some reason, the StatefulSetOperatorTests seem to be `@Ignored`. I think that is shame and they should be fixed and used.