### PR TITLE
Remove the LOCAL storage type which is actually not used for anything

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/Storage.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/Storage.java
@@ -155,8 +155,7 @@ public class Storage {
     public enum StorageType {
 
         EPHEMERAL("ephemeral"),
-        PERSISTENT_CLAIM("persistent-claim"),
-        LOCAL("local");
+        PERSISTENT_CLAIM("persistent-claim");
 
         private final String type;
 
@@ -175,8 +174,6 @@ public class Storage {
                 return EPHEMERAL;
             } else if (type.equals(PERSISTENT_CLAIM.type)) {
                 return PERSISTENT_CLAIM;
-            } else if (type.equals(LOCAL.type)) {
-                return LOCAL;
             } else {
                 throw new IllegalArgumentException("Unknown type: " + type + ". Allowed types are: " + Arrays.toString(values()));
             }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -138,6 +138,8 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator {
         result.add(kafkaSetOperations.reconcile(namespace, KafkaCluster.kafkaClusterName(name), null));
 
         if (deleteClaims) {
+            log.debug("{}: delete kafka {} PVCs", reconciliation, name);
+
             for (int i = 0; i < kafka.getReplicas(); i++) {
                 result.add(pvcOperations.reconcile(namespace,
                         kafka.getPersistentVolumeClaimName(i), null));
@@ -189,6 +191,8 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator {
         result.add(zkSetOperations.reconcile(namespace, ZookeeperCluster.zookeeperClusterName(name), null));
 
         if (deleteClaims) {
+            log.debug("{}: delete zookeeper {} PVCs", reconciliation, name);
+
             for (int i = 0; i < zk.getReplicas(); i++) {
                 result.add(pvcOperations.reconcile(namespace, zk.getPersistentVolumeClaimName(i), null));
             }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorMockTest.java
@@ -115,11 +115,7 @@ public class KafkaAssemblyOperatorMockTest {
             new JsonObject("{\"type\": \"persistent-claim\", " +
                     "\"size\": \"123\", " +
                     "\"class\": \"foo\"," +
-                    "\"delete-claim\": false}"),
-
-            new JsonObject("{\"type\": \"local\", " +
-                    "\"size\": \"123\", " +
-                    "\"class\": \"foo\"}")
+                    "\"delete-claim\": false}")
         };
         String[] resources = {
             "{ \"limits\" : { \"cpu\": 5, \"memory\": 5000 }, \"requests\": { \"cpu\": 5, \"memory\": 5000 } }"
@@ -556,11 +552,6 @@ public class KafkaAssemblyOperatorMockTest {
 
     @Test
     public void testUpdateKafkaWithChangedStorageType(TestContext context) {
-        if (!Storage.StorageType.LOCAL.equals(storageType(kafkaStorage))) {
-            LOGGER.info("Skipping change storage type test because using storage type {}", kafkaStorage);
-            return;
-        }
-
         KafkaAssemblyOperator kco = createCluster(context);
         List<PersistentVolumeClaim> originalPVCs = mockClient.apps().statefulSets().inNamespace(NAMESPACE).withName(KafkaCluster.kafkaClusterName(CLUSTER_NAME)).get().getSpec().getVolumeClaimTemplates();
         List<Volume> originalVolumes = mockClient.apps().statefulSets().inNamespace(NAMESPACE).withName(KafkaCluster.kafkaClusterName(CLUSTER_NAME)).get().getSpec().getTemplate().getSpec().getVolumes();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperatorTest.java
@@ -114,10 +114,7 @@ public class KafkaAssemblyOperatorTest {
             "{\"type\": \"persistent-claim\", " +
                     "\"size\": \"123\", " +
                     "\"class\": \"foo\"," +
-                    "\"delete-claim\": true}",
-            "{\"type\": \"local\", " +
-                    "\"size\": \"123\", " +
-                    "\"class\": \"foo\"}"
+                    "\"delete-claim\": true}"
         };
         String[] kafkaConfigs = {
             null,


### PR DESCRIPTION
### Type of change

- Bugfix
- ~~Enhancement / new feature~~
- ~~Refactoring~~

### Description

The Storage configuration today contains a Local storage type. This was probably expected to be sued for the Local persistent volumes. However, this type was actually never used. And although we run tests for its support, it wasn't doing anything. 

In Kubernetes 1.10, the way Local volumes are handled is through regular PersistentVolumeClaims and StorageClass (see [here](https://kubernetes.io/blog/2018/04/13/local-persistent-volumes-beta/) as an example).

Due to this, we do not need any special support for Local volumes, they can be used through the  `persistent-claim` storage type just by specifying proper StorageClass. Therefore the `local` type can be removed from the code and from the tests.