### PR TITLE
fixed jsonpath for initContainer name

### DIFF
--- a/systemtest/src/test/java/io/strimzi/systemtest/AbstractClusterIT.java
+++ b/systemtest/src/test/java/io/strimzi/systemtest/AbstractClusterIT.java
@@ -314,7 +314,7 @@ public class AbstractClusterIT {
 
     public String  getInitContainerImageName(String podName) {
         String clusterOperatorJson = kubeClient.getResourceAsJson("pod", podName);
-        return JsonPath.parse(clusterOperatorJson).read("$.status.initContainerStatuses[*].image").toString();
+        return JsonPath.parse(clusterOperatorJson).read("$.status.initContainerStatuses[0].image").toString();
     }
 
 }


### PR DESCRIPTION
### Type of change

- Fix for system test


### Description

fixed jsonpath for initContainer name

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging

