### PR TITLE
Rack support system test

### DIFF
--- a/.travis/setup-kubernetes.sh
+++ b/.travis/setup-kubernetes.sh
@@ -103,4 +103,6 @@ else
     exit 1
 fi
 
-label_node
+if [ "$TRAVIS" = false ]; then
+    label_node
+fi

--- a/.travis/setup-kubernetes.sh
+++ b/.travis/setup-kubernetes.sh
@@ -33,6 +33,18 @@ function wait_for_minikube {
     return 1
 }
 
+function label_node {
+
+    if [ "$TEST_CLUSTER" = "minikube" ]; then
+        echo $(kubectl get nodes)
+        kubectl label node minikube rack-key=zone
+    elif [ "$TEST_CLUSTER" = "minishift" ]; then
+        oc label node minishift rack-key=zone
+    elif [ "$TEST_CLUSTER" = "oc" ]; then
+        oc label node localhost rack-key=zone
+    fi
+}
+
 if [ "$TEST_CLUSTER" = "minikube" ]; then
     install_kubectl
     if [ "${TEST_MINIKUBE_VERSION:-latest}" = "latest" ]; then
@@ -90,3 +102,5 @@ else
     echo "Unsupported TEST_CLUSTER '$TEST_CLUSTER'"
     exit 1
 fi
+
+label_node

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -390,7 +390,7 @@ public class KafkaCluster extends AbstractModel {
             ResourceRequirements resources = new ResourceRequirementsBuilder()
                     .addToRequests("cpu", new Quantity("100m"))
                     .addToRequests("memory", new Quantity("128Mi"))
-                    .addToLimits("cpu", new Quantity("1000m"))
+                    .addToLimits("cpu", new Quantity("1"))
                     .addToLimits("memory", new Quantity("256Mi"))
                     .build();
 

--- a/common-test/src/main/java/io/strimzi/test/StrimziRunner.java
+++ b/common-test/src/main/java/io/strimzi/test/StrimziRunner.java
@@ -5,6 +5,7 @@
 package io.strimzi.test;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
@@ -455,6 +456,15 @@ public class StrimziRunner extends BlockJUnit4ClassRunner {
                             }
                         }
                     }
+                }
+
+                if ("06-role-binding-kafka.yaml".equals(f.getName())) {
+                    String ns = annotations(element, Namespace.class).get(0).value();
+                    ArrayNode a = (ArrayNode) node.get("subjects");
+                    JsonNodeFactory factory = new JsonNodeFactory(false);
+                    ObjectNode subject = new ObjectNode(factory);
+                    subject.put("kind", "ServiceAccount").put("name", "strimzi-kafka").put("namespace", ns);
+                    a.set(0, subject);
                 }
             })).collect(Collectors.toList());
             last = new Bracket(last) {

--- a/common-test/src/main/java/io/strimzi/test/StrimziRunner.java
+++ b/common-test/src/main/java/io/strimzi/test/StrimziRunner.java
@@ -460,11 +460,11 @@ public class StrimziRunner extends BlockJUnit4ClassRunner {
 
                 if ("06-role-binding-kafka.yaml".equals(f.getName())) {
                     String ns = annotations(element, Namespace.class).get(0).value();
-                    ArrayNode a = (ArrayNode) node.get("subjects");
+                    ArrayNode subjects = (ArrayNode) node.get("subjects");
                     JsonNodeFactory factory = new JsonNodeFactory(false);
                     ObjectNode subject = new ObjectNode(factory);
                     subject.put("kind", "ServiceAccount").put("name", "strimzi-kafka").put("namespace", ns);
-                    a.set(0, subject);
+                    subjects.set(0, subject);
                 }
             })).collect(Collectors.toList());
             last = new Bracket(last) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
@@ -390,7 +390,7 @@ public class KafkaClusterIT extends AbstractClusterIT {
             zkNodes = 1,
             config = {
                     @CmData(key = "kafka-rack",
-                            value = "{\"topologyKey\": \"my-key\"}")
+                            value = "{\"topologyKey\": \"rack-key\"}")
             })
     public void testRackAware() {
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
@@ -382,4 +382,24 @@ public class KafkaClusterIT extends AbstractClusterIT {
         List<String> topics = listTopicsUsingPodCLI(CLUSTER_NAME, kafkaPodName(CLUSTER_NAME, 1));
         assertThat(topics, not(hasItems("topic-from-cli", "my-topic")));
     }
+
+    @Test
+    @JUnitGroup(name = "regression")
+    @KafkaCluster(name = CLUSTER_NAME,
+            kafkaNodes = 1,
+            zkNodes = 1,
+            config = {
+                    @CmData(key = "kafka-rack",
+                            value = "{\"topologyKey\": \"my-key\"}")
+            })
+    public void testRackAware() {
+
+        kubeClient.waitForStatefulSet(kafkaClusterName(CLUSTER_NAME), 1);
+        String kafkaPodName = kafkaPodName(CLUSTER_NAME, 0);
+        kubeClient.waitForPod(kafkaPodName);
+
+        List<Event> events = getEvents("Pod", kafkaPodName);
+        assertThat(events, hasAllOfReasons(Scheduled, Pulled, Created, Started));
+        assertThat(events, hasNoneOfReasons(Failed, Unhealthy, FailedSync, FailedValidation));
+    }
 }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds a new system test for the rack aware feature.
In order to do that it also needs to label the minikube/minishift cluster node for having a label used as rack topology key during the related test.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging

