### PR TITLE
Add support for `broker.rack` follow up

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -59,7 +59,7 @@ public abstract class AbstractModel {
     protected static final Logger log = LogManager.getLogger(AbstractModel.class.getName());
 
     private static final String VOLUME_MOUNT_HACK_IMAGE = "busybox";
-    private static final String VOLUME_MOUNT_HACK_NAME = "volume-mount-hack";
+    protected static final String VOLUME_MOUNT_HACK_NAME = "volume-mount-hack";
     private static final Long VOLUME_MOUNT_HACK_GROUPID = 1001L;
 
     public static final String METRICS_CONFIG_FILE = "config.yml";

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -36,10 +36,9 @@ public class KafkaCluster extends AbstractModel {
 
     public static final String KAFKA_SERVICE_ACCOUNT = "strimzi-kafka";
 
-    protected static final String INIT_KAFKA_IMAGE = "strimzi/init-kafka:latest";
-    protected static final String INIT_KAFKA_NAME = "init-kafka";
-    protected static final String INIT_KAFKA_VOLUME_NAME = "rack-volume";
-    protected static final String INIT_KAFKA_VOLUME_MOUNT = "/opt/kafka/rack";
+    protected static final String INIT_NAME = "init-kafka";
+    protected static final String RACK_VOLUME_NAME = "rack-volume";
+    protected static final String RACK_VOLUME_MOUNT = "/opt/kafka/rack";
     private static final String ENV_VAR_INIT_KAFKA_RACK_TOPOLOGY_KEY = "RACK_TOPOLOGY_KEY";
     private static final String ENV_VAR_INIT_KAFKA_NODE_NAME = "NODE_NAME";
 
@@ -56,10 +55,14 @@ public class KafkaCluster extends AbstractModel {
     // Kafka configuration
     private String zookeeperConnect = DEFAULT_KAFKA_ZOOKEEPER_CONNECT;
     private RackConfig rackConfig;
+    private String initImage;
 
     // Configuration defaults
     private static final String DEFAULT_IMAGE =
             System.getenv().getOrDefault("STRIMZI_DEFAULT_KAFKA_IMAGE", "strimzi/kafka:latest");
+    private static final String DEFAULT_INIT_IMAGE =
+            System.getenv().getOrDefault("STRIMZI_DEFAULT_INIT_KAFKA_IMAGE", "strimzi/init-kafka:latest");
+
 
     private static final int DEFAULT_REPLICAS = 3;
     private static final int DEFAULT_HEALTHCHECK_DELAY = 15;
@@ -80,6 +83,7 @@ public class KafkaCluster extends AbstractModel {
     public static final String KEY_JVM_OPTIONS = "kafka-jvmOptions";
     public static final String KEY_RESOURCES = "kafka-resources";
     public static final String KEY_RACK = "kafka-rack";
+    public static final String KEY_INIT_IMAGE = "init-kafka-image";
 
     // Kafka configuration keys (EnvVariables)
     public static final String ENV_VAR_KAFKA_ZOOKEEPER_CONNECT = "KAFKA_ZOOKEEPER_CONNECT";
@@ -108,6 +112,8 @@ public class KafkaCluster extends AbstractModel {
         this.mountPath = "/var/lib/kafka";
         this.metricsConfigVolumeName = "kafka-metrics-config";
         this.metricsConfigMountPath = "/opt/prometheus/config/";
+
+        this.initImage = DEFAULT_INIT_IMAGE;
     }
 
     public static String kafkaClusterName(String cluster) {
@@ -162,6 +168,7 @@ public class KafkaCluster extends AbstractModel {
         if (rackConfig != null) {
             kafka.setRackConfig(rackConfig);
         }
+        kafka.setInitImage(Utils.getNonEmptyString(data, KEY_INIT_IMAGE, DEFAULT_INIT_IMAGE));
 
         return kafka;
     }
@@ -215,6 +222,14 @@ public class KafkaCluster extends AbstractModel {
         if (affinity != null) {
             String rackTopologyKey = affinity.getPodAntiAffinity().getPreferredDuringSchedulingIgnoredDuringExecution().get(0).getPodAffinityTerm().getTopologyKey();
             kafka.setRackConfig(new RackConfig(rackTopologyKey));
+        }
+
+        List<Container> initContainers = ss.getSpec().getTemplate().getSpec().getInitContainers();
+        if (initContainers != null && !initContainers.isEmpty()) {
+
+            initContainers.stream()
+                    .filter(ic -> ic.getName().equals(INIT_NAME))
+                    .forEach(ic -> kafka.setInitImage(ic.getImage()));
         }
 
         return kafka;
@@ -302,7 +317,7 @@ public class KafkaCluster extends AbstractModel {
             volumeList.add(createConfigMapVolume(metricsConfigVolumeName, metricsConfigName));
         }
         if (rackConfig != null) {
-            volumeList.add(createEmptyDirVolume(INIT_KAFKA_VOLUME_NAME));
+            volumeList.add(createEmptyDirVolume(RACK_VOLUME_NAME));
         }
 
         return volumeList;
@@ -323,7 +338,7 @@ public class KafkaCluster extends AbstractModel {
             volumeMountList.add(createVolumeMount(metricsConfigVolumeName, metricsConfigMountPath));
         }
         if (rackConfig != null) {
-            volumeMountList.add(createVolumeMount(INIT_KAFKA_VOLUME_NAME, INIT_KAFKA_VOLUME_MOUNT));
+            volumeMountList.add(createVolumeMount(RACK_VOLUME_NAME, RACK_VOLUME_MOUNT));
         }
 
         return volumeMountList;
@@ -374,10 +389,10 @@ public class KafkaCluster extends AbstractModel {
                             buildEnvVar(ENV_VAR_INIT_KAFKA_RACK_TOPOLOGY_KEY, rackConfig.getTopologyKey()));
 
             Container initContainer = new ContainerBuilder()
-                    .withName(INIT_KAFKA_NAME)
-                    .withImage(INIT_KAFKA_IMAGE)
+                    .withName(INIT_NAME)
+                    .withImage(initImage)
                     .withEnv(varList)
-                    .withVolumeMounts(createVolumeMount(INIT_KAFKA_VOLUME_NAME, INIT_KAFKA_VOLUME_MOUNT))
+                    .withVolumeMounts(createVolumeMount(RACK_VOLUME_NAME, RACK_VOLUME_MOUNT))
                     .build();
 
             initContainers.add(initContainer);
@@ -411,5 +426,9 @@ public class KafkaCluster extends AbstractModel {
 
     protected void setRackConfig(RackConfig rackConfig) {
         this.rackConfig = rackConfig;
+    }
+
+    protected void setInitImage(String initImage) {
+        this.initImage = initImage;
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -39,7 +39,7 @@ public class KafkaCluster extends AbstractModel {
     protected static final String INIT_KAFKA_IMAGE = "strimzi/init-kafka:latest";
     protected static final String INIT_KAFKA_NAME = "init-kafka";
     protected static final String INIT_KAFKA_VOLUME_NAME = "rack-volume";
-    protected static final String INIT_KAFKA_VOLUME_MOUNT = "/rack";
+    protected static final String INIT_KAFKA_VOLUME_MOUNT = "/opt/kafka/rack";
     private static final String ENV_VAR_INIT_KAFKA_RACK_TOPOLOGY_KEY = "RACK_TOPOLOGY_KEY";
     private static final String ENV_VAR_INIT_KAFKA_NODE_NAME = "NODE_NAME";
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -16,6 +16,9 @@ import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PodAffinityTerm;
 import io.fabric8.kubernetes.api.model.PodAntiAffinity;
 import io.fabric8.kubernetes.api.model.PodAntiAffinityBuilder;
+import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServicePort;
 import io.fabric8.kubernetes.api.model.Volume;
@@ -384,6 +387,13 @@ public class KafkaCluster extends AbstractModel {
 
         if (rackConfig != null) {
 
+            ResourceRequirements resources = new ResourceRequirementsBuilder()
+                    .addToRequests("cpu", new Quantity("100m"))
+                    .addToRequests("memory", new Quantity("128Mi"))
+                    .addToLimits("cpu", new Quantity("1000m"))
+                    .addToLimits("memory", new Quantity("256Mi"))
+                    .build();
+
             List<EnvVar> varList =
                     Arrays.asList(buildEnvVarFromFieldRef(ENV_VAR_INIT_KAFKA_NODE_NAME, "spec.nodeName"),
                             buildEnvVar(ENV_VAR_INIT_KAFKA_RACK_TOPOLOGY_KEY, rackConfig.getTopologyKey()));
@@ -391,6 +401,7 @@ public class KafkaCluster extends AbstractModel {
             Container initContainer = new ContainerBuilder()
                     .withName(INIT_NAME)
                     .withImage(initImage)
+                    .withResources(resources)
                     .withEnv(varList)
                     .withVolumeMounts(createVolumeMount(RACK_VOLUME_NAME, RACK_VOLUME_MOUNT))
                     .build();

--- a/cluster-operator/src/main/resources/log4j2.properties
+++ b/cluster-operator/src/main/resources/log4j2.properties
@@ -1,4 +1,4 @@
-name = KIConfig
+name = COConfig
  
 appender.console.type = Console
 appender.console.name = STDOUT

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -152,7 +152,7 @@ public class KafkaClusterTest {
 
             boolean isInitKafka = false;
             for (Container container: initContainers) {
-                isInitKafka = container.getName().equals(KafkaCluster.INIT_KAFKA_NAME);
+                isInitKafka = container.getName().equals(KafkaCluster.INIT_NAME);
                 if (isInitKafka)
                     break;
             }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -12,6 +12,7 @@ import io.fabric8.kubernetes.api.model.WeightedPodAffinityTerm;
 import io.fabric8.kubernetes.api.model.extensions.StatefulSet;
 import io.strimzi.operator.cluster.InvalidConfigMapException;
 import io.strimzi.operator.cluster.ResourceUtils;
+import io.vertx.core.json.JsonObject;
 import org.junit.Test;
 
 import java.util.List;
@@ -91,7 +92,7 @@ public class KafkaClusterTest {
     public void testGenerateStatefulSet() {
         // We expect a single statefulSet ...
         StatefulSet ss = kc.generateStatefulSet(true);
-        checkStatefulSet(ss, cm);
+        checkStatefulSet(ss, cm, true);
     }
 
     @Test
@@ -102,10 +103,22 @@ public class KafkaClusterTest {
                         null, "{\"topologyKey\": \"rack-key\"}");
         KafkaCluster kc = KafkaCluster.fromConfigMap(cm);
         StatefulSet ss = kc.generateStatefulSet(true);
-        checkStatefulSet(ss, cm);
+        checkStatefulSet(ss, cm, true);
     }
 
-    private void checkStatefulSet(StatefulSet ss, ConfigMap cm) {
+    @Test
+    public void testGenerateStatefulSetWithInitContainers() {
+
+        ConfigMap cm =
+                ResourceUtils.createKafkaClusterConfigMap(namespace, cluster, replicas, image, healthDelay, healthTimeout,
+                        metricsCmJson, configurationJson, "{}", "{ \"type\": \"persistent-claim\", \"size\": \"1Gi\" }",
+                        null, "{\"topologyKey\": \"rack-key\"}");
+        KafkaCluster kc = KafkaCluster.fromConfigMap(cm);
+        StatefulSet ss = kc.generateStatefulSet(false);
+        checkStatefulSet(ss, cm, false);
+    }
+
+    private void checkStatefulSet(StatefulSet ss, ConfigMap cm, boolean isOpenShift) {
         assertEquals(KafkaCluster.kafkaClusterName(cluster), ss.getMetadata().getName());
         // ... in the same namespace ...
         assertEquals(namespace, ss.getMetadata().getNamespace());
@@ -124,6 +137,26 @@ public class KafkaClusterTest {
         assertEquals(new Integer(healthDelay), ss.getSpec().getTemplate().getSpec().getContainers().get(0).getReadinessProbe().getInitialDelaySeconds());
         assertEquals("foo=bar\n", AbstractModel.containerEnvVars(ss.getSpec().getTemplate().getSpec().getContainers().get(0)).get(KafkaCluster.ENV_VAR_KAFKA_CONFIGURATION));
 
+        if (cm.getData().get("kafka-storage") != null) {
+
+            JsonObject json = new JsonObject(cm.getData().get("kafka-storage"));
+            Storage storage = Storage.fromJson(json);
+
+            if ((storage.type() == Storage.StorageType.PERSISTENT_CLAIM) && !isOpenShift) {
+
+                PodSpec podSpec = ss.getSpec().getTemplate().getSpec();
+
+                // check that pod spec contains the volume hack container for Kubernetes
+                List<Container> initContainers = podSpec.getInitContainers();
+                assertNotNull(initContainers);
+                assertTrue(initContainers.size() > 0);
+
+                boolean isVolumeHack =
+                        initContainers.stream().anyMatch(container -> container.getName().equals(AbstractModel.VOLUME_MOUNT_HACK_NAME));
+                assertTrue(isVolumeHack);
+            }
+        }
+
         if (cm.getData().get("kafka-rack") != null) {
 
             RackConfig rackConfig = RackConfig.fromJson(cm.getData().get("kafka-rack"));
@@ -137,12 +170,8 @@ public class KafkaClusterTest {
             assertNotNull(terms);
             assertTrue(terms.size() > 0);
 
-            boolean isTopologyKey = false;
-            for (WeightedPodAffinityTerm term: terms) {
-                isTopologyKey = term.getPodAffinityTerm().getTopologyKey().equals(rackConfig.getTopologyKey());
-                if (isTopologyKey)
-                    break;
-            }
+            boolean isTopologyKey =
+                    terms.stream().anyMatch(term -> term.getPodAffinityTerm().getTopologyKey().equals(rackConfig.getTopologyKey()));
             assertTrue(isTopologyKey);
 
             // check that pod spec contains the init Kafka container
@@ -150,12 +179,8 @@ public class KafkaClusterTest {
             assertNotNull(initContainers);
             assertTrue(initContainers.size() > 0);
 
-            boolean isInitKafka = false;
-            for (Container container: initContainers) {
-                isInitKafka = container.getName().equals(KafkaCluster.INIT_NAME);
-                if (isInitKafka)
-                    break;
-            }
+            boolean isInitKafka =
+                    initContainers.stream().anyMatch(container -> container.getName().equals(KafkaCluster.INIT_NAME));
             assertTrue(isInitKafka);
         }
     }
@@ -170,7 +195,7 @@ public class KafkaClusterTest {
         // Don't check the metrics CM, since this isn't restored from the StatefulSet
         checkService(kc2.generateService());
         checkHeadlessService(kc2.generateHeadlessService());
-        checkStatefulSet(kc2.generateStatefulSet(true), cm);
+        checkStatefulSet(kc2.generateStatefulSet(true), cm, true);
     }
 
     // TODO test volume claim templates

--- a/docker-images/kafka/scripts/kafka_run.sh
+++ b/docker-images/kafka/scripts/kafka_run.sh
@@ -36,8 +36,8 @@ fi
 export LOG_DIR="$KAFKA_HOME"
 
 # get broker rack if it's enabled
-if [ -e /rack/rack.id ]; then
-  export KAFKA_RACK=$(cat /rack/rack.id)
+if [ -e $KAFKA_HOME/rack/rack.id ]; then
+  export KAFKA_RACK=$(cat $KAFKA_HOME/rack/rack.id)
 fi
 
 # Generate and print the config file

--- a/documentation/book/cluster-operator.adoc
+++ b/documentation/book/cluster-operator.adoc
@@ -64,6 +64,9 @@ the related ConfigMap :
 Number of Kafka broker nodes. Default is 3.
 `kafka-image`::
 The Docker image to use for the Kafka brokers. Default is determined by the value of the `<<STRIMZI_DEFAULT_KAFKA_IMAGE,STRIMZI_DEFAULT_KAFKA_IMAGE>>` environment variable of the Cluster Operator.
+`init-kafka-image`::
+The Docker image to use for the init container which does some initial configuration work (i.e. rack support).
+Default is determined by the value of the `<<STRIMZI_DEFAULT_INIT_KAFKA_IMAGE,STRIMZI_DEFAULT_INIT_KAFKA_IMAGE>>` environment variable of the Cluster Operator.
 `kafka-healthcheck-delay`::
 The initial delay for the liveness and readiness probes for each Kafka broker node. Default is 15.
 `kafka-healthcheck-timeout`::
@@ -907,6 +910,10 @@ increased when using {ProductName} on clusters where regular {ProductPlatformNam
 [[STRIMZI_DEFAULT_KAFKA_IMAGE]] `STRIMZI_DEFAULT_KAFKA_IMAGE`:: Optional, default `strimzi/kafka:latest`.
 The image name to use as a default when deploying Kafka, if
 no image is specified as the `kafka-image` in the <<kafka_config_map_details,Kafka cluster ConfigMap>>.
+
+[[STRIMZI_DEFAULT_INIT_KAFKA_IMAGE]] `STRIMZI_DEFAULT_INIT_KAFKA_IMAGE`:: Optional, default `strimzi/init-kafka:latest`.
+The image name to use as default for the init container started before the broker for doing initial configuration work (i.e. rack support), if
+no image is specified as the `init-kafka-image` in the <<kafka_config_map_details,Kafka cluster ConfigMap>>.
 
 [[STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE]] `STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE`:: Optional, default `strimzi/kafka-connect:latest`.
 The image name to use as a default when deploying Kafka Connect, if

--- a/documentation/book/cluster-operator.adoc
+++ b/documentation/book/cluster-operator.adoc
@@ -524,13 +524,14 @@ memory used by the JVM.
 [[kafka_rack]]
 ===== Kafka rack
 
-It is possible to enable Kafka rack-awareness by specifying a JSON string for the `kafka-rack` field in the cluster ConfigMap.
-Such a JSON object has one mandatory field named `topologyKey`.
+It is possible to enable Kafka rack-awareness (more information can be found on the {KafkaRacks})
+by specifying a JSON object for the `kafka-rack` field in the cluster ConfigMap.
+The `kafka-rack` JSON object has one mandatory field named `topologyKey`.
 This key needs to match one of the labels assigned to the {ProductPlatformName} cluster nodes.
-The label is used by {ProductPlatformName} when scheduling Kafka broker pods to nodes. 
-{ProductPlatformName} will try to minimize the number of pods scheduled on nodes with the same label value.
+The label is used by {ProductPlatformName} when scheduling Kafka broker pods to nodes.
 If the {ProductPlatformName} cluster is running on a cloud provider platform, that label should represent the availability zone where the node is running.
-This will have the effect of spreading the broker pods across the availability zones, and also setting the brokers `rack.id` configuration parameter.
+Usually, the nodes are labeled with `failure-domain.beta.kubernetes.io/zone` that can be easily used as `topologyKey` value.
+This will have the effect of spreading the broker pods across zones, and also setting the brokers `broker.rack` configuration parameter.
 
 .Example Kafka rack JSON configuration
 [source,json]
@@ -831,11 +832,22 @@ The Deployment of the operator then needs to specify this in the `serviceAccount
 [source,yaml,numbered,options="nowrap",highlight='12']
 .Partial example Deployment for the Cluster Operator
 ----
-include::examples/install/cluster-operator/04-deployment.yaml[lines=1..13]
+include::examples/install/cluster-operator/07-deployment.yaml[lines=1..13]
 # etc ...
 ----
 
 Note line 12, where the the `strimzi-cluster-operator` ServiceAccount is specified as the `serviceAccountName`.
+
+If the rack awareness feature is used, a Kafka init container will be started before the broker container in order to enable it.
+The application inside this container is best run using a ServiceAccount:
+
+[source,yaml,options="nowrap"]
+.Example ServiceAccount for the Kafka init container
+----
+include::examples/install/cluster-operator/04-service-account-kafka.yaml[]
+----
+
+The Cluster Operator will be in charge of configuring this ServiceAccount as `serviceAccountName` for the Kafka init container during cluster deployment.
 
 ==== Defining a Role
 
@@ -853,6 +865,16 @@ include::examples/install/cluster-operator/02-role.yaml[]
 ----
 
 When the Role cannot be created, the predefined ClusterRole named `edit` can be used instead.
+
+If the rack awareness feature is used, the started Kafka init container needs to operate using a ClusterRole that gives it access to the necessary resources.
+
+[source,yaml,options="nowrap"]
+.Example Role for the Kafka init container
+----
+include::examples/install/cluster-operator/05-role-kafka.yaml[]
+----
+
+The assigned privileges allow the Kafka init container to get Nodes information.
 
 ==== Defining a RoleBinding
 
@@ -883,6 +905,16 @@ roleRef:
   name: edit
   apiGroup: rbac.authorization.k8s.io
 ----
+
+If the rack awareness feature is used, the Kafka init container needs a ClusterRoleBinding which associates its ClusterRole with its ServiceAccount:
+
+[source,yaml,options="nowrap"]
+.Example ClusterRoleBinding for the Kafka init container
+----
+include::examples/install/cluster-operator/06-role-binding-kafka.yaml[]
+----
+
+It's important to highlight that the `namespace` field, specified in the ServiceAccount subject, needs to be the same namespace where the Kafka cluster will be deployed.
 
 === Operator configuration
 

--- a/documentation/common/attributes.adoc
+++ b/documentation/common/attributes.adoc
@@ -28,6 +28,9 @@
 // Source and download links
 :ReleaseDownload: https://github.com/strimzi/strimzi/releases[GitHub]
 
+// External links
+:KafkaRacks: https://kafka.apache.org/documentation/#basic_ops_racks[Kafka racks documentation]
+
 // Docker image names
 :DockerTag: {ProductVersion}
 :DockerRepository: https://hub.docker.com/u/strimzi[Docker Hub]

--- a/init-kafka/pom.xml
+++ b/init-kafka/pom.xml
@@ -22,6 +22,22 @@
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/init-kafka/src/main/java/io/strimzi/init/kafka/RackWriter.java
+++ b/init-kafka/src/main/java/io/strimzi/init/kafka/RackWriter.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017-2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.init.kafka;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Map;
+
+public class RackWriter {
+
+    private static final Logger log = LogManager.getLogger(RackWriter.class);
+
+    private KubernetesClient client;
+
+    public RackWriter(KubernetesClient client) {
+        this.client = client;
+    }
+
+    /**
+     * Write the rack-id
+     *
+     * @param config Rack Writer configuration instance
+     * @return if the operation was executed successfully
+     */
+    public boolean write(RackWriterConfig config) {
+
+        Map<String, String> nodeLabels = client.nodes().withName(config.getNodeName()).get().getMetadata().getLabels();
+        log.info("NodeLabels = {}", nodeLabels);
+        String rackId = nodeLabels.get(config.getRackTopologyKey());
+        log.info("Rack: {} = {}", config.getRackTopologyKey(), rackId);
+
+        if (rackId == null) {
+            log.error("Node {} doesn't have the label {} for getting the rackid",
+                    config.getNodeName(), config.getRackTopologyKey());
+            return false;
+        }
+
+        PrintWriter writer = null;
+        boolean isWritten;
+        try {
+            writer = new PrintWriter(config.getRackFolder() + "/rack.id", "UTF-8");
+            writer.write(rackId);
+            log.info("Rack written successfully");
+            isWritten = true;
+        } catch (IOException e) {
+            log.error("Error writing the rackid", e);
+            isWritten = false;
+        } finally {
+            if (writer != null)
+                writer.close();
+        }
+
+        return isWritten;
+    }
+}

--- a/init-kafka/src/main/java/io/strimzi/init/kafka/RackWriterConfig.java
+++ b/init-kafka/src/main/java/io/strimzi/init/kafka/RackWriterConfig.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017-2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.init.kafka;
+
+import java.util.Map;
+
+/**
+ * Rack Writer configuration
+ */
+public class RackWriterConfig {
+
+    public static final String RACK_FOLDER = "RACK_FOLDER";
+    public static final String RACK_TOPOLOGY_KEY = "RACK_TOPOLOGY_KEY";
+    public static final String NODE_NAME = "NODE_NAME";
+
+    public static final String DEFAULT_RACK_FOLDER = "/opt/kafka/rack";
+
+    private String nodeName;
+    private String rackTopologyKey;
+    private String rackFolder;
+
+    /**
+     * Load configuration parameters from a related map
+     *
+     * @param map map from which loading configuration parameters
+     * @return Rack Writer configuration instance
+     */
+    public static RackWriterConfig fromMap(Map<String, String> map) {
+
+        String nodeName = map.get(RackWriterConfig.NODE_NAME);
+        if (nodeName == null || nodeName.equals("")) {
+            throw new IllegalArgumentException(RackWriterConfig.NODE_NAME + " cannot be null or empty");
+        }
+
+        String rackTopologyKey = map.get(RackWriterConfig.RACK_TOPOLOGY_KEY);
+        if (rackTopologyKey == null || rackTopologyKey.equals("")) {
+            throw new IllegalArgumentException(RackWriterConfig.RACK_TOPOLOGY_KEY + " cannot be null or empty");
+        }
+
+        String rackFolder = DEFAULT_RACK_FOLDER;
+        String rackFolderEnvVar = map.get(RackWriterConfig.RACK_FOLDER);
+        if (rackFolderEnvVar != null) {
+            rackFolder = rackFolderEnvVar;
+        }
+
+        return new RackWriterConfig(nodeName, rackTopologyKey, rackFolder);
+    }
+
+    public RackWriterConfig(String nodeName, String rackTopologyKey, String rackFolder) {
+        this.nodeName = nodeName;
+        this.rackTopologyKey = rackTopologyKey;
+        this.rackFolder = rackFolder;
+    }
+
+    /**
+     * @return Kubernetes/OpenShift cluster node name from which getting the rack related label
+     */
+    public String getNodeName() {
+        return nodeName;
+    }
+
+    /**
+     * @return the Kubernetes/OpenShift cluster node label to use as topology key for rack definition
+     */
+    public String getRackTopologyKey() {
+        return rackTopologyKey;
+    }
+
+    /**
+     * @return folder where the rackid file is written
+     */
+    public String getRackFolder() {
+        return rackFolder;
+    }
+
+    @Override
+    public String toString() {
+        return "RackWriterConfig(" +
+                "nodeName=" + nodeName +
+                ",rackTopologyKey=" + rackTopologyKey +
+                ",rackFolder=" + rackFolder +
+                ")";
+    }
+}

--- a/init-kafka/src/main/resources/log4j2.properties
+++ b/init-kafka/src/main/resources/log4j2.properties
@@ -1,9 +1,11 @@
-log4j.rootLogger=INFO,stdout
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.Target=System.out
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+name = IKConfig
 
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
 
-log4j.logger.io.strimzi=INFO, stdout
-log4j.additivity.io.strimzi=false
+rootLogger.level = ${env:STRIMZI_LOG_LEVEL:-INFO}
+rootLogger.appenderRefs = stdout
+rootLogger.appenderRef.console.ref = STDOUT
+rootLogger.additivity = false

--- a/init-kafka/src/test/java/io/strimzi/init/kafka/RackWriterConfigTest.java
+++ b/init-kafka/src/test/java/io/strimzi/init/kafka/RackWriterConfigTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.init.kafka;
+
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class RackWriterConfigTest {
+
+    private static Map<String, String> envVars = new HashMap<>(2);
+
+    static {
+
+        envVars.put(RackWriterConfig.NODE_NAME, "localhost");
+        envVars.put(RackWriterConfig.RACK_TOPOLOGY_KEY, "failure-domain.beta.kubernetes.io/zone");
+    }
+
+    @Test
+    public void testEnvVars() {
+
+        RackWriterConfig config = RackWriterConfig.fromMap(envVars);
+
+        assertEquals("localhost", config.getNodeName());
+        assertEquals("failure-domain.beta.kubernetes.io/zone", config.getRackTopologyKey());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testEmptyEnvVars() {
+
+        RackWriterConfig.fromMap(Collections.emptyMap());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNoNodeName() {
+
+        Map<String, String> envVars = new HashMap<>(RackWriterConfigTest.envVars);
+        envVars.remove(RackWriterConfig.NODE_NAME);
+
+        RackWriterConfig.fromMap(envVars);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNoRackTopologyKey() {
+
+        Map<String, String> envVars = new HashMap<>(RackWriterConfigTest.envVars);
+        envVars.remove(RackWriterConfig.RACK_TOPOLOGY_KEY);
+
+        RackWriterConfig.fromMap(envVars);
+    }
+}

--- a/init-kafka/src/test/java/io/strimzi/init/kafka/RackWriterTest.java
+++ b/init-kafka/src/test/java/io/strimzi/init/kafka/RackWriterTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.init.kafka;
+
+import io.fabric8.kubernetes.api.model.Node;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mock;
+
+public class RackWriterTest {
+
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    private static Map<String, String> envVars = new HashMap<>(2);
+    private static Map<String, String> labels = new HashMap<>(4);
+
+    static {
+
+        envVars.put(RackWriterConfig.NODE_NAME, "localhost");
+        envVars.put(RackWriterConfig.RACK_TOPOLOGY_KEY, "failure-domain.beta.kubernetes.io/zone");
+
+        // metadata labels related to the Kubernetes/OpenShift cluster node
+        labels.put("beta.kubernetes.io/arch", "amd64");
+        labels.put("beta.kubernetes.io", "linux");
+        labels.put("kubernetes.io/hostname", "localhost");
+        labels.put("failure-domain.beta.kubernetes.io/zone", "eu-zone1");
+    }
+
+    @Test
+    public void testWriteRackId() throws IOException {
+
+        // create and configure (env vars) the path to the rack-id file
+        File kafkaFolder = tmpFolder.newFolder("opt", "kafka");
+        String rackFolder = kafkaFolder.getAbsolutePath() + "/rack";
+        new File(rackFolder).mkdir();
+
+        Map<String, String> envVars = new HashMap<>(RackWriterTest.envVars);
+        envVars.put(RackWriterConfig.RACK_FOLDER, rackFolder);
+
+        RackWriterConfig config = RackWriterConfig.fromMap(envVars);
+
+        KubernetesClient client = mockKubernetesClient(config.getNodeName(), labels);
+
+        RackWriter writer = new RackWriter(client);
+        assertTrue(writer.write(config));
+    }
+
+    @Test
+    public void testNoLabel() {
+
+        // the cluster node will not have the requested label
+        Map<String, String> labels = new HashMap<>(RackWriterTest.labels);
+        labels.remove("failure-domain.beta.kubernetes.io/zone");
+
+        RackWriterConfig config = RackWriterConfig.fromMap(envVars);
+
+        KubernetesClient client = mockKubernetesClient(config.getNodeName(), labels);
+
+        RackWriter writer = new RackWriter(client);
+        assertFalse(writer.write(config));
+    }
+
+    @Test
+    public void testNoFolder() throws IOException {
+
+        // specify a not existing folder for emulating IOException in the rack writer
+        Map<String, String> envVars = new HashMap<>(RackWriterTest.envVars);
+        envVars.put(RackWriterConfig.RACK_FOLDER, "/no-folder");
+
+        RackWriterConfig config = RackWriterConfig.fromMap(envVars);
+
+        KubernetesClient client = mockKubernetesClient(config.getNodeName(), labels);
+
+        RackWriter writer = new RackWriter(client);
+        assertFalse(writer.write(config));
+    }
+
+    /**
+     * Mock a Kubernetes client for getting cluster node information
+     *
+     * @param nodeName cluster node name
+     * @param labels metadata labels to be returned for the provided cluster node name
+     * @return mocked Kubernetes client
+     */
+    private KubernetesClient mockKubernetesClient(String nodeName, Map<String, String> labels) {
+
+        KubernetesClient client = mock(KubernetesClient.class);
+        NonNamespaceOperation mockNodes = mock(NonNamespaceOperation.class);
+        Resource mockResource = mock(Resource.class);
+        Node mockNode = mock(Node.class);
+        ObjectMeta mockNodeMetadata = mock(ObjectMeta.class);
+
+        when(client.nodes()).thenReturn(mockNodes);
+        when(mockNodes.withName(nodeName)).thenReturn(mockResource);
+        when(mockResource.get()).thenReturn(mockNode);
+        when(mockNode.getMetadata()).thenReturn(mockNodeMetadata);
+        when(mockNodeMetadata.getLabels()).thenReturn(labels);
+
+        return client;
+    }
+
+}


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR is about #36 for adding broker.rack support.
It follows up the PR #461 already merged with few other change requests.
It contains : 

- a refactoring of the init container application for adding more unit tests.
- init container cpu and memory resources definition
- making init container image configurable through the cluster ConfigMap
- some doc changes

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging

