### PR TITLE
Make it possible to configure KAFKA_JVM_PERFORMANCE_OPTS

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -654,7 +654,7 @@ public abstract class AbstractModel {
     /**
      * Adds KAFKA_HEAP_OPTS variable to the EnvVar list if any heap related options were specified.
      *
-     * @param envVars
+     * @param envVars List of Environment Variables
      */
     protected void heapOptions(List<EnvVar> envVars, double dynamicHeapFraction, long dynamicHeapMaxBytes) {
         StringBuilder kafkaHeapOpts = new StringBuilder();
@@ -685,7 +685,7 @@ public abstract class AbstractModel {
     /**
      * Adds KAFKA_JVM_PERFORMANCE_OPTS variable to the EnvVar list if any performance related options were specified.
      *
-     * @param envVars
+     * @param envVars List of Environment Variables
      */
     protected void jvmPerformanceOptions(List<EnvVar> envVars) {
         StringBuilder jvmPerformanceOpts = new StringBuilder();
@@ -708,7 +708,6 @@ public abstract class AbstractModel {
                     jvmPerformanceOpts.append(k).append("=").append(v);
                 }
             });
-
         }
 
         String trim = jvmPerformanceOpts.toString().trim();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/AbstractModel.java
@@ -65,6 +65,7 @@ public abstract class AbstractModel {
     public static final String METRICS_CONFIG_FILE = "config.yml";
     public static final String ENV_VAR_DYNAMIC_HEAP_FRACTION = "DYNAMIC_HEAP_FRACTION";
     public static final String ENV_VAR_KAFKA_HEAP_OPTS = "KAFKA_HEAP_OPTS";
+    public static final String ENV_VAR_KAFKA_JVM_PERFORMANCE_OPTS = "KAFKA_JVM_PERFORMANCE_OPTS";
     public static final String ENV_VAR_DYNAMIC_HEAP_MAX = "DYNAMIC_HEAP_MAX";
 
     protected final String cluster;
@@ -650,7 +651,12 @@ public abstract class AbstractModel {
         this.jvmOptions = jvmOptions;
     }
 
-    protected void kafkaHeapOptions(List<EnvVar> envVars, double dynamicHeapFraction, long dynamicHeapMaxBytes) {
+    /**
+     * Adds KAFKA_HEAP_OPTS variable to the EnvVar list if any heap related options were specified.
+     *
+     * @param envVars
+     */
+    protected void heapOptions(List<EnvVar> envVars, double dynamicHeapFraction, long dynamicHeapMaxBytes) {
         StringBuilder kafkaHeapOpts = new StringBuilder();
         String xms = jvmOptions != null ? jvmOptions.getXms() : null;
 
@@ -673,6 +679,41 @@ public abstract class AbstractModel {
         String trim = kafkaHeapOpts.toString().trim();
         if (!trim.isEmpty()) {
             envVars.add(buildEnvVar(ENV_VAR_KAFKA_HEAP_OPTS, trim));
+        }
+    }
+
+    /**
+     * Adds KAFKA_JVM_PERFORMANCE_OPTS variable to the EnvVar list if any performance related options were specified.
+     *
+     * @param envVars
+     */
+    protected void jvmPerformanceOptions(List<EnvVar> envVars) {
+        StringBuilder jvmPerformanceOpts = new StringBuilder();
+        Boolean server = jvmOptions != null ? jvmOptions.getServer() : null;
+
+        if (server != null && server) {
+            jvmPerformanceOpts.append("-server");
+        }
+
+        Map<String, String> xx = jvmOptions != null ? jvmOptions.getXx() : null;
+        if (xx != null) {
+            xx.forEach((k, v) -> {
+                jvmPerformanceOpts.append(' ').append("-XX:");
+
+                if ("true".equalsIgnoreCase(v))   {
+                    jvmPerformanceOpts.append("+").append(k);
+                } else if ("false".equalsIgnoreCase(v)) {
+                    jvmPerformanceOpts.append("-").append(k);
+                } else  {
+                    jvmPerformanceOpts.append(k).append("=").append(v);
+                }
+            });
+
+        }
+
+        String trim = jvmPerformanceOpts.toString().trim();
+        if (!trim.isEmpty()) {
+            envVars.add(buildEnvVar(ENV_VAR_KAFKA_JVM_PERFORMANCE_OPTS, trim));
         }
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/JvmOptions.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/JvmOptions.java
@@ -4,12 +4,16 @@
  */
 package io.strimzi.operator.cluster.model;
 
+import java.util.Map;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class JvmOptions {
 
     private String xmx;
     private String xms;
+    private Boolean server = false;
+    private Map<String, String> xx;
 
     @JsonProperty("-Xmx")
     public String getXmx() {
@@ -27,6 +31,24 @@ public class JvmOptions {
 
     public void setXms(String xms) {
         this.xms = xms;
+    }
+
+    @JsonProperty("-server")
+    public Boolean getServer() {
+        return server;
+    }
+
+    public void setServer(Boolean server) {
+        this.server = server;
+    }
+
+    @JsonProperty("-XX")
+    public Map<String, String> getXx() {
+        return xx;
+    }
+
+    public void setXx(Map<String, String> xx) {
+        this.xx = xx;
     }
 
     public static JvmOptions fromJson(String json) {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -422,7 +422,8 @@ public class KafkaCluster extends AbstractModel {
         List<EnvVar> varList = new ArrayList<>();
         varList.add(buildEnvVar(ENV_VAR_KAFKA_ZOOKEEPER_CONNECT, zookeeperConnect));
         varList.add(buildEnvVar(ENV_VAR_KAFKA_METRICS_ENABLED, String.valueOf(isMetricsEnabled)));
-        kafkaHeapOptions(varList, 0.5, 5L * 1024L * 1024L * 1024L);
+        heapOptions(varList, 0.5, 5L * 1024L * 1024L * 1024L);
+        jvmPerformanceOptions(varList);
 
         if (configuration != null) {
             varList.add(buildEnvVar(ENV_VAR_KAFKA_CONFIGURATION, configuration.getConfiguration()));

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectCluster.java
@@ -150,7 +150,8 @@ public class KafkaConnectCluster extends AbstractModel {
     protected List<EnvVar> getEnvVars() {
         List<EnvVar> varList = new ArrayList<>();
         varList.add(buildEnvVar(ENV_VAR_KAFKA_CONNECT_CONFIGURATION, configuration.getConfiguration()));
-        kafkaHeapOptions(varList, 1.0, 0L);
+        heapOptions(varList, 1.0, 0L);
+        jvmPerformanceOptions(varList);
 
         return varList;
     }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ZookeeperCluster.java
@@ -225,7 +225,8 @@ public class ZookeeperCluster extends AbstractModel {
         List<EnvVar> varList = new ArrayList<>();
         varList.add(buildEnvVar(ENV_VAR_ZOOKEEPER_NODE_COUNT, Integer.toString(replicas)));
         varList.add(buildEnvVar(ENV_VAR_ZOOKEEPER_METRICS_ENABLED, String.valueOf(isMetricsEnabled)));
-        kafkaHeapOptions(varList, 0.75, 2L * 1024L * 1024L * 1024L);
+        heapOptions(varList, 0.75, 2L * 1024L * 1024L * 1024L);
+        jvmPerformanceOptions(varList);
         varList.add(buildEnvVar(ENV_VAR_ZOOKEEPER_CONFIGURATION, configuration.getConfiguration()));
 
         return varList;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractModelTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/AbstractModelTest.java
@@ -71,18 +71,18 @@ public class AbstractModelTest {
 
         assertNull(getPerformanceOptions(opts));
 
-        opts = JvmOptions.fromJson("{\n" +
-                "  \"-server\": \"true\"\n" +
+        opts = JvmOptions.fromJson("{" +
+                "  \"-server\": \"true\"" +
                 "}");
 
         assertEquals("-server", getPerformanceOptions(opts));
 
-        opts = JvmOptions.fromJson("{\n" +
-                "    \"-XX\":\n" +
-                "            {\"key1\": \"value1\",\n" +
-                "            \"key2\": \"true\",\n" +
-                "            \"key3\": false,\n" +
-                "            \"key4\": 10}\n" +
+        opts = JvmOptions.fromJson("{" +
+                "    \"-XX\":" +
+                "            {\"key1\": \"value1\"," +
+                "            \"key2\": \"true\"," +
+                "            \"key3\": false," +
+                "            \"key4\": 10}" +
                 "}");
 
         assertEquals("-XX:key1=value1 -XX:+key2 -XX:-key3 -XX:key4=10", getPerformanceOptions(opts));

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/JvmOptionsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/JvmOptionsTest.java
@@ -16,9 +16,9 @@ import static org.junit.Assert.assertTrue;
 public class JvmOptionsTest {
     @Test
     public void testXmxXms() {
-        JvmOptions opts = JvmOptions.fromJson("{\n" +
-                "  \"-Xmx\": \"2g\",\n" +
-                "  \"-Xms\": \"1g\"\n" +
+        JvmOptions opts = JvmOptions.fromJson("{" +
+                "  \"-Xmx\": \"2g\"," +
+                "  \"-Xms\": \"1g\"" +
                 "}");
 
         assertEquals("1g", opts.getXms());
@@ -35,21 +35,21 @@ public class JvmOptionsTest {
 
     @Test
     public void testServer() {
-        JvmOptions opts = JvmOptions.fromJson("{\n" +
-                "  \"-server\": \"true\"\n" +
+        JvmOptions opts = JvmOptions.fromJson("{" +
+                "  \"-server\": \"true\"" +
                 "}");
 
         assertTrue(opts.getServer());
 
 
-        opts = JvmOptions.fromJson("{\n" +
-                "  \"-server\": true\n" +
+        opts = JvmOptions.fromJson("{" +
+                "  \"-server\": true" +
                 "}");
 
         assertTrue(opts.getServer());
 
-        opts = JvmOptions.fromJson("{\n" +
-                "  \"-server\": \"false\"\n" +
+        opts = JvmOptions.fromJson("{" +
+                "  \"-server\": \"false\"" +
                 "}");
 
         assertFalse(opts.getServer());
@@ -61,13 +61,13 @@ public class JvmOptionsTest {
 
     @Test
     public void testXx() {
-        JvmOptions opts = JvmOptions.fromJson("{\n" +
-                "    \"-XX\":\n" +
-                "            {\"key1\": \"value1\",\n" +
-                "            \"key2\": \"value2\",\n" +
-                "            \"key3\": \"true\",\n" +
-                "            \"key4\": true,\n" +
-                "            \"key5\": 10}\n" +
+        JvmOptions opts = JvmOptions.fromJson("{" +
+                "    \"-XX\":" +
+                "            {\"key1\": \"value1\"," +
+                "            \"key2\": \"value2\"," +
+                "            \"key3\": \"true\"," +
+                "            \"key4\": true," +
+                "            \"key5\": 10}" +
                 "}");
 
         assertEquals(ResourceUtils.map("key1", "value1", "key2", "value2", "key3", "true", "key4", "true", "key5", "10"), opts.getXx());

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/JvmOptionsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/JvmOptionsTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2018, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model;
+
+import io.strimzi.operator.cluster.ResourceUtils;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class JvmOptionsTest {
+    @Test
+    public void testXmxXms() {
+        JvmOptions opts = JvmOptions.fromJson("{\n" +
+                "  \"-Xmx\": \"2g\",\n" +
+                "  \"-Xms\": \"1g\"\n" +
+                "}");
+
+        assertEquals("1g", opts.getXms());
+        assertEquals("2g", opts.getXmx());
+    }
+
+    @Test
+    public void testEmptyXmxXms() {
+        JvmOptions opts = JvmOptions.fromJson("{}");
+
+        assertNull(opts.getXms());
+        assertNull(opts.getXmx());
+    }
+
+    @Test
+    public void testServer() {
+        JvmOptions opts = JvmOptions.fromJson("{\n" +
+                "  \"-server\": \"true\"\n" +
+                "}");
+
+        assertTrue(opts.getServer());
+
+
+        opts = JvmOptions.fromJson("{\n" +
+                "  \"-server\": true\n" +
+                "}");
+
+        assertTrue(opts.getServer());
+
+        opts = JvmOptions.fromJson("{\n" +
+                "  \"-server\": \"false\"\n" +
+                "}");
+
+        assertFalse(opts.getServer());
+
+        opts = JvmOptions.fromJson("{}");
+
+        assertFalse(opts.getServer());
+    }
+
+    @Test
+    public void testXx() {
+        JvmOptions opts = JvmOptions.fromJson("{\n" +
+                "    \"-XX\":\n" +
+                "            {\"key1\": \"value1\",\n" +
+                "            \"key2\": \"value2\",\n" +
+                "            \"key3\": \"true\",\n" +
+                "            \"key4\": true,\n" +
+                "            \"key5\": 10}\n" +
+                "}");
+
+        assertEquals(ResourceUtils.map("key1", "value1", "key2", "value2", "key3", "true", "key4", "true", "key5", "10"), opts.getXx());
+    }
+}
+

--- a/documentation/book/cluster-operator.adoc
+++ b/documentation/book/cluster-operator.adoc
@@ -508,7 +508,7 @@ The `-server` and `-XX` options are used to configure the `KAFKA_JVM_PERFORMANCE
 }
 ----
 
-The example configuration above will result in following JVM options:
+The example configuration above will result in the following JVM options:
 
 [source]
 ----

--- a/documentation/book/cluster-operator.adoc
+++ b/documentation/book/cluster-operator.adoc
@@ -515,7 +515,7 @@ The example configuration above will result in following JVM options:
 -server -XX:+UseG1GC -XX:MaxGCPauseMillis=20 -XX:InitiatingHeapOccupancyPercent=35 -XX:+ExplicitGCInvokesConcurrent -XX:-UseParNewGC
 ----
 
-When none of the two options (`-server` and `-XX`) is specified, the default Apache Kafka configuration of `KAFKA_JVM_PERFORMANCE_OPTS` will be used.
+When neither of the two options (`-server` and `-XX`) is specified, the default Apache Kafka configuration of `KAFKA_JVM_PERFORMANCE_OPTS` will be used.
 
 [[setting_xmx]]
 ====== Setting `-Xmx`

--- a/documentation/book/cluster-operator.adoc
+++ b/documentation/book/cluster-operator.adoc
@@ -510,6 +510,7 @@ The `-server` and `-XX` options are used to configure the `KAFKA_JVM_PERFORMANCE
 The example configuration above will result in following JVM options:
 
 [source]
+----
 -server -XX:+UseG1GC -XX:MaxGCPauseMillis=20 -XX:InitiatingHeapOccupancyPercent=35 -XX:+ExplicitGCInvokesConcurrent -XX:-UseParNewGC
 ----
 

--- a/documentation/book/cluster-operator.adoc
+++ b/documentation/book/cluster-operator.adoc
@@ -495,6 +495,7 @@ The `-server` and `-XX` options are used to configure the `KAFKA_JVM_PERFORMANCE
 
 .Example advanced runtime JVM configuration
 [source,json]
+----
 {
   "-server": true,
   "-XX": {

--- a/documentation/book/cluster-operator.adoc
+++ b/documentation/book/cluster-operator.adoc
@@ -485,6 +485,36 @@ suffix. This is in contrast to the units used for <<resources_json_config,memory
 In the above example, the JVM will use 2 GiB (=2,147,483,648 bytes) for its heap.
 Its total memory usage will be approximately 8GiB.
 
+`-server`::
+Selects the server JVM. This option can be set to true or false. Optional.
+
+`-XX`::
+A JSON Object for configuring advanced runtime options of a JVM. Optional
+
+The `-server` and `-XX` options are used to configure the `KAFKA_JVM_PERFORMANCE_OPTS` option of Apache Kafka.
+
+.Example advanced runtime JVM configuration
+[source,json]
+{
+  "-server": true,
+  "-XX": {
+             "UseG1GC": true,
+             "MaxGCPauseMillis": 20,
+             "InitiatingHeapOccupancyPercent": 35,
+             "ExplicitGCInvokesConcurrent": true,
+             "UseParNewGC": false
+         }
+}
+----
+
+The example configuration above will result in following JVM options:
+
+[source]
+-server -XX:+UseG1GC -XX:MaxGCPauseMillis=20 -XX:InitiatingHeapOccupancyPercent=35 -XX:+ExplicitGCInvokesConcurrent -XX:-UseParNewGC
+----
+
+When none of the two options (`-server` and `-XX`) is specified, the default Apache Kafka configuration of `KAFKA_JVM_PERFORMANCE_OPTS` will be used.
+
 [[setting_xmx]]
 ====== Setting `-Xmx`
 

--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractClusterIT.java
@@ -217,7 +217,7 @@ public class AbstractClusterIT {
         assertEquals(cpuRequest, requests.get("cpu").getAmount());
     }
 
-    protected void assertExpectedJavaOpts(String podName, String expectedXmx, String expectedXms) {
+    protected void assertExpectedJavaOpts(String podName, String expectedXmx, String expectedXms, String expectedServer, String expectedXx) {
         List<List<String>> cmdLines = commandLines(podName, "java");
         assertEquals("Expected exactly 1 java process to be running",
                 1, cmdLines.size());
@@ -231,6 +231,8 @@ public class AbstractClusterIT {
         }
         assertCmdOption(cmd, expectedXmx);
         assertCmdOption(cmd, expectedXms);
+        assertCmdOption(cmd, expectedServer);
+        assertCmdOption(cmd, expectedXx);
     }
 
     private void assertCmdOption(List<String> cmd, String expectedXmx) {

--- a/systemtest/src/test/java/io/strimzi/systemtest/ConnectClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/ConnectClusterIT.java
@@ -47,7 +47,15 @@ import static org.valid4j.matchers.jsonpath.JsonPathMatchers.hasJsonPath;
 @RunWith(StrimziRunner.class)
 @Namespace(ConnectClusterIT.NAMESPACE)
 @ClusterOperator
-@KafkaCluster(name = ConnectClusterIT.KAFKA_CLUSTER_NAME)
+@KafkaCluster(
+        name = ConnectClusterIT.KAFKA_CLUSTER_NAME,
+        config = {
+                @CmData(key = "kafka-storage",
+                        value = "{ \"type\": \"ephemeral\" }"),
+                @CmData(key = "zookeeper-storage",
+                        value = "{ \"type\": \"ephemeral\" }")
+        }
+)
 public class ConnectClusterIT extends AbstractClusterIT {
 
     private static final Logger LOGGER = LogManager.getLogger(ConnectClusterIT.class);
@@ -108,14 +116,14 @@ public class ConnectClusterIT extends AbstractClusterIT {
         config = {
                 @CmData(key = "resources", value = "{ \"limits\": {\"memory\": \"400M\", \"cpu\": 2}, " +
                         "\"requests\": {\"memory\": \"300M\", \"cpu\": 1} }"),
-                @CmData(key = "jvmOptions", value = "{\"-Xmx\": \"200m\", \"-Xms\": \"200m\"}")
+                @CmData(key = "jvmOptions", value = "{\"-Xmx\": \"200m\", \"-Xms\": \"200m\", \"-server\": true, \"-XX\": { \"UseG1GC\": true }}")
         })
     public void testJvmAndResources() {
         String podName = kubeClient.list("Pod").stream().filter(n -> n.startsWith("jvm-resource-connect-")).findFirst().get();
         assertResources(NAMESPACE, podName,
                 "400M", "2", "300M", "1");
         assertExpectedJavaOpts(podName,
-                "-Xmx200m", "-Xms200m");
+                "-Xmx200m", "-Xms200m", "-server", "-XX:+UseG1GC");
     }
 
     @Test

--- a/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/KafkaClusterIT.java
@@ -314,33 +314,36 @@ public class KafkaClusterIT extends AbstractClusterIT {
         kafkaNodes = 1,
         zkNodes = 1,
         config = {
+            @CmData(key = "kafka-storage",
+                    value = "{ \"type\": \"ephemeral\" }"),
             @CmData(key = "kafka-resources",
                     value = "{ \"limits\": {\"memory\": \"2Gi\", \"cpu\": \"400m\"}, " +
                             "\"requests\": {\"memory\": \"2Gi\", \"cpu\": \"400m\"}}"),
             @CmData(key = "kafka-jvmOptions",
-                    value = "{\"-Xmx\": \"1g\", \"-Xms\": \"1G\"}"),
+                    value = "{\"-Xmx\": \"1g\", \"-Xms\": \"1G\", \"-server\": true, \"-XX\": { \"UseG1GC\": true }}"),
+            @CmData(key = "zookeeper-storage",
+                    value = "{ \"type\": \"ephemeral\" }"),
             @CmData(key = "zookeeper-resources",
                     value = "{ \"limits\": {\"memory\": \"1G\", \"cpu\": \"300m\"}, " +
                             "\"requests\": {\"memory\": \"1G\", \"cpu\": \"300m\"} }"),
             @CmData(key = "zookeeper-jvmOptions",
-                    value = "{\"-Xmx\": \"600m\", \"-Xms\": \"300m\"}"),
+                    value = "{\"-Xmx\": \"600m\", \"-Xms\": \"300m\", \"-server\": true, \"-XX\": { \"UseG1GC\": true }}"),
             @CmData(key = "topic-operator-config",
                     value = "{\"resources\": { \"limits\": {\"memory\": \"500M\", \"cpu\": \"300m\"}, " +
                             "\"requests\": {\"memory\": \"500M\", \"cpu\": \"300m\"} } }")
     })
-
     @Test
     @JUnitGroup(name = "acceptance")
     public void testJvmAndResources() {
         assertResources(NAMESPACE, "jvm-resource-cluster-kafka-0",
                 "2Gi", "400m", "2Gi", "400m");
         assertExpectedJavaOpts("jvm-resource-cluster-kafka-0",
-                "-Xmx1g", "-Xms1G");
+                "-Xmx1g", "-Xms1G", "-server", "-XX:+UseG1GC");
 
         assertResources(NAMESPACE, "jvm-resource-cluster-zookeeper-0",
                 "1G", "300m", "1G", "300m");
         assertExpectedJavaOpts("jvm-resource-cluster-zookeeper-0",
-                "-Xmx600m", "-Xms300m");
+                "-Xmx600m", "-Xms300m", "-server", "-XX:+UseG1GC");
 
         String podName = client.pods().inNamespace(NAMESPACE).list().getItems().stream().filter(p -> p.getMetadata().getName().startsWith("jvm-resource-cluster-topic-operator-")).findFirst().get().getMetadata().getName();
 


### PR DESCRIPTION
### Type of change

- ~~Bugfix~~
- Enhancement / new feature
- ~~Refactoring~~

### Description

This PR makes it possible to configure some additional options of the JVM - mainly related to performance. These options are passed to KAfka, Zoo and Connect through `KAFKA_JVM_PERFORMANCE_OPTS` environment variable.

Additionally it renames the method `kafkaHeapOptions` to `heapOptions` to avoid thew confusion that this method is used only for Kafka and not for other assemblies.

This relates to the discussion in #441.

As a part of this PR I also enhanced the system tests. I did also enabled usage of ephemeral storage for all Kafka Connect tests and for the JVM options tests in Kafka. That should give us some speedup with not sacrificing any quality of the system tests.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging

